### PR TITLE
Offmap housecleaning

### DIFF
--- a/maps/gateway_vr/zoo.dmm
+++ b/maps/gateway_vr/zoo.dmm
@@ -149,7 +149,6 @@
 /area/awaymission/zoo/pirateship)
 "aw" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 9
 	},
 /turf/simulated/floor/plating,
@@ -447,9 +446,7 @@
 /turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "bt" = (
-/obj/structure/sink{
-	dir = 2
-	},
+/obj/structure/sink,
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
@@ -575,22 +572,20 @@
 /area/awaymission/zoo/tradeship)
 "bK" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/shuttle/floor/black,
 /area/awaymission/zoo/tradeship)
 "bL" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/zoo/tradeship)
 "bM" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	dir = 4
+	dir = 4;
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /area/awaymission/zoo/tradeship)
@@ -681,9 +676,7 @@
 /turf/simulated/floor/carpet,
 /area/awaymission/zoo/tradeship)
 "cg" = (
-/obj/machinery/sleep_console{
-	dir = 8
-	},
+/obj/machinery/sleep_console,
 /turf/simulated/shuttle/floor/black,
 /area/awaymission/zoo/tradeship)
 "ch" = (
@@ -852,10 +845,7 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/masks,
 /obj/item/weapon/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 4
@@ -876,13 +866,6 @@
 /obj/item/weapon/reagent_containers/blood/OMinus,
 /obj/structure/closet/medical_wall{
 	pixel_y = 32
-	},
-/turf/simulated/shuttle/floor/black,
-/area/awaymission/zoo/tradeship)
-"cH" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
 	},
 /turf/simulated/shuttle/floor/black,
 /area/awaymission/zoo/tradeship)
@@ -945,7 +928,6 @@
 /area/awaymission/zoo/pirateship)
 "cS" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -955,7 +937,6 @@
 /area/awaymission/zoo/pirateship)
 "cT" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
 	dir = 4
 	},
 /turf/space,
@@ -1031,9 +1012,7 @@
 /area/awaymission/zoo/tradeship)
 "dd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/black,
 /area/awaymission/zoo/tradeship)
@@ -1052,8 +1031,8 @@
 /area/awaymission/zoo/tradeship)
 "dg" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	dir = 4
+	dir = 4;
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /area/awaymission/zoo/tradeship)
@@ -1112,7 +1091,6 @@
 /area/awaymission/zoo/tradeship)
 "dq" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 1
 	},
 /turf/simulated/shuttle/floor/black,
@@ -1295,7 +1273,6 @@
 /obj/item/clothing/gloves/sterile,
 /obj/item/clothing/mask/surgical,
 /obj/item/weapon/surgical/retractor{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/weapon/surgical/scalpel,
@@ -1467,7 +1444,6 @@
 "ep" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /turf/simulated/floor/plating,
@@ -1507,7 +1483,6 @@
 /area/awaymission/zoo/tradeship)
 "eu" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -1517,7 +1492,6 @@
 /area/awaymission/zoo/tradeship)
 "ev" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/shuttle/floor/black,
@@ -1571,7 +1545,6 @@
 "eC" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /obj/item/weapon/reagent_containers/food/snacks/xenomeat,
@@ -1846,7 +1819,6 @@
 /obj/machinery/button/remote/blast_door{
 	id = "trade";
 	name = "Shop Shutters";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/simulated/shuttle/floor/black,
@@ -1921,7 +1893,6 @@
 /area/awaymission/zoo/tradeship)
 "fG" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	dir = 2;
 	start_pressure = 740.5
 	},
 /turf/simulated/shuttle/floor/black,
@@ -2038,9 +2009,7 @@
 "ga" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/black,
 /area/awaymission/zoo/tradeship)
@@ -2136,7 +2105,6 @@
 /area/awaymission/zoo/tradeship)
 "gn" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2347,7 +2315,6 @@
 /area/awaymission/zoo/pirateship)
 "gW" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -2368,9 +2335,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -2390,7 +2355,6 @@
 "hb" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2400,14 +2364,12 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2460,7 +2422,6 @@
 "hh" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2470,7 +2431,6 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2480,7 +2440,6 @@
 "hi" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2494,7 +2453,6 @@
 "hj" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2504,7 +2462,6 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2528,19 +2485,16 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2570,7 +2524,6 @@
 "ht" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	pixel_x = -32;
-	pixel_y = 0;
 	req_access = list(150)
 	},
 /obj/item/stack/medical/splint,
@@ -2636,13 +2589,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2687,13 +2638,11 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -2704,9 +2653,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -2738,7 +2685,6 @@
 "hN" = (
 /obj/machinery/flasher{
 	id = "syndieflash";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/light/small{
@@ -2751,7 +2697,6 @@
 	desc = "Talk through this. Evilly";
 	frequency = 1213;
 	name = "Syndicate Intercom";
-	pixel_x = 0;
 	pixel_y = -32;
 	subspace_transmission = 1;
 	syndie = 1
@@ -2802,9 +2747,7 @@
 /area/awaymission/zoo/syndieship)
 "hW" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -2848,8 +2791,7 @@
 /obj/machinery/button/flasher{
 	id = "syndieflash";
 	name = "Flasher";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -2883,9 +2825,7 @@
 	pixel_y = 9
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -2940,9 +2880,7 @@
 /area/awaymission/zoo/syndieship)
 "im" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/sleeper{
 	dir = 8
@@ -2999,9 +2937,7 @@
 /obj/structure/table/standard,
 /obj/item/clothing/gloves/yellow,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -3165,9 +3101,7 @@
 /obj/structure/table/rack,
 /obj/item/device/multitool,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -3227,9 +3161,7 @@
 "iK" = (
 /obj/item/weapon/weldingtool,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/awaymission/zoo/syndieship)
@@ -3270,13 +3202,10 @@
 "iP" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/closet/secure_closet/medical_wall{
 	pixel_x = 32;
-	pixel_y = 0;
 	req_access = list(150)
 	},
 /obj/item/weapon/tank/anesthetic,
@@ -3348,13 +3277,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3364,13 +3291,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3390,13 +3315,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3410,13 +3333,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3432,7 +3353,6 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3446,7 +3366,6 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3460,13 +3379,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3480,13 +3397,11 @@
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -3506,7 +3421,6 @@
 /area/awaymission/zoo)
 "jm" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/grassybush,
@@ -3621,7 +3535,6 @@
 /area/awaymission/zoo)
 "jB" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /turf/simulated/floor/grass,
@@ -3642,7 +3555,6 @@
 /area/awaymission/zoo)
 "jF" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 10
 	},
 /turf/simulated/floor/grass,
@@ -3704,7 +3616,6 @@
 /area/awaymission/zoo)
 "jP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 10
 	},
 /obj/structure/flora/ausbushes/grassybush,
@@ -3913,11 +3824,6 @@
 /obj/item/clothing/mask/gas/owl_mask,
 /turf/simulated/floor/holofloor/carpet,
 /area/awaymission/zoo)
-"kv" = (
-/obj/structure/table/rack,
-/obj/item/toy/waterflower,
-/turf/simulated/floor/holofloor/carpet,
-/area/awaymission/zoo)
 "kw" = (
 /obj/structure/table/rack,
 /obj/item/toy/sword,
@@ -3941,7 +3847,6 @@
 /area/awaymission/zoo)
 "kz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /turf/simulated/floor/beach/water{
@@ -4022,9 +3927,7 @@
 "kO" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/white,
 /area/awaymission/zoo)
@@ -4034,7 +3937,6 @@
 /area/awaymission/zoo)
 "kQ" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -4164,8 +4066,6 @@
 /area/awaymission/zoo)
 "ll" = (
 /obj/machinery/door/airlock/glass{
-	icon_state = "door_closed";
-	locked = 0;
 	name = "Exhibit Airlock"
 	},
 /turf/simulated/floor/tiled/white,
@@ -4182,8 +4082,6 @@
 /area/awaymission/zoo)
 "lo" = (
 /obj/machinery/door/airlock/glass{
-	icon_state = "door_closed";
-	locked = 0;
 	name = "Exhibit Airlock"
 	},
 /turf/simulated/floor/holofloor/carpet,
@@ -4211,7 +4109,6 @@
 "lt" = (
 /obj/structure/table/marble,
 /obj/machinery/cash_register{
-	icon_state = "register_idle";
 	dir = 1
 	},
 /turf/simulated/floor/holofloor/lino,
@@ -4242,14 +4139,14 @@
 /area/awaymission/zoo)
 "ly" = (
 /obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain_full";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_plain_full"
 	},
 /obj/structure/showcase{
-	name = "Statue";
 	desc = "It looks almost lifelike.";
 	icon = 'icons/obj/statue.dmi';
-	icon_state = "monkey"
+	icon_state = "monkey";
+	name = "Statue"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/zoo)
@@ -4263,8 +4160,6 @@
 /area/awaymission/zoo)
 "lA" = (
 /obj/machinery/door/airlock/glass{
-	icon_state = "door_closed";
-	locked = 0;
 	name = "Exhibit Airlock"
 	},
 /turf/simulated/floor/wood,
@@ -4285,7 +4180,6 @@
 "lD" = (
 /obj/structure/table/marble,
 /obj/machinery/cash_register{
-	icon_state = "register_idle";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -4296,7 +4190,6 @@
 /area/awaymission/zoo)
 "lF" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 10
 	},
 /turf/simulated/floor/beach/water{
@@ -4358,7 +4251,6 @@
 /area/awaymission/zoo)
 "lP" = (
 /obj/structure/table/rack,
-/obj/item/toy/crossbow,
 /turf/simulated/floor/holofloor/carpet,
 /area/awaymission/zoo)
 "lQ" = (
@@ -4396,7 +4288,6 @@
 /obj/item/weapon/storage/backpack/clown,
 /obj/item/clothing/shoes/rainbow,
 /obj/item/clothing/under/color/rainbow,
-/obj/item/clothing/under/seromi/undercoat/standard/rainbow,
 /obj/item/clothing/gloves/rainbow,
 /obj/item/clothing/head/soft/rainbow,
 /turf/simulated/floor/holofloor/carpet,
@@ -4420,9 +4311,7 @@
 /turf/simulated/floor/tiled,
 /area/awaymission/zoo)
 "lZ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 2
-	},
+/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
@@ -4502,8 +4391,6 @@
 /area/awaymission/zoo)
 "mm" = (
 /obj/machinery/door/airlock/glass{
-	icon_state = "door_closed";
-	locked = 0;
 	name = "Exhibit Airlock"
 	},
 /turf/simulated/floor/holofloor/lino,
@@ -4533,19 +4420,16 @@
 "mr" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4633,19 +4517,16 @@
 "my" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4655,7 +4536,6 @@
 "mz" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4669,13 +4549,11 @@
 "mA" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4750,13 +4628,11 @@
 "mL" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4766,7 +4642,6 @@
 "mM" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4780,13 +4655,11 @@
 "mN" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4856,13 +4729,11 @@
 "mW" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1;
-	icon_state = "phoronrwindow";
 	maxhealth = 10000;
 	name = "robust borosilicate window"
 	},
@@ -4989,10 +4860,10 @@
 "nq" = (
 /obj/structure/bed/chair,
 /obj/structure/showcase{
-	name = "Statue";
 	desc = "It looks almost lifelike.";
 	icon = 'icons/obj/statue.dmi';
-	icon_state = "Human_male"
+	icon_state = "Human_male";
+	name = "Statue"
 	},
 /turf/simulated/floor/lino,
 /area/awaymission/zoo)
@@ -5087,8 +4958,8 @@
 /area/awaymission/zoo)
 "nG" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beachcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "beachcorner"
 	},
 /area/awaymission/zoo)
 "nH" = (
@@ -5104,8 +4975,7 @@
 /area/awaymission/zoo)
 "nK" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beachcorner";
-	dir = 2
+	icon_state = "beachcorner"
 	},
 /area/awaymission/zoo)
 "nL" = (
@@ -5295,14 +5165,14 @@
 /area/awaymission/zoo)
 "og" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 10
+	dir = 10;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "oh" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 6
+	dir = 6;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "oi" = (
@@ -5385,8 +5255,7 @@
 /area/awaymission/zoo)
 "ou" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 2
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "ov" = (
@@ -5628,7 +5497,6 @@
 "pd" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 10
 	},
 /turf/simulated/floor/holofloor/grass,
@@ -5839,7 +5707,6 @@
 "pH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /turf/simulated/floor/holofloor/grass,
@@ -5872,7 +5739,6 @@
 /area/awaymission/zoo)
 "pM" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /turf/simulated/floor/holofloor/grass,
@@ -5885,8 +5751,7 @@
 /area/awaymission/zoo)
 "pO" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -5901,8 +5766,7 @@
 /area/awaymission/zoo)
 "pP" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -5911,8 +5775,7 @@
 /area/awaymission/zoo)
 "pQ" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -5956,8 +5819,7 @@
 /area/awaymission/zoo)
 "pW" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 8
@@ -5966,15 +5828,13 @@
 /area/awaymission/zoo)
 "pX" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /turf/simulated/floor/lino,
 /area/awaymission/zoo)
 "pY" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -6011,26 +5871,25 @@
 /area/awaymission/zoo)
 "qe" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 9
+	dir = 9;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "qf" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 1
+	dir = 1;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "qg" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 5
+	dir = 5;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "qh" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 8
@@ -6043,16 +5902,14 @@
 /area/awaymission/zoo)
 "qi" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/lino,
 /area/awaymission/zoo)
 "qj" = (
 /obj/effect/floor_decal/carpet{
-	icon_state = "carpet";
-	dir = 2
+	icon_state = "carpet"
 	},
 /obj/effect/floor_decal/carpet,
 /obj/effect/floor_decal/carpet{
@@ -6084,14 +5941,14 @@
 /area/awaymission/zoo)
 "qn" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beachcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "beachcorner"
 	},
 /area/awaymission/zoo)
 "qo" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beachcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "beachcorner"
 	},
 /area/awaymission/zoo)
 "qp" = (
@@ -6219,7 +6076,6 @@
 /area/awaymission/zoo)
 "qE" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6383,7 +6239,6 @@
 /area/awaymission/zoo)
 "rg" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	icon_state = "spline_fancy";
 	dir = 10
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6442,15 +6297,12 @@
 /turf/simulated/floor,
 /area/awaymission/zoo)
 "rr" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 2
-	},
+/obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/awaymission/zoo)
 "rs" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -6861,12 +6713,6 @@
 "sg" = (
 /obj/effect/overlay/palmtree_l,
 /turf/simulated/floor/holofloor/grass,
-/area/awaymission/zoo)
-"sh" = (
-/mob/living/simple_mob/hostile/samak{
-	faction = "zoo"
-	},
-/turf/simulated/floor/holofloor/snow,
 /area/awaymission/zoo)
 "si" = (
 /obj/effect/floor_decal/spline/plain{
@@ -7682,12 +7528,6 @@
 	},
 /turf/simulated/floor/holofloor/grass,
 /area/awaymission/zoo)
-"ua" = (
-/mob/living/simple_mob/fox{
-	faction = "zoo"
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/awaymission/zoo)
 "ub" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8069,8 +7909,8 @@
 /area/awaymission/zoo)
 "uW" = (
 /turf/simulated/floor/holofloor/beach/water{
-	icon_state = "beach";
-	dir = 8
+	dir = 8;
+	icon_state = "beach"
 	},
 /area/awaymission/zoo)
 "uX" = (
@@ -8220,12 +8060,6 @@
 /obj/item/stack/tile/grass,
 /turf/simulated/floor/plating,
 /area/awaymission/zoo)
-"vn" = (
-/mob/living/simple_mob/hostile/shantak{
-	faction = "zoo"
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/awaymission/zoo)
 "vo" = (
 /mob/living/carbon/human/monkey{
 	faction = "zoo"
@@ -8234,25 +8068,8 @@
 	icon_state = "dgrass2"
 	},
 /area/awaymission/zoo)
-"vp" = (
-/mob/living/simple_mob/hostile/shantak{
-	color = "";
-	faction = "zoo";
-	health = 100;
-	maxHealth = 100;
-	name = "alpha shantak"
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/awaymission/zoo)
 "vq" = (
 /mob/living/simple_mob/animal/space/tree{
-	faction = "zoo"
-	},
-/turf/simulated/floor/holofloor/snow,
-/area/awaymission/zoo)
-"vr" = (
-/obj/structure/flora/bush,
-/mob/living/simple_mob/hostile/shantak{
 	faction = "zoo"
 	},
 /turf/simulated/floor/holofloor/snow,
@@ -8381,10 +8198,7 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/masks,
 /obj/item/weapon/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 4
@@ -8416,9 +8230,7 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/zoo)
 "vN" = (
-/obj/machinery/sleep_console{
-	dir = 8
-	},
+/obj/machinery/sleep_console,
 /turf/simulated/floor/tiled/white,
 /area/awaymission/zoo)
 "vO" = (
@@ -8444,7 +8256,6 @@
 /obj/item/clothing/gloves/sterile,
 /obj/item/clothing/mask/surgical,
 /obj/item/weapon/surgical/retractor{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/weapon/surgical/scalpel,
@@ -8536,10 +8347,6 @@
 /turf/simulated/floor/plating,
 /area/awaymission/zoo)
 "wh" = (
-/obj/machinery/power/smes/magical{
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
-	name = "power storage unit"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/zoo)
@@ -8712,8 +8519,7 @@
 /obj/machinery/door/airlock/security{
 	icon_state = "door_locked";
 	locked = 1;
-	name = "Security";
-	req_one_access = list(1)
+	name = "Security"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/zoo)
@@ -8841,7 +8647,6 @@
 "xf" = (
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/structure/window/reinforced{
-	dir = 2;
 	health = 1e+006
 	},
 /obj/structure/window/reinforced{
@@ -8858,7 +8663,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 2;
 	health = 1e+006
 	},
 /obj/structure/table/rack,
@@ -8868,7 +8672,6 @@
 "xh" = (
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/structure/window/reinforced{
-	dir = 2;
 	health = 1e+006
 	},
 /obj/structure/window/reinforced{
@@ -8885,7 +8688,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 2;
 	health = 1e+006
 	},
 /obj/structure/table/rack,
@@ -8909,8 +8711,7 @@
 "xl" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar/fake,
 /turf/simulated/floor/airless{
@@ -8934,8 +8735,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8963,8 +8763,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/zoo/solars)
@@ -9000,8 +8799,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/zoo/solars)
@@ -9009,8 +8807,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9053,8 +8850,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/zoo/solars)
@@ -9080,8 +8876,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/zoo/solars)
@@ -20210,7 +20005,7 @@ hq
 hq
 hq
 gP
-kg
+kh
 jM
 jM
 kg
@@ -20517,7 +20312,7 @@ hq
 hq
 hq
 jQ
-kg
+kh
 jM
 jM
 kg
@@ -21131,7 +20926,7 @@ hq
 hq
 hq
 jS
-kg
+kh
 jM
 jM
 kg
@@ -21438,7 +21233,7 @@ hq
 hq
 hq
 gP
-kg
+kh
 jM
 jM
 kg
@@ -35560,7 +35355,7 @@ hq
 hq
 hq
 jR
-kv
+lP
 kW
 kW
 kW
@@ -44826,7 +44621,7 @@ qK
 qK
 qZ
 qK
-sh
+qK
 rJ
 qK
 qK
@@ -44897,9 +44692,9 @@ qY
 qK
 qK
 qZ
-vn
-vn
-vr
+qK
+qK
+rJ
 qK
 qK
 qK
@@ -45204,9 +44999,9 @@ qK
 qK
 qK
 qK
-vn
-vp
-vn
+qK
+qK
+qK
 qK
 qK
 qK
@@ -45511,9 +45306,9 @@ qK
 qK
 qK
 qK
-vn
-vn
-vn
+qK
+qK
+qK
 qK
 qK
 qK
@@ -46665,7 +46460,7 @@ qK
 qK
 qK
 qK
-sh
+qK
 qK
 qK
 qK
@@ -51616,7 +51411,7 @@ qK
 qK
 qK
 qY
-ua
+qK
 qK
 qK
 qK
@@ -51920,7 +51715,7 @@ qK
 qK
 rJ
 ra
-ua
+qK
 qK
 rJ
 qZ
@@ -53326,7 +53121,7 @@ bn
 bJ
 bJ
 bJ
-cH
+eI
 bn
 bn
 bJ
@@ -53932,7 +53727,7 @@ aa
 bn
 bn
 ch
-cH
+eI
 df
 bJ
 dT
@@ -53945,7 +53740,7 @@ bn
 fI
 bJ
 bJ
-cH
+eI
 gD
 bn
 bn

--- a/maps/gateway_vr/zoo_b.dmm
+++ b/maps/gateway_vr/zoo_b.dmm
@@ -1,0 +1,25975 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"ad" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"ae" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/item/weapon/coin/gold,
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"ah" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/material/knife/butch,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"aj" = (
+/obj/machinery/door/airlock/silver{
+	name = "Men's Restroom"
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"am" = (
+/obj/machinery/door/blast/regular{
+	id = "syndieshutters_telebay";
+	name = "Outer Airlock"
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"an" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"ao" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Originating from the jungles of Earth, Parrots are a highly intelligent avian that have become an expensive commodity in space, prized for their colorful plumage, and their famous ability to mimic speech. Ship captains traditionally keep them as exotic pets, to demonstrate wealth, and to have someone to talk with. Some researchers believe some parrot species to be capable of intelligence up to that of a 5 year old Human in some aspects. Purebreds of exceptionally varied color pallets are especially prized among traders and space pirates.";
+	name = "Parrot Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"ap" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"ar" = (
+/obj/machinery/button/remote/airlock{
+	id = "packerMed";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"au" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"aw" = (
+/obj/machinery/door/airlock/silver{
+	name = "Toilet"
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"aA" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"aC" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"aD" = (
+/mob/living/simple_mob/animal/passive/tindalos{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"aF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"aH" = (
+/obj/structure/sink,
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"aJ" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"aL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"aM" = (
+/obj/machinery/shieldwallgen,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"aO" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"aU" = (
+/obj/structure/table/standard,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"bf" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"bg" = (
+/obj/machinery/gateway{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"bk" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"bm" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"bn" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"bp" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"br" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"bw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"by" = (
+/obj/structure/table/rack,
+/obj/item/toy/cultsword,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"bz" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"bC" = (
+/obj/machinery/suit_cycler/syndicate{
+	locked = 0
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"bD" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"bF" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"bG" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"bI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Not to be confused with the common Earth bat, the Space Bat is a mammalian-like creature that is capable of surviving in the vacuum of space! These creatures live and fly in groups, and are most commonly found in caves, such as those on asteroids, or small planetary bodies with light gravity and no atmosphere. These creatures survive by sucking the blood of wayward space travelers, and are considered to be a pest by the Free Trade Union for their habit of infesting space ships sitting at dock. Their origin is currently unknown.";
+	name = "Space Bat Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"bL" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"bN" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"bO" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"bT" = (
+/obj/machinery/door/airlock/silver{
+	icon_state = "door_locked";
+	locked = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/zoo/pirateship)
+"bZ" = (
+/mob/living/simple_mob/vore/horse{
+	faction = "zoo"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"cb" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"ce" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"cf" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"cq" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"cx" = (
+/obj/machinery/gateway{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"cE" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"cI" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"cN" = (
+/obj/machinery/door/airlock/glass_medical,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"cO" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"cX" = (
+/obj/machinery/computer/operating,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"cZ" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"da" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "syndieshutters_workshop";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"db" = (
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"dd" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/reinforced,
+/area/awaymission/zoo/pirateship)
+"de" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/spacecash/c500,
+/obj/item/weapon/spacecash/c100,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo/pirateship)
+"dj" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"dn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"dq" = (
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/turf/flooring/misc_vr.dmi';
+	icon_state = "hive";
+	name = "giant honeycomb"
+	},
+/area/awaymission/zoo)
+"dt" = (
+/obj/structure/closet,
+/obj/item/weapon/reagent_containers/food/snacks/tastybread,
+/obj/item/weapon/reagent_containers/food/snacks/tastybread,
+/obj/item/weapon/reagent_containers/food/snacks/tastybread,
+/obj/item/weapon/reagent_containers/food/snacks/tastybread,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"dw" = (
+/obj/structure/kitchenspike,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"dz" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"dA" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"dC" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/mob/living/simple_mob/animal/space/alien{
+	faction = "zoo";
+	name = "invisible alien hunter"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"dF" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"dJ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"dP" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"dQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"dU" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"dW" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"dZ" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"eh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"ek" = (
+/obj/machinery/door/airlock/glass{
+	name = "Exhibit Airlock"
+	},
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"em" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"et" = (
+/obj/structure/table/rack{
+	dir = 1
+	},
+/obj/item/weapon/extinguisher,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"ey" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"ez" = (
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"eB" = (
+/mob/living/simple_mob/animal/passive/cat/kitten{
+	name = "Enola"
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"eE" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"eF" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"eG" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"eH" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"eR" = (
+/mob/living/simple_mob/vore/catgirl{
+	faction = "zoo"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"eS" = (
+/mob/living/simple_mob/animal/passive/bird/parrot/cockatiel/yellowish{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"eT" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"eV" = (
+/obj/machinery/door/unpowered/shuttle,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"eW" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"eY" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"fa" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"fe" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"fk" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-24"
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"fo" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"fp" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ft" = (
+/mob/living/simple_mob/animal/passive/bird/parrot/poly{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"fu" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"fv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"fC" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"fF" = (
+/obj/machinery/body_scanconsole,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"fI" = (
+/obj/machinery/door/airlock/glass{
+	name = "Exhibit Airlock"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"fL" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"fP" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"fT" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/area/awaymission/zoo/syndieship)
+"fV" = (
+/obj/item/device/multitool,
+/turf/simulated/floor/reinforced,
+/area/awaymission/zoo/pirateship)
+"fW" = (
+/turf/simulated/shuttle/wall/dark,
+/area/awaymission/zoo/syndieship)
+"fY" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"fZ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"ga" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"gb" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"gh" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"gk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"gl" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"gt" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"gx" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"gz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"gE" = (
+/obj/machinery/sleep_console,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"gG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"gI" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"gM" = (
+/turf/simulated/floor/holofloor/reinforced{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "lava";
+	name = "hololava"
+	},
+/area/awaymission/zoo)
+"gS" = (
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"gU" = (
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"gW" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"gZ" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"hd" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"hi" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/mob/living/simple_mob/vore/aggressive/mimic{
+	faction = "zoo"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"hk" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"hm" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"hn" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"hx" = (
+/obj/item/weapon/storage/box/matches,
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"hy" = (
+/obj/item/weapon/coin/silver,
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"hB" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"hC" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"hF" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"hH" = (
+/obj/structure/sign/securearea{
+	name = "CAUTION";
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/mopbucket,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"hI" = (
+/obj/machinery/flasher{
+	id = "syndieflash";
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"hJ" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"hK" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"hM" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_mob/animal/passive/bird/parrot/cockatiel/grey{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"hN" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"hS" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"hU" = (
+/obj/structure/flora/ausbushes/pointybush,
+/mob/living/simple_mob/animal/passive/bird/parrot/pink_cockatoo{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ih" = (
+/obj/item/clothing/glasses/regular/hipster,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"im" = (
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"in" = (
+/obj/machinery/door/window/northright{
+	name = "Telecoms Mainframe";
+	req_access = list(150)
+	},
+/obj/machinery/telecomms/relay/preset/station,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"io" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"ip" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"iq" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"it" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"iv" = (
+/obj/machinery/door/airlock/medical,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"ix" = (
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"iy" = (
+/obj/item/weapon/storage/box,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"iE" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"iG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"iL" = (
+/mob/living/simple_mob/animal/passive/chick,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"iP" = (
+/mob/living/simple_mob/animal/space/alien{
+	faction = "zoo";
+	name = "invisible alien hunter"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"iQ" = (
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"iV" = (
+/obj/structure/ore_box,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"iW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/landmark/loot_spawn{
+	live_cargo = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"iY" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"iZ" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/storage/hooded/costume/ian,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"jc" = (
+/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"je" = (
+/obj/effect/landmark/away,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"jg" = (
+/obj/structure/flora/tree/dead,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"jn" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"jq" = (
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"jy" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"jz" = (
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"jB" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"jD" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"jJ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"jL" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/mob/living/simple_mob/animal/space/alien/drone{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"jN" = (
+/obj/item/trash/syndi_cakes,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"jR" = (
+/obj/effect/overlay/coconut,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"jT" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/mob/living/simple_mob/animal/space/alien/queen{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"jY" = (
+/mob/living/simple_mob/animal/passive/chick,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ka" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "meatConvey2"
+	},
+/obj/item/weapon/material/knife,
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"kc" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"kd" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ke" = (
+/obj/machinery/gibber,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"kh" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"kl" = (
+/obj/structure/grille{
+	name = "mass ventilation"
+	},
+/obj/effect/blocker,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"km" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"kr" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ks" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ky" = (
+/obj/item/weapon/tool/crowbar,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"kC" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"kF" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"kJ" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"kY" = (
+/mob/living/simple_mob/animal/passive/snake{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"kZ" = (
+/obj/structure/table/rack,
+/obj/random/action_figure,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"li" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "The Xenomorph XX121, better known just as Xenomorph, are an extraterrestrial, endoparasitoid species with multiple life cycles, possibly originating from the planet Proteus (also known as Xenomorph Prime), which orbits the star A6 454. One of the deadliest of all known alien species, these creatures need a host organism in order to reproduce. The appearance of the Xenomorph varies depending on its host. The Human phenotype is generally around 7�8 feet, and roughly 136.0 to 181.4 kilograms in weight, with a long, muscular tail and large, curved, oblong head. The Queen of this species is generally twice as large (they can grow even larger, some even up to 100 feet tall, and stronger if given time) and possesses superior speed, strength and intelligence. The term Xenomorph is derived from the Greek words xeno ('stranger', 'alien', and 'foreigner') and morphe ('form', 'shape'). There are no solid facts as to the origins of the Xenomorph species; instead, there are many assumptions which cannot be confirmed. Based on the limited information we have, the most commonly accepted hypothesis is that they are an artificially created species, although another hypothesis says that they evolved naturally on a planet much different than our own. The Xenomorph lives in a hive together with its queen. Amazingly, the blood and other bodily fluids of the Xenomorph are highly acidic. It is not yet understood how a creature of such biology can exist. The planet Proteus is also home to rare, red-hued Xenomorphs, who frequently fight their black-colored rivals. Some Xenomorphs are alleged to be able to cloak themselves to be invisible to the human eye, but this has not been confirmed by independent study.";
+	name = "Xenomorph Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"ln" = (
+/obj/machinery/door/airlock/glass{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Exhibit Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"lo" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"lv" = (
+/obj/item/weapon/cell/high,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"lw" = (
+/obj/machinery/door/window/southleft,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"lB" = (
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"lH" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass4"
+	},
+/area/awaymission/zoo)
+"lQ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"lR" = (
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"lU" = (
+/obj/structure/closet,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"lZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"mb" = (
+/obj/structure/table/marble,
+/obj/item/toy/nanotrasenballoon,
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"mf" = (
+/turf/simulated/shuttle/wall/dark/hard_corner,
+/area/awaymission/zoo/syndieship)
+"mi" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"ml" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"mn" = (
+/obj/machinery/door/window/southright,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"mr" = (
+/mob/living/simple_mob/animal/passive/bird/parrot/budgerigar{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"mu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"mv" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"mE" = (
+/obj/structure/flora/grass/both,
+/mob/living/simple_mob/animal/passive/penguin{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"mG" = (
+/obj/effect/overlay/coconut,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"mM" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"mT" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"mX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"nb" = (
+/obj/machinery/optable,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"nj" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"nm" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"no" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder{
+	pixel_x = -4
+	},
+/obj/item/weapon/folder/red{
+	pixel_y = 3
+	},
+/obj/item/weapon/folder/blue{
+	pixel_x = 5
+	},
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/stamp/internalaffairs,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"nr" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"ns" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"nw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"nx" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ny" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"nA" = (
+/obj/machinery/gateway{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"nC" = (
+/obj/effect/blocker,
+/turf/space,
+/area/space)
+"nI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"nJ" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"nS" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"nT" = (
+/obj/machinery/door/airlock/external{
+	icon_state = "door_locked";
+	locked = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"nV" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"nY" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/landmark/away,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"nZ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/mimic/guaranteed,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"oe" = (
+/obj/machinery/vending/food,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"oh" = (
+/obj/structure/grille,
+/obj/structure/shuttle/window,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ok" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Space Bumble Bee is a large, usually docile stinging insect native to Virgo-Prime in the Virgo Erigone system. It normally lives in small oases around what few bodies of water exist on the arid landscape, but ever since Humans have come to colonize the world, they have been discovered in city parks even in the capital city of Anur. Despite their gentle demeanor however, they can and will attack when provoked, and are capable of opening their mandibles wide enough to swallow a Human sized victim whole. Deep in their abdomen, they process their victims along with harvested nectar into rich honey.";
+	name = "Space Bumble Bee Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"on" = (
+/mob/living/simple_mob/animal/passive/chicken{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"oq" = (
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"ox" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"oA" = (
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"oE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"oF" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"oJ" = (
+/obj/structure/table/rack,
+/obj/item/device/multitool,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"oN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"oR" = (
+/obj/item/poster,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"oS" = (
+/obj/machinery/vending/cigarette{
+	name = "hacked cigarette machine";
+	prices = list();
+	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"oU" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/button/flasher{
+	id = "syndieflash";
+	name = "Flasher";
+	pixel_x = 27
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"oV" = (
+/turf/space,
+/area/awaymission/zoo/pirateship)
+"pa" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. Evilly";
+	frequency = 1213;
+	name = "Syndicate Intercom";
+	pixel_y = -32;
+	subspace_transmission = 1;
+	syndie = 1
+	},
+/obj/machinery/light,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"pf" = (
+/obj/item/bodybag,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"pg" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"ph" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"pk" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/mob/living/simple_mob/animal/passive/cat{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"ps" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"pB" = (
+/obj/structure/flora/bush,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"pE" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"pM" = (
+/obj/machinery/button/remote/airlock{
+	id = "packerCargo";
+	pixel_y = -24
+	},
+/obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"pN" = (
+/obj/structure/frame{
+	anchored = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"pR" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "syndieshutters_workshop";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"pS" = (
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"pU" = (
+/obj/structure/closet/secure_closet/medical_wall{
+	pixel_x = -32;
+	req_access = list(150)
+	},
+/obj/item/stack/medical/splint,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/weapon/storage/belt/medical/emt,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"pX" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "meatConvey1"
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"qb" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/oxygen/yellow,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"qg" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"qh" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"qk" = (
+/turf/simulated/floor/tiled/red,
+/area/awaymission/zoo)
+"ql" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"qo" = (
+/obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"qp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"qu" = (
+/obj/structure/closet,
+/obj/item/clothing/under/lawyer/bluesuit,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"qA" = (
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"qD" = (
+/obj/machinery/gateway,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"qE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"qG" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"qI" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"qO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"qS" = (
+/turf/simulated/wall,
+/area/awaymission/zoo)
+"qU" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"re" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"ri" = (
+/mob/living/simple_mob/animal/passive/tindalos{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"rj" = (
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"rm" = (
+/mob/living/simple_mob/vore/aggressive/giant_snake{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ro" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"rw" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"rz" = (
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"rA" = (
+/obj/structure/table/rack,
+/obj/item/device/binoculars,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"rF" = (
+/obj/item/trash/chips,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"rG" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"rI" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"rM" = (
+/obj/machinery/porta_turret{
+	dir = 8;
+	emagged = 1;
+	installation = /obj/item/weapon/gun/energy/lasercannon
+	},
+/turf/simulated/floor/reinforced,
+/area/awaymission/zoo/pirateship)
+"rN" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "meatConvey2"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"rO" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"rQ" = (
+/turf/space,
+/area/space)
+"rW" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"sa" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"sb" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/monkeysuit,
+/obj/item/clothing/mask/gas/monkeymask,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"sd" = (
+/obj/item/weapon/weldingtool,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"sh" = (
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"so" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"st" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"sv" = (
+/turf/simulated/mineral/ignore_mapgen,
+/area/awaymission/zoo)
+"sw" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"sz" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/spacecash/c10,
+/obj/item/weapon/spacecash/c200,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"sB" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"sI" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"sM" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"sN" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"sQ" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"sR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Samak are the apex predator in the various plains regions of the northern hemisphere of Meralar. Unlike many creatures of Meralar, it does not have any fur to speak of. Instead, it is completely covered in thick armored plates which act as a barrier between the Samak's internal warmth and the cold environment. However, this is still not that efficient, so the Samak feed often to keep themselves warm. The Samak have six thick legs tipped with broad claws, and roughly aerodynamic bodies. They burrow underground, detecting prey through incredibly keen thermal detection. They pop up suddenly, grab their next meal, and return underground just as quickly. They prefer larger prey, such as the Baqara, Elu'a Eli, and Tajaran. Due to their voracious appetites and tendency to ruin mine shafts and infrastructure, they have been hunted almost to extinction, mainly by the Slavemasters. For the Tajaran, being able to kill a Samak singlehandedly (and without 'cheating', such as saturation bombing and the like) is an incredible feat, and any individual who pulls it off is lauded greatly.";
+	name = "Samak Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"sS" = (
+/mob/living/simple_mob/animal/passive/dog/corgi{
+	faction = "zoo"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"sV" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ti" = (
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"tj" = (
+/mob/living/simple_mob/animal/passive/mouse{
+	faction = "zoo"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"tr" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"tx" = (
+/obj/structure/table/rack,
+/obj/item/toy/bosunwhistle,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"ty" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"tz" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"tA" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"tE" = (
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"tK" = (
+/obj/structure/table/rack,
+/obj/item/device/camera_film,
+/obj/item/device/camera,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"tM" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"tN" = (
+/obj/structure/table/standard,
+/obj/item/weapon/material/knife{
+	pixel_x = -6
+	},
+/obj/item/weapon/reagent_containers/syringe/drugs{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/weapon/reagent_containers/syringe/drugs{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/syringe/drugs{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"tP" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"tR" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/wallet/poly,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"tU" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"tX" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"tY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"tZ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ub" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"uc" = (
+/obj/machinery/door/airlock/silver{
+	icon_state = "door_locked";
+	locked = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ui" = (
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"uk" = (
+/obj/item/stack/cable_coil/random{
+	amount = 5
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"up" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"us" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "A mouse (plural: mice), native to Earth in the Sol system, is a small rodent characteristically having a pointed snout, small rounded ears, a body-length scaly tail and a high breeding rate. The best known mouse species is the common house mouse (Mus musculus). It is also a popular pet. In some places, certain kinds of field mice are locally common. They are known to invade homes and space ships for food and shelter. Cats, wild dogs, foxes, birds of prey, snakes and even certain kinds of arthropods have been known to prey heavily upon mice. Nevertheless, because of its remarkable adaptability to almost any environment, the mouse is one of the most successful mammalian genera living in the galaxy today.";
+	name = "Mouse Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"uv" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/space,
+/area/awaymission/zoo/pirateship)
+"uw" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"uz" = (
+/obj/machinery/computer{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"uA" = (
+/obj/item/weapon/storage/box/syringes,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"uC" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"uI" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"uM" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Tindalos is a large insect creature native to the Tubau plains of Zzarlaanis, in the Tiphonia system. The Human settlers who live on the planet have compared them to wingless grasshoppers. At high population densities and under certain environmental conditions, the Tindalos have been known to change behavior and form swarms. Tindalos are plant-eaters, sometimes becoming serious pests of cereals, vegetables and pasture, especially when they swarm in their millions and destroy crops over wide areas.";
+	name = "Tindalos Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"uN" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"uP" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"uT" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "syndieshutters_infirmary";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"uY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "syndieshutters_workshop";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"va" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"vb" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"vc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"vf" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"vj" = (
+/obj/item/weapon/stool,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"vl" = (
+/obj/structure/symbol/pr,
+/turf/simulated/shuttle/wall,
+/area/awaymission/zoo/pirateship)
+"vm" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"vs" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"vt" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"vM" = (
+/obj/structure/flora/ausbushes/brflowers,
+/mob/living/simple_mob/animal/passive/bird/parrot/cockatiel/yellowish{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"vP" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"vU" = (
+/mob/living/simple_mob/animal/sif/diyaab{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"vV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"wa" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"wl" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"wq" = (
+/obj/machinery/power/fractal_reactor/fluff/converter{
+	mapped_in = 1;
+	power_generation_rate = 10000
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"ws" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"wF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"wM" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"wO" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"wV" = (
+/turf/simulated/shuttle/wall,
+/area/awaymission/zoo/pirateship)
+"xd" = (
+/obj/machinery/door/airlock/silver,
+/turf/simulated/floor,
+/area/awaymission/zoo/pirateship)
+"xf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"xh" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"xu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"xv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"xz" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"xA" = (
+/obj/structure/table/marble,
+/obj/item/weapon/pen/multi,
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"xB" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass4"
+	},
+/area/awaymission/zoo)
+"xJ" = (
+/mob/living/simple_mob/vore/aggressive/frog{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"xL" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"xP" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "meatConvey1"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"xU" = (
+/mob/living/simple_mob/animal/passive/tindalos{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"xY" = (
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"yc" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"yd" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"yg" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/storage/hooded/costume/carp,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"yn" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"yp" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"yq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"yw" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"yx" = (
+/mob/living/simple_mob/animal/passive/tindalos{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"yy" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"yC" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"yE" = (
+/obj/structure/grille{
+	name = "mass ventilation"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"yK" = (
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"yQ" = (
+/obj/effect/blocker,
+/turf/simulated/wall/r_wall,
+/area/awaymission/zoo)
+"yR" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"yU" = (
+/obj/structure/closet,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"yW" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"yY" = (
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"yZ" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"za" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"ze" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"zf" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 28
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"zg" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"zj" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"zk" = (
+/obj/machinery/gateway{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"zs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"zv" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"zx" = (
+/obj/effect/floor_decal/asteroid,
+/mob/living/simple_mob/animal/space/alien{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"zC" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"zD" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"zE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"zH" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 1
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 1
+	},
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"zJ" = (
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"zO" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/space,
+/area/awaymission/zoo/syndieship)
+"zV" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass4"
+	},
+/area/awaymission/zoo)
+"zW" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"zY" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"zZ" = (
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Ag" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"Ai" = (
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"Ao" = (
+/obj/machinery/door/unpowered/shuttle,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"Ar" = (
+/obj/machinery/optable,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Av" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "This giant snake is a rare beast native to Paraiso, in the Carnelia system. Though normally only found deep in the jungles, these ravenous monsters have been known to slither out onto the planet's many beach resorts to swallow up unwary sunbathers. Otherwise, the creature's diet consists mainly of monkeys that were accidentally introduced to the planet by pet owners. The presence of the invasive monkey species had caused giant snake populations to swell in the 2530's, but today, due to excessive hunting, the giant snake's numbers have dwindled to the point of being an endangered species.";
+	name = "Giant Snake Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Aw" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Ax" = (
+/obj/structure/sign/vacuum,
+/turf/simulated/shuttle/wall,
+/area/awaymission/zoo/pirateship)
+"AB" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"AH" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"AL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"AR" = (
+/obj/effect/landmark/away,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/zoo)
+"AW" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"Bb" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"Bc" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Bi" = (
+/obj/item/weapon/tool/wrench,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Bk" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/chickensuit,
+/obj/item/clothing/head/chicken,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Bn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "The Samak are the apex predator in the various plains regions of the northern hemisphere of Meralar. Unlike many creatures of Meralar, it does not have any fur to speak of. Instead, it is completely covered in thick armored plates which act as a barrier between the Samak's internal warmth and the cold environment. However, this is still not that efficient, so the Samak feed often to keep themselves warm. The Samak have six thick legs tipped with broad claws, and roughly aerodynamic bodies. They burrow underground, detecting prey through incredibly keen thermal detection. They pop up suddenly, grab their next meal, and return underground just as quickly. They prefer larger prey, such as the Baqara, Elu'a Eli, and Tajaran. Due to their voracious appetites and tendency to ruin mine shafts and infrastructure, they have been hunted almost to extinction, mainly by the Slavemasters. For the Tajaran, being able to kill a Samak singlehandedly (and without 'cheating', such as saturation bombing and the like) is an incredible feat, and any individual who pulls it off is lauded greatly.";
+	name = "Samak Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Bo" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Bq" = (
+/obj/machinery/button/remote/airlock{
+	id = "packerCargo";
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Br" = (
+/obj/structure/table/rack,
+/obj/item/clothing/head/sombrero,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Bs" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"Bu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"By" = (
+/obj/structure/table/rack,
+/obj/item/weapon/beach_ball,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"BC" = (
+/mob/living/simple_mob/vore/aggressive/giant_snake{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"BK" = (
+/mob/living/simple_mob/animal/passive/penguin{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"BL" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"BN" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/mob/living/simple_mob/animal/space/alien/drone{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"BO" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"BS" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Cc" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"Ce" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"Cj" = (
+/obj/structure/table/rack,
+/obj/item/weapon/cell/high,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Cm" = (
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"Co" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Cp" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Cq" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Cx" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Cy" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/pen/red,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"Cz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "The Diyaab is a predatory creature whose various geneses dwell at the upper latitudes of both hemispheres of most continents on Meralar, in the Rarkajar system. They resemble wolverines in appearance, but are slightly larger, and with longer legs. They also have long ears and leonine tails tipped with a contrasting color, the specifics of which vary based on species. They live in packs of up to seven individuals. They are omnivores, consuming Chur'eech nuts and Thaa'dra, as well as fish, eggs, Arnab, and Dubaab. However, they are most notable for being able to take down larger creatures, including Tajara, by using group tactics. They communicate through body language involving the ears and tail. If forcibly separated from their packs with no means of returning, a Diyaab will lay down and die. It has been theorized that they are related to the Farwa.";
+	name = "Diyaab Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"CA" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/awaymission/zoo/pirateship)
+"CH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"CJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"CM" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile,
+/obj/item/clothing/mask/surgical,
+/obj/item/weapon/surgical/retractor{
+	pixel_y = 6
+	},
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/surgical/hemostat{
+	pixel_y = 4
+	},
+/obj/item/weapon/surgical/cautery{
+	pixel_y = 4
+	},
+/obj/item/weapon/surgical/FixOVein{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bonegel{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"CO" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/weapon/paper{
+	info = "The next person who takes one of my screwdrivers gets stabbed with one. They are MINE. - Love, Madsen";
+	name = "scribbled note"
+	},
+/obj/item/weapon/tool/screwdriver,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"CR" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/photo_album,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"CS" = (
+/obj/machinery/body_scanconsole,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"CX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Db" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Dd" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"Df" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"Dh" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Dl" = (
+/obj/machinery/seed_extractor,
+/obj/item/seeds/angelmycelium,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Dm" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"Dq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"Dr" = (
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Dw" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"DE" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/zoo)
+"DF" = (
+/obj/machinery/gateway{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"DM" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/mob/living/simple_mob/animal/passive/bird/parrot/kea{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"DQ" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"DT" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"DW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"DX" = (
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/weapon/storage/firstaid/o2{
+	layer = 2.8;
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/fire{
+	layer = 2.9;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/medical_wall{
+	pixel_y = 32
+	},
+/obj/item/weapon/storage/firstaid/combat,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Ea" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/asteroid,
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"Ei" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. Evilly";
+	frequency = 1213;
+	name = "Syndicate Intercom";
+	pixel_y = -32;
+	subspace_transmission = 1;
+	syndie = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"El" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "syndieshutters_infirmary";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"Et" = (
+/mob/living/simple_mob/animal/passive/snake{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"Ew" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"EE" = (
+/mob/living/simple_mob/animal/space/alien{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"EF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "Not to be confused with the common Earth bat, the Space Bat is a mammalian-like creature that is capable of surviving in the vacuum of space! These creatures live and fly in groups, and are most commonly found in caves, such as those on asteroids, or small planetary bodies with light gravity and no atmosphere. These creatures survive by sucking the blood of wayward space travelers, and are considered to be a pest by the Free Trade Union for their habit of infesting space ships sitting at dock. Their origin is currently unknown.";
+	name = "Space Bat Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"EH" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"EL" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"EO" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"ET" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"EW" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Fd" = (
+/mob/living/simple_mob/vore/bee{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/turf/flooring/misc_vr.dmi';
+	icon_state = "hive";
+	name = "giant honeycomb"
+	},
+/area/awaymission/zoo)
+"Fe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Fh" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Fi" = (
+/obj/machinery/door/unpowered/shuttle,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Fr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Fx" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Fy" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Fz" = (
+/obj/machinery/door/airlock/silver{
+	icon_state = "door_locked";
+	locked = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"FD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "The Ir'ash'uint (translating roughly from Skrellian to 'Giant Frog' in Galactic Common), this amphibian lives on the Skrell homeworld Qerrbalak, in the Qerr�valis System. The Giant Frog shares a common, albeit distant ancestry with the Skrell, but unlike the Skrell, its diet is exclusively carnivorous. Its diet includes large insects, fish, and indeed, even Skrell.";
+	name = "Giant Frog Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"FE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"FF" = (
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"FN" = (
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"FO" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"FQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"FS" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"FV" = (
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"FW" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"FX" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"FY" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/pen/red{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"FZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/zoo/pirateship)
+"Ge" = (
+/mob/living/simple_mob/animal/passive/cat{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"Gg" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Gh" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Go" = (
+/obj/structure/table/rack,
+/obj/item/clothing/under/owl,
+/obj/item/clothing/mask/gas/owl_mask,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Gp" = (
+/obj/machinery/computer,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Gr" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Gs" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Gv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo/pirateship)
+"Gz" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/bio_suit/plaguedoctorsuit,
+/obj/item/clothing/head/plaguedoctorhat,
+/obj/item/clothing/mask/gas/plaguedoctor,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"GC" = (
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"GF" = (
+/obj/structure/table/rack,
+/obj/item/weapon/soap/deluxe,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"GI" = (
+/obj/machinery/vending/assist{
+	contraband = null;
+	name = "AntagCorpVend";
+	products = list(/obj/item/device/assembly/prox_sensor = 5, /obj/item/device/assembly/signaler = 4, /obj/item/device/assembly/infra = 4, /obj/item/device/assembly/prox_sensor = 4, /obj/item/weapon/handcuffs = 8, /obj/item/device/flash = 4, /obj/item/weapon/cartridge/signal = 4, /obj/item/clothing/glasses/sunglasses = 4)
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"GO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "Catgirls (not to be confused with Nekos, an interspecies hybrid born of a union between Human and Tajaran parents) were created artificially with the intention of producing a Human-feline hybrid that could serve aboard a space-faring vessel, control pests aboard such ships, and even alleviate stress among male crew members. Their eyes are between 20% and 50% larger than the average Human, which gives them their famously 'Kawaii' appearance. The large eyes trigger a subconscious psychological 'cute' response among Humans, causing them to usually become relaxed in their presence. Some catgirls have learned to abuse this trait, and have evolved to prey upon Humans who linger too close for too long.";
+	name = "Catgirl Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"GQ" = (
+/obj/effect/landmark/away,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"GS" = (
+/obj/machinery/door/window/southleft,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"GZ" = (
+/obj/structure/reagent_dispensers,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"Hj" = (
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Hl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Ho" = (
+/mob/living/simple_mob/animal/space/alien{
+	faction = "pirate"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Hs" = (
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Hw" = (
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"Hx" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Cats were once common features on many trading, exploration, and naval ships in the early days of Human sailing. Cats were attracted by an abundance of mice and rats, which can cause damage to ropes, woodwork, and eventually as technology progressed, electrical wiring. Rodents also presented a threat to the stores the ship carried, both as cargo and as food for sailors. Furthermore, rats and mice were also sources of disease, which was dangerous for ships at sea for long periods of time. As Humanity thrust its self into the age of slipspace, the Cat has again made the common spaceship its hunting ground for exactly the same reasons it had in times of old. Skrell scientists have noted how the common Cat has been able to tame and even control Humans. It is believed that had the cat ever achieved sentience, Humanity its self would fall to its knees before their feline overlords. Fortunately for Humans across the galaxy, there is negligible evolutionary benefit for the cat to evolve further.";
+	name = "Cat Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"HA" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"HC" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Corgi (Welsh for 'dwarf dog') is a small type of herding dog that originated in Wales, on the planet Earth (Sol system). Two separate breeds are recognized: the Pembroke Welsh Corgi (as seen here) and the Cardigan Welsh Corgi. Historically, the Pembroke has been attributed to the influx of dogs alongside Flemish weavers from around the 10th century, while the Cardigan is attributed to the dogs brought with Norse settlers, in particular a common ancestor of the Swedish Vallhund. A certain degree of inbreeding between the two types has been suggested to explain the similarities between the two. Here it is seen in a replica of its natural habitat, the common office building, where it participates in a symbiotic relationship with the Humans who also reside here. In exchange for treats and bellyrubs, the Corgi provides the Humans with emotional support in the otherwise soul-crushing environment of the corporate workplace.";
+	name = "Corgi Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"HG" = (
+/obj/structure/urinal{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"HJ" = (
+/mob/living/simple_mob/humanoid/merc/ranged{
+	desc = "He doesn't seem like he's looking for a fight.";
+	faction = "neutral";
+	friendly = "hugs";
+	name = "Mercenary"
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"HM" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"HO" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"HT" = (
+/obj/effect/decal/remains,
+/obj/effect/gibspawner/generic,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"HU" = (
+/obj/effect/floor_decal/asteroid,
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"HW" = (
+/mob/living/simple_mob/animal/passive/dog/corgi/puppy{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"HX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"HZ" = (
+/obj/machinery/door/window/westleft,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Id" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Ie" = (
+/obj/structure/grille{
+	name = "mass ventilation"
+	},
+/turf/unsimulated/wall/planetary/normal,
+/area/awaymission/zoo)
+"Ii" = (
+/obj/machinery/door/airlock/silver{
+	name = "Women's Restroom"
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Il" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"Im" = (
+/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Io" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	icon_state = "right"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Iq" = (
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Iv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"Iw" = (
+/turf/simulated/floor/reinforced,
+/area/awaymission/zoo/pirateship)
+"Iy" = (
+/obj/machinery/door/blast/shutters{
+	id = "packerMed"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"IB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"ID" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"IP" = (
+/obj/machinery/door/window/northright,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"IQ" = (
+/obj/structure/curtain/open/privacy,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"IW" = (
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"IX" = (
+/obj/structure/table/standard,
+/obj/item/borg/sight/thermal,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Jd" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/zoo/pirateship)
+"Jh" = (
+/obj/structure/table/rack,
+/obj/effect/landmark/costume,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Ji" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/weapon/surgical/FixOVein{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/weapon/surgical/hemostat,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Ju" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Jv" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Jy" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"JC" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"JD" = (
+/obj/structure/table/rack,
+/obj/item/device/camera_film,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"JH" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/fancy/crayons,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"JI" = (
+/mob/living/simple_mob/animal/passive/bird/parrot/white_caique{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"JN" = (
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"JS" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"JY" = (
+/obj/machinery/iv_drip,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Ka" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"Kb" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"Kg" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"Kn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"Kq" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"Ku" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Kw" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Kx" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"KF" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"KM" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"KP" = (
+/mob/living/simple_mob/animal/passive/cat{
+	faction = "zoo"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"KR" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"KT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"KV" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"Lh" = (
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"Ll" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Lo" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The common Green Snake is an invasive species that makes its home on tropical worlds across the galaxy. Its ancestors were once kept as pets by Humans, but these snakes had escaped into the ventilation of ships over many centuries to feed on the abundance of mice usually infesting the maintinence passages. It is believed that they are descended from the Ball Python, native to Earth, in the Sol system.";
+	name = "Green Snake Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Lr" = (
+/obj/structure/table/standard,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bonegel{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/stack/medical/advanced/bruise_pack,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Lw" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Ly" = (
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"LA" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"LG" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"LI" = (
+/obj/machinery/sleep_console,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"LJ" = (
+/obj/item/frame/mirror,
+/turf/simulated/wall,
+/area/awaymission/zoo)
+"LL" = (
+/obj/structure/symbol/es{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"LN" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"LS" = (
+/obj/structure/symbol/sa{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"LX" = (
+/turf/space{
+	density = 1;
+	desc = "You can't go there!";
+	name = "The 4th Wall"
+	},
+/area/space)
+"LY" = (
+/obj/structure/table/standard,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Md" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Mh" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"Mj" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"Ml" = (
+/turf/simulated/floor/wood,
+/area/awaymission/zoo/pirateship)
+"Mm" = (
+/obj/machinery/computer,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"Mo" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Mr" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"ML" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"MM" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"MO" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"MS" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"MT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Nb" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Nc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_mob/animal/passive/penguin{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"Nd" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Nh" = (
+/obj/machinery/sleeper,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Ni" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Nj" = (
+/obj/structure/closet/lawcloset,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Nk" = (
+/obj/structure/bed/roller,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"No" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Nt" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"Nw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"NB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Don't be fooled, this isn't a storage room, but in fact the hunting ground of a deadly ambush predator known as the Mimic. The origin of this species is largely unknown, but they are theorized to be a cousin of the even more elusive changeling species. However, unlike the changeling, the mimic is known for disguising its self as inanimate objects, rather than other animals. When a suitable prey disturbs the mimic, it attacks, and if possible, swallows its victim whole. Scientists do not know how the creature reproduces, as all efforts to study the organism, dead or alive, have revealed that specimens examined do not have reproductive organs at all! It is hypothesized that the mimic grows and uses reproductive organs during a later life cycle, not yet recorded by any known sentient species.";
+	name = "Mimic Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"NC" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -25
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"NF" = (
+/obj/machinery/door/airlock/glass{
+	name = "Exhibit Airlock"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"NH" = (
+/obj/machinery/light/small,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"NI" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/yellow,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo/pirateship)
+"NS" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"NU" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"NV" = (
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"NY" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/candy,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"NZ" = (
+/obj/structure/sign/redcross,
+/turf/simulated/wall/durasteel,
+/area/awaymission/zoo)
+"Oa" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"Oc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Oe" = (
+/obj/machinery/door/airlock/silver{
+	icon_state = "door_locked";
+	locked = 1
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo/pirateship)
+"Oh" = (
+/obj/machinery/sleep_console,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Oo" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"Op" = (
+/obj/machinery/door/window/westright,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Ov" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "This giant snake is a rare beast native to Paraiso, in the Carnelia system. Though normally only found deep in the jungles, these ravenous monsters have been known to slither out onto the planet's many beach resorts to swallow up unwary sunbathers. Otherwise, the creature's diet consists mainly of monkeys that were accidentally introduced to the planet by pet owners. The presence of the invasive monkey species had caused giant snake populations to swell in the 2530's, but today, due to excessive hunting, the giant snake's numbers have dwindled to the point of being an endangered species.";
+	name = "Giant Snake Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Ow" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"OH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"OK" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"ON" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"OP" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/lights,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"OR" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"OT" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"OV" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/glass{
+	amount = 15
+	},
+/obj/item/weapon/cell{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"OZ" = (
+/obj/item/weapon/surgical/scalpel,
+/obj/structure/closet/crate,
+/obj/item/weapon/tank/anesthetic,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Pa" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Pc" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper/zoo/pirate/volk,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"Pd" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Pn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Pp" = (
+/obj/item/weapon/material/knife,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Pq" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Pr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"Ps" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Pt" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"Pv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Pw" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/material/knife,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Px" = (
+/obj/machinery/door/airlock/silver,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Py" = (
+/obj/structure/table/rack,
+/obj/item/toy/nanotrasenballoon,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Pz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"PB" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper{
+	info = "DEAR DAIRY: So we was doing our typpical route when the captain says we've been picking up weird signals on some backwatter planet. Madsen wanted to stay on course but he ain't the captain, so we went out of the way to check it out. There was lots of rocks on the way, but we got to the planet fine. Found a big fancy camp with nobody around and this big metal donut thing with NT stamps all over it right in the middle. Case of beer too. Captain reckons we can pass it off to some buyer in the Syndicate. Ingram says it's bad luck and that someone is going to come look for it but it sounds like better money than selling bad meat to jerky companies.";
+	name = "Old Diary"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"PC" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass4"
+	},
+/area/awaymission/zoo)
+"PG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"PH" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"PJ" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"PN" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"PV" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "meatConvey2"
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"PZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Qa" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -25
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Qg" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Qh" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass2"
+	},
+/area/awaymission/zoo)
+"Ql" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"Qp" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Qq" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"Qw" = (
+/obj/machinery/door/airlock/glass{
+	name = "Exhibit Airlock"
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Qy" = (
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"QD" = (
+/obj/item/weapon/mop,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"QK" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"QN" = (
+/obj/structure/table/rack,
+/obj/random/plushie,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"QQ" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/awaymission/zoo/syndieship)
+"QR" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"Rb" = (
+/obj/effect/landmark/away,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Re" = (
+/mob/living/simple_mob/animal/passive/cat{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass3"
+	},
+/area/awaymission/zoo)
+"Rh" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"Ri" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"Rj" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"Rk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Rl" = (
+/mob/living/simple_mob/humanoid/pirate,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"Rq" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Rr" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Rt" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"RD" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"RH" = (
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"RI" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"RJ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"RM" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"RN" = (
+/obj/structure/table/marble,
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"RO" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"RX" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/mineral/floor/ignore_mapgen,
+/area/awaymission/zoo)
+"RY" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Sc" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Sd" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"Sf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/landmark/loot_spawn{
+	live_cargo = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Sg" = (
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/zoo)
+"Sh" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/mob/living/simple_mob/humanoid/pirate,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Si" = (
+/obj/machinery/gateway{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Sj" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"Sm" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Ss" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Ir'ash'uint (translating roughly from Skrellian to 'Giant Frog' in Galactic Common), this amphibian lives on the Skrell homeworld Qerrbalak, in the Qerr�valis System. The Giant Frog shares a common, albeit distant ancestry with the Skrell, but unlike the Skrell, its diet is exclusively carnivorous. Its diet includes large insects, fish, and indeed, even Skrell.";
+	name = "Giant Frog Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Su" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_w";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/asteroid,
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"SG" = (
+/obj/structure/table/rack,
+/obj/item/toy/sword,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"SH" = (
+/obj/effect/blocker,
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/awaymission/zoo)
+"SI" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"SR" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/area/awaymission/zoo/syndieship)
+"Ta" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Tc" = (
+/obj/structure/closet,
+/obj/item/clothing/under/overalls,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"Td" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/packageWrap,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Te" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Tm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"Ts" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "meatConvey1"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"Tt" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"TA" = (
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"TJ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Penguins are a group of aquatic, flightless birds living almost exclusively in the Southern Hemisphere of Earth, in the Sol system, especially in the continent of Antarctica. Highly adapted for life in the water, penguins have countershaded dark and white plumage, and their wings have evolved into flippers. Most penguins feed on krill, fish, squid and other forms of sealife caught while swimming underwater. They spend about half of their lives on land and half in the oceans. Due to the effects of global warming, penguins have been sent off-world to wildlife sanctuaries across the galaxy. Today, many such reserves harbor the last of this species, while penguins are now extinct on Earth.";
+	name = "Space Penguin Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"TK" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"TR" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"TT" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"TW" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/awaymission/zoo)
+"Ub" = (
+/obj/structure/table/standard,
+/obj/structure/closet/secure_closet/medical_wall{
+	pixel_y = 32;
+	req_access = list(150)
+	},
+/obj/item/bodybag,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/weapon/reagent_containers/syringe,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Uj" = (
+/obj/structure/closet/syndicate/suit{
+	name = "suit closet"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Un" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/backpack/clown,
+/obj/item/clothing/shoes/rainbow,
+/obj/item/clothing/under/color/rainbow,
+/obj/item/clothing/gloves/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Up" = (
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Us" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	opened = 1
+	},
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Ux" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"Uz" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"UE" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/landmark/loot_spawn{
+	live_cargo = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"UI" = (
+/obj/structure/table/marble,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"UM" = (
+/obj/machinery/gateway/centeraway{
+	calibrated = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"UN" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1;
+	icon_state = "spline_plain_full"
+	},
+/obj/structure/showcase{
+	desc = "It looks almost lifelike.";
+	icon = 'icons/obj/statue.dmi';
+	icon_state = "monkey";
+	name = "Statue"
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"UO" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"UT" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/spacecash/c10,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"UV" = (
+/obj/machinery/newscaster,
+/turf/simulated/wall,
+/area/awaymission/zoo)
+"UW" = (
+/obj/structure/table/rack,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"UY" = (
+/obj/machinery/gateway{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"UZ" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"Ve" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	icon_state = "right"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Vh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "syndieshutters_infirmary";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"Vi" = (
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Vj" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"Vk" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"Vl" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"Vn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Vp" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "meatConvey2"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/pirateship)
+"Vv" = (
+/obj/effect/landmark/away,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"Vw" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Vz" = (
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"VA" = (
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"VD" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo/pirateship)
+"VH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/awaymission/zoo/pirateship)
+"VK" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"VQ" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"VS" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"VU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/material/knife,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"VX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"VY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"We" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Wg" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "applebush"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/zoo)
+"Wh" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/beach/water,
+/area/awaymission/zoo)
+"Wk" = (
+/obj/machinery/door/window/eastleft,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Wl" = (
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"Wn" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Wr" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/zoo)
+"Wu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Wv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"WD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"WE" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"WG" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "Catgirls (not to be confused with Nekos, an interspecies hybrid born of a union between Human and Tajaran parents) were created artificially with the intention of producing a Human-feline hybrid that could serve aboard a space-faring vessel, control pests aboard such ships, and even alleviate stress among male crew members. Their eyes are between 20% and 50% larger than the average Human, which gives them their famously 'Kawaii' appearance. The large eyes trigger a subconscious psychological 'cute' response among Humans, causing them to usually become relaxed in their presence. Some catgirls have learned to abuse this trait, and have evolved to prey upon Humans who linger too close for too long.";
+	name = "Catgirl Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"WM" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/mob/living/simple_mob/animal/passive/bird/parrot/budgerigar/bluegreen{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"WO" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"WR" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/zoo/pirateship)
+"WU" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"WV" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/oxygen/yellow,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"WY" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/spacecash/c1000,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"WZ" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"Xe" = (
+/mob/living/simple_mob/animal/space/bats{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert,
+/area/awaymission/zoo)
+"Xg" = (
+/obj/structure/largecrate,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Xj" = (
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_e";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_s";
+	name = "rocky edge"
+	},
+/obj/effect/floor_decal/spline{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid_edge_n";
+	name = "rocky edge"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"Xq" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass4"
+	},
+/area/awaymission/zoo)
+"Xr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Xv" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/carpet,
+/area/awaymission/zoo/pirateship)
+"Xz" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/grass,
+/area/awaymission/zoo)
+"XB" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/mob/living/simple_mob/animal/passive/bird/parrot/cockatiel{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"XH" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass1"
+	},
+/area/awaymission/zoo)
+"XO" = (
+/turf/simulated/floor/holofloor/desert,
+/area/awaymission/zoo)
+"XP" = (
+/mob/living/simple_mob/animal/space/alien/drone{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/desert{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroidplating";
+	name = "scorched sand"
+	},
+/area/awaymission/zoo)
+"XQ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"XZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"Ya" = (
+/obj/structure/flora/tree/pine,
+/turf/simulated/floor/holofloor/snow,
+/area/awaymission/zoo)
+"Yj" = (
+/obj/structure/mopbucket,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Yl" = (
+/obj/machinery/door/window/northleft,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Yn" = (
+/obj/structure/symbol/da,
+/turf/simulated/wall,
+/area/awaymission/zoo)
+"Yp" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass1"
+	},
+/area/awaymission/zoo)
+"Yr" = (
+/obj/item/clothing/suit/caution,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"Yu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/sign/kiddieplaque{
+	desc = "The Xenomorph XX121, better known just as Xenomorph, are an extraterrestrial, endoparasitoid species with multiple life cycles, possibly originating from the planet Proteus (also known as Xenomorph Prime), which orbits the star A6 454. One of the deadliest of all known alien species, these creatures need a host organism in order to reproduce. The appearance of the Xenomorph varies depending on its host. The Human phenotype is generally around 7�8 feet, and roughly 136.0 to 181.4 kilograms in weight, with a long, muscular tail and large, curved, oblong head. The Queen of this species is generally twice as large (they can grow even larger, some even up to 100 feet tall, and stronger if given time) and possesses superior speed, strength and intelligence. The term Xenomorph is derived from the Greek words xeno ('stranger', 'alien', and 'foreigner') and morphe ('form', 'shape'). There are no solid facts as to the origins of the Xenomorph species; instead, there are many assumptions which cannot be confirmed. Based on the limited information we have, the most commonly accepted hypothesis is that they are an artificially created species, although another hypothesis says that they evolved naturally on a planet much different than our own. The Xenomorph lives in a hive together with its queen. Amazingly, the blood and other bodily fluids of the Xenomorph are highly acidic. It is not yet understood how a creature of such biology can exist. The planet Proteus is also home to rare, red-hued Xenomorphs, who frequently fight their black-colored rivals. Some Xenomorphs are alleged to be able to cloak themselves to be invisible to the human eye, but this has not been confirmed by independent study.";
+	name = "Xenomorph Exhibit"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Yv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/cautery,
+/obj/item/weapon/surgical/retractor,
+/obj/item/stack/nanopaste,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Yx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/awaymission/zoo/syndieship)
+"YB" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass2"
+	},
+/area/awaymission/zoo)
+"YC" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor,
+/area/awaymission/zoo)
+"YE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/grass{
+	icon = 'icons/jungle.dmi';
+	icon_state = "grass2"
+	},
+/area/awaymission/zoo)
+"YG" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"YL" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"YM" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/item/weapon/storage/wallet/random,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/zoo/pirateship)
+"YO" = (
+/mob/living/simple_mob/humanoid/pirate,
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"YP" = (
+/obj/structure/closet{
+	name = "custodial"
+	},
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"YR" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"YS" = (
+/obj/machinery/door/blast/shutters{
+	id = "packerCargo"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/zoo/pirateship)
+"YW" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo/pirateship)
+"YX" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-22"
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/zoo)
+"Za" = (
+/obj/item/weapon/tool/crowbar,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"Ze" = (
+/obj/structure/table/marble,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/lino,
+/area/awaymission/zoo)
+"Zh" = (
+/mob/living/simple_mob/animal/passive/bird/parrot/white_cockatoo{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"Zq" = (
+/obj/structure/window/phoronreinforced{
+	dir = 1;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4;
+	maxhealth = 10000;
+	name = "robust borosilicate window"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/awaymission/zoo)
+"Zt" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/awaymission/zoo)
+"Zw" = (
+/obj/effect/floor_decal/carpet{
+	icon_state = "carpet"
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 6
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"Zx" = (
+/turf/simulated/wall/durasteel,
+/area/awaymission/zoo)
+"Zy" = (
+/obj/structure/bed/chair,
+/obj/structure/showcase{
+	desc = "It looks almost lifelike.";
+	icon = 'icons/obj/statue.dmi';
+	icon_state = "Human_male";
+	name = "Statue"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/zoo)
+"ZA" = (
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"ZE" = (
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ZH" = (
+/mob/living/simple_mob/animal/passive/cow{
+	faction = "zoo"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass0"
+	},
+/area/awaymission/zoo)
+"ZI" = (
+/obj/machinery/door/window/eastright,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+"ZK" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "fullgrass0"
+	},
+/area/awaymission/zoo)
+"ZL" = (
+/obj/effect/overlay/palmtree_l,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ZN" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ZP" = (
+/obj/effect/overlay/palmtree_r,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "dgrass3"
+	},
+/area/awaymission/zoo)
+"ZU" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/awaymission/zoo)
+"ZV" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/closet/secure_closet/medical_wall{
+	pixel_x = 32;
+	req_access = list(150)
+	},
+/obj/item/weapon/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/sterile,
+/obj/item/weapon/reagent_containers/syringe,
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/turf/simulated/shuttle/floor/darkred,
+/area/awaymission/zoo/syndieship)
+
+(1,1,1) = {"
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+"}
+(2,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(3,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(4,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(5,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+kC
+mT
+Dm
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kC
+mT
+Dm
+rj
+ez
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+sI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+rj
+ez
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+sI
+Lh
+Lh
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(6,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Up
+ez
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+gt
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Up
+ez
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+gt
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(7,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ui
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+rW
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ui
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+rW
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(8,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Ux
+qh
+cf
+Vz
+Ux
+qh
+cf
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+yQ
+SH
+kl
+kl
+kl
+SH
+yQ
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(9,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+dJ
+Xz
+rI
+UO
+Vz
+vm
+rI
+ty
+KR
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+yQ
+DE
+DE
+DE
+yE
+DE
+DE
+DE
+yQ
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(10,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Ux
+Xz
+PG
+cO
+Vz
+Vz
+Vz
+cO
+Bc
+ty
+cf
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+HC
+NS
+qS
+ub
+HC
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+yQ
+DE
+DE
+DE
+yE
+yE
+yE
+DE
+DE
+DE
+yQ
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+Lo
+NS
+qS
+ub
+Lo
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(11,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Jv
+Fx
+VQ
+fa
+zD
+Vz
+VQ
+fa
+zD
+Jv
+Fx
+Lh
+Lh
+Lh
+Lh
+qS
+Dr
+FY
+Dr
+Dr
+Dr
+Te
+Dr
+Dr
+Dr
+Te
+Dr
+Dr
+Nj
+Nj
+rG
+qS
+Lh
+Lh
+Lh
+Lh
+SH
+DE
+DE
+DE
+yE
+DE
+yE
+DE
+DE
+DE
+SH
+Lh
+Lh
+Lh
+Lh
+qS
+xf
+hC
+bf
+yq
+hC
+KV
+Dd
+WZ
+Ag
+Yp
+bf
+Pt
+bk
+hC
+xz
+qS
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(12,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Bc
+UO
+Vz
+iY
+Vz
+Vz
+Vz
+iY
+Vz
+vm
+PG
+Lh
+Lh
+Lh
+Lh
+BO
+Zy
+no
+Dr
+sS
+EO
+Te
+Dr
+Dr
+EO
+Te
+Dr
+fC
+lo
+yw
+Dr
+BO
+Lh
+Lh
+Lh
+Lh
+kl
+DE
+yE
+yE
+yE
+yE
+yE
+yE
+yE
+DE
+kl
+Lh
+Lh
+Lh
+Lh
+BO
+qG
+qG
+kY
+bf
+hC
+FX
+hC
+Iv
+WZ
+bf
+yq
+WZ
+WZ
+dF
+bf
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(13,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Vz
+Vz
+Vz
+Vz
+Vz
+Wg
+Vz
+Vz
+Vz
+Vz
+Vz
+Lh
+Lh
+Lh
+Lh
+ln
+Dr
+lB
+Dr
+Dr
+Dr
+Te
+Dr
+Dr
+Dr
+Te
+Dr
+Gh
+VS
+JC
+Dr
+ln
+Lh
+Lh
+Lh
+Lh
+kl
+yE
+yE
+DE
+yE
+Ie
+yE
+DE
+yE
+yE
+kl
+Lh
+Lh
+Lh
+Lh
+ln
+zC
+vb
+xf
+EL
+EL
+EL
+yW
+bf
+WZ
+WZ
+OR
+EL
+an
+bL
+bf
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(14,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Ux
+KR
+Vz
+cO
+Vz
+Vz
+Vz
+cO
+Vz
+dJ
+cf
+Lh
+Lh
+Lh
+Lh
+BO
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+YR
+Cp
+Zw
+Dr
+BO
+Lh
+Lh
+Lh
+Lh
+kl
+DE
+yE
+yE
+yE
+yE
+yE
+yE
+yE
+DE
+kl
+Lh
+Lh
+Lh
+Lh
+BO
+zC
+zC
+qG
+qG
+XH
+bf
+zW
+hC
+aF
+Et
+EL
+XH
+WZ
+mi
+PC
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(15,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Jv
+Fx
+VQ
+fa
+zD
+Vz
+VQ
+fa
+zD
+Jv
+Fx
+Lh
+Lh
+Lh
+Lh
+qS
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+uP
+uP
+uP
+qS
+Lh
+Lh
+Lh
+Lh
+SH
+DE
+DE
+DE
+yE
+DE
+yE
+DE
+DE
+DE
+SH
+Lh
+Lh
+Lh
+Lh
+qS
+gh
+zC
+bf
+jn
+qG
+gI
+EL
+EL
+EL
+EL
+EL
+EL
+Bb
+fP
+qg
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(16,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Bc
+hJ
+cf
+iY
+Vz
+Vz
+Vz
+iY
+Ux
+vt
+PG
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+RX
+HC
+NS
+qS
+ub
+HC
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+yQ
+DE
+DE
+DE
+yE
+yE
+yE
+DE
+DE
+DE
+yQ
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+Lo
+NS
+qS
+ub
+Lo
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(17,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+vm
+hJ
+qh
+KR
+Vz
+dJ
+qh
+vt
+UO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+yQ
+DE
+DE
+DE
+yE
+DE
+DE
+DE
+yQ
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(18,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Bc
+rI
+PG
+Vz
+Bc
+rI
+PG
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+yQ
+SH
+kl
+kl
+kl
+SH
+yQ
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(19,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+bI
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+bI
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+Yu
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Yu
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(20,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+pS
+pS
+pS
+pS
+pS
+pS
+HU
+pS
+pS
+pS
+pS
+pS
+HU
+pS
+pS
+pS
+pS
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(21,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+oh
+oh
+oh
+oh
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+wF
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+pS
+pS
+hS
+Ea
+hS
+hS
+hS
+hS
+pS
+hS
+hS
+pS
+pS
+pS
+pS
+HU
+pS
+pS
+pS
+wF
+nI
+Lh
+Lh
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(22,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+NV
+Mm
+PJ
+PJ
+Mm
+NV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+Qw
+BO
+qS
+UV
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+ln
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+pS
+HU
+em
+gM
+gM
+gM
+gM
+gM
+gM
+Xj
+gM
+gM
+Rh
+hS
+hS
+hS
+XP
+pS
+hS
+hS
+hS
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(23,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+NV
+NV
+NV
+oF
+oF
+NV
+NV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+sI
+Lh
+Lh
+Lh
+wl
+jz
+jz
+jz
+jz
+jz
+wl
+Lh
+Lh
+Lh
+wl
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+wl
+Lh
+Lh
+Lh
+wl
+tM
+rz
+io
+rz
+vc
+wl
+Lh
+Lh
+Lh
+wl
+hS
+em
+gM
+gM
+ro
+Mj
+Mj
+eF
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+Rh
+em
+gM
+gM
+gM
+wl
+Lh
+Lh
+Lh
+au
+EW
+rQ
+rQ
+rQ
+nC
+"}
+(24,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+wV
+tE
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+nT
+nT
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+gt
+Lh
+Lh
+Lh
+Lh
+Db
+jz
+jz
+jz
+jz
+jz
+Db
+Lh
+Lh
+Lh
+Db
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+Db
+Lh
+Lh
+Lh
+Db
+tM
+rz
+io
+rz
+vc
+Db
+Lh
+Lh
+Lh
+Db
+gM
+gM
+gM
+Ri
+hS
+hS
+HU
+pS
+Mj
+dC
+Mj
+gx
+eE
+gM
+gM
+gM
+gM
+gM
+gM
+ro
+Mj
+Db
+Lh
+Lh
+Lh
+Lh
+LA
+EW
+rQ
+rQ
+nC
+"}
+(25,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+vf
+kd
+tY
+wV
+wV
+NV
+NV
+Pc
+gG
+Mm
+NV
+NV
+NV
+NV
+uc
+tE
+tE
+wV
+wV
+vf
+kd
+tY
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+iQ
+rz
+rz
+iQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+rW
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+jz
+jz
+jz
+Hs
+Hs
+VY
+Lh
+Lh
+Lh
+VY
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+VY
+Lh
+Lh
+Lh
+VY
+tM
+jN
+io
+bw
+vc
+VY
+Lh
+Lh
+Lh
+VY
+gM
+gM
+gM
+gM
+gM
+gM
+Rh
+pS
+HU
+pS
+mM
+gM
+gM
+gM
+ro
+Mj
+Mj
+Mj
+Mj
+pS
+pS
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+rW
+qS
+rQ
+nC
+"}
+(26,1,1) = {"
+nC
+LX
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+de
+Ml
+Ml
+wV
+NV
+NV
+NV
+Vj
+Xv
+NV
+NV
+NV
+NV
+NV
+uc
+tE
+tE
+pN
+wV
+rM
+Iw
+rM
+wV
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+nT
+nT
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+gl
+jz
+jz
+Hs
+jz
+jz
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+tM
+rz
+io
+eY
+vc
+qS
+Lh
+Lh
+Lh
+qS
+Mj
+Mj
+Su
+Mj
+eF
+gM
+gM
+nm
+pS
+hS
+em
+gM
+ro
+Mj
+pS
+pS
+pS
+HU
+pS
+pS
+pS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(27,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+NI
+Gv
+Ml
+Oe
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+wV
+tE
+bD
+pN
+wV
+VH
+Iw
+Iw
+wV
+rQ
+rQ
+db
+fk
+sM
+sM
+Lh
+Lh
+Lh
+Lh
+sM
+sM
+fk
+db
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Hs
+jz
+jz
+UI
+jz
+za
+Lh
+Lh
+Lh
+wl
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+wl
+Lh
+Lh
+Lh
+wl
+tM
+Ku
+io
+rz
+vc
+wl
+Lh
+Lh
+Lh
+wl
+pS
+pS
+pS
+pS
+pS
+BN
+gM
+Rh
+em
+gM
+gM
+gM
+nm
+pS
+iP
+pS
+pS
+pS
+pS
+hS
+hS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(28,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+wV
+wV
+wV
+NV
+NV
+NV
+Rl
+NV
+NV
+NV
+NV
+NV
+NV
+wV
+tE
+tE
+tE
+wV
+wV
+eV
+wV
+wV
+rQ
+rQ
+FV
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+FV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+EF
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+EF
+Lh
+Lh
+Lh
+us
+tM
+eY
+io
+tj
+vc
+us
+Lh
+Lh
+Lh
+li
+pS
+pS
+pS
+EE
+pS
+mM
+gM
+gM
+gM
+gM
+ro
+Mj
+pS
+pS
+pS
+pS
+pS
+pS
+em
+gM
+gM
+li
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(29,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Md
+qO
+tE
+uc
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+NV
+wV
+tE
+tE
+tE
+uc
+tE
+qO
+MT
+wV
+rQ
+rQ
+Zq
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+Zq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+Hs
+jz
+jz
+UI
+jz
+za
+Lh
+Lh
+Lh
+VY
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+Xe
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+VY
+Lh
+Lh
+Lh
+VY
+tM
+rz
+io
+tj
+vc
+VY
+Lh
+Lh
+Lh
+VY
+pS
+pS
+HU
+pS
+pS
+pS
+Mj
+Mj
+Mj
+Mj
+pS
+pS
+HU
+pS
+XP
+pS
+pS
+em
+gM
+gM
+ro
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(30,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+qb
+tE
+YL
+wV
+wV
+wV
+wV
+wV
+wV
+Fz
+wV
+wV
+Fz
+wV
+wV
+wV
+wV
+wV
+wV
+Rk
+tE
+WV
+wV
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+qS
+LL
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+Xe
+Xe
+Xe
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+tM
+tj
+io
+KF
+vc
+qS
+Lh
+Lh
+Lh
+qS
+hS
+hS
+hS
+pS
+pS
+pS
+pS
+pS
+hS
+hS
+jT
+hS
+hS
+hS
+pS
+pS
+em
+gM
+gM
+ro
+pS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+LL
+qS
+rQ
+nC
+"}
+(31,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Rk
+tE
+YL
+wV
+CO
+LN
+LN
+LN
+XZ
+LN
+LN
+LN
+LN
+XZ
+LN
+LN
+LN
+LN
+wV
+Rk
+tE
+tE
+Sm
+tP
+rz
+tP
+Lh
+Lh
+Lh
+tz
+tz
+tz
+tz
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+wl
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+Xe
+Xe
+Xe
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+BO
+Lh
+Lh
+Lh
+wl
+tM
+bO
+io
+re
+vc
+wl
+Lh
+Lh
+Lh
+wl
+gM
+gM
+gM
+Rh
+hS
+hS
+Ea
+em
+gM
+gM
+gM
+gM
+gM
+gM
+Rh
+em
+gM
+gM
+ro
+pS
+pS
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(32,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+qb
+tE
+qo
+wV
+LN
+jc
+LN
+LN
+LN
+LN
+LN
+LN
+Sh
+LN
+LN
+LN
+LN
+NH
+wV
+Oc
+tE
+WV
+Ax
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+ws
+ps
+ps
+gb
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+oe
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+Db
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+Xe
+Xe
+Xe
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+ln
+Lh
+Lh
+Lh
+Db
+Ju
+tj
+io
+YC
+vc
+Db
+Lh
+Lh
+Lh
+Db
+Mj
+eF
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+ro
+Su
+Mj
+eF
+gM
+gM
+gM
+gM
+ro
+pS
+pS
+pS
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(33,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Rk
+tE
+YL
+wV
+uC
+uC
+uC
+aJ
+LN
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+Jd
+LN
+LN
+wV
+Rk
+tE
+tE
+Sm
+tP
+rz
+tP
+Lh
+Lh
+Lh
+sM
+sM
+sM
+sM
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+VY
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+Xe
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+XO
+BO
+Lh
+Lh
+Lh
+VY
+tM
+rF
+io
+tj
+vc
+VY
+Lh
+Lh
+Lh
+VY
+pS
+HU
+Mj
+Mj
+Mj
+Su
+Mj
+Mj
+gx
+hS
+hS
+hS
+pS
+Mj
+Mj
+Mj
+Mj
+pS
+pS
+HU
+pS
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(34,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+qb
+tE
+YL
+wV
+aH
+Hj
+Hj
+xh
+LN
+Jd
+qp
+qp
+Nw
+qp
+tE
+Jd
+LN
+LN
+wV
+Rk
+tE
+WV
+vl
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+tM
+rz
+io
+tj
+vc
+qS
+Lh
+Lh
+Lh
+qS
+pS
+hS
+hS
+pS
+HU
+pS
+pS
+mM
+gM
+gM
+gM
+gM
+Rh
+HU
+pS
+pS
+XP
+pS
+pS
+pS
+HU
+Yn
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(35,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Ll
+tE
+fp
+wV
+gW
+Hj
+Im
+xh
+LN
+Jd
+OH
+qp
+qp
+tE
+Qy
+Jd
+LN
+LN
+wV
+Ll
+mX
+fp
+wV
+rQ
+rQ
+db
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+db
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+wl
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+wl
+Lh
+Lh
+Lh
+wl
+tM
+rz
+io
+eY
+vc
+wl
+Lh
+Lh
+Lh
+wl
+em
+gM
+gM
+Rh
+XP
+pS
+Ea
+em
+gM
+ro
+eF
+gM
+gM
+Rh
+hS
+pS
+pS
+pS
+pS
+pS
+pS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(36,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Ax
+Sm
+vl
+wV
+uN
+Hj
+Hj
+Dl
+LN
+Jd
+Pz
+tE
+Ho
+No
+tE
+Jd
+LN
+LN
+wV
+wV
+wV
+wV
+wV
+rQ
+rQ
+FV
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+FV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+EF
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+EF
+Lh
+Lh
+Lh
+us
+tM
+FS
+io
+rz
+vc
+us
+Lh
+Lh
+Lh
+li
+gM
+gM
+gM
+gM
+Rh
+em
+gM
+gM
+gM
+nm
+pS
+eF
+gM
+gM
+gM
+Rh
+pS
+HU
+pS
+zx
+pS
+li
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(37,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+aH
+nS
+Hj
+xh
+LN
+Jd
+Nb
+Nb
+Ve
+Nb
+Nb
+Jd
+LN
+LN
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+fk
+tz
+tz
+Lh
+Lh
+Lh
+Lh
+tz
+tz
+fk
+Zq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+Hs
+jz
+jz
+Hs
+jz
+za
+Lh
+Lh
+Lh
+VY
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+VY
+Lh
+Lh
+Lh
+VY
+tM
+et
+io
+rz
+vc
+VY
+Lh
+Lh
+Lh
+VY
+gM
+ro
+eF
+gM
+gM
+gM
+gM
+ro
+Mj
+pS
+pS
+iP
+Mj
+eF
+gM
+gM
+Rh
+hS
+pS
+pS
+pS
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(38,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Rt
+Rt
+Rt
+nJ
+LN
+aM
+tE
+tE
+tE
+Bi
+tE
+aM
+LN
+LN
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+nT
+nT
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+gl
+jz
+jz
+Hs
+jz
+jz
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+tM
+rz
+io
+rz
+vc
+qS
+Lh
+Lh
+Lh
+qS
+gM
+nm
+pS
+eF
+gM
+gM
+gM
+Rh
+jL
+hS
+pS
+pS
+HU
+pS
+eF
+gM
+gM
+gM
+Rh
+pS
+pS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(39,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+Pp
+LN
+LN
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+iQ
+rz
+rz
+iQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Uz
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+jz
+jz
+jz
+Hs
+zZ
+wl
+Lh
+Lh
+Lh
+wl
+XO
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+sv
+XO
+XO
+XO
+XO
+XO
+wl
+Lh
+Lh
+Lh
+wl
+tM
+rz
+io
+sa
+vc
+wl
+Lh
+Lh
+Lh
+wl
+Mj
+pS
+HU
+pS
+Mj
+eF
+gM
+gM
+gM
+gM
+Rh
+hS
+pS
+hS
+hS
+eE
+gM
+gM
+gM
+Rh
+pS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Uz
+qS
+rQ
+nC
+"}
+(40,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+LN
+LN
+LN
+LN
+LN
+LN
+oq
+LN
+LN
+LN
+LN
+LN
+LN
+zY
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+nT
+nT
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+Mo
+Lh
+Lh
+Lh
+Lh
+Db
+jz
+jz
+jz
+jz
+jz
+Db
+Lh
+Lh
+Lh
+Db
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+sv
+sv
+XO
+sv
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+Db
+Lh
+Lh
+Lh
+Db
+tM
+eY
+io
+Qq
+vc
+Db
+Lh
+Lh
+Lh
+Db
+pS
+HU
+pS
+Ea
+hS
+em
+gM
+gM
+gM
+gM
+gM
+gM
+Xj
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+Rh
+Db
+Lh
+Lh
+Lh
+Lh
+yZ
+fu
+rQ
+rQ
+nC
+"}
+(41,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+wV
+wV
+wV
+Fi
+wV
+wV
+LN
+LN
+LN
+LN
+wV
+wV
+Fi
+wV
+wV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+ON
+Lh
+Lh
+Lh
+VY
+jz
+jz
+jz
+jz
+jz
+VY
+Lh
+Lh
+Lh
+VY
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+VY
+Lh
+Lh
+Lh
+VY
+tM
+uI
+io
+GC
+vc
+VY
+Lh
+Lh
+Lh
+VY
+hS
+hS
+em
+gM
+gM
+gM
+gM
+ro
+Mj
+Mj
+eF
+gM
+gM
+gM
+fe
+gM
+gM
+gM
+fe
+gM
+gM
+VY
+Lh
+Lh
+Lh
+HO
+fu
+rQ
+rQ
+rQ
+nC
+"}
+(42,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+tE
+wV
+ah
+Qg
+Vl
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+wV
+tE
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+Qw
+BO
+qS
+UV
+Lh
+Lh
+Lh
+qS
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+ln
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+gM
+gM
+gM
+gM
+ro
+Mj
+Mj
+pS
+pS
+HU
+pS
+Mj
+Mj
+Su
+pS
+Mj
+Mj
+Mj
+pS
+Mj
+Mj
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(43,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+tE
+tE
+wV
+yR
+Qg
+Vl
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+NH
+wV
+tE
+tE
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+DW
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+Mj
+Mj
+Mj
+HU
+pS
+pS
+HU
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+HU
+pS
+pS
+pS
+DW
+nI
+Lh
+Lh
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(44,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+tE
+tE
+tE
+wV
+VD
+Qg
+zJ
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+LN
+wV
+tE
+tE
+tE
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+HU
+pS
+pS
+pS
+pS
+pS
+pS
+HU
+pS
+pS
+HU
+pS
+pS
+pS
+pS
+pS
+HU
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(45,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+tE
+tE
+tE
+tE
+wV
+fv
+fv
+Nd
+LN
+Pv
+pX
+xP
+LN
+LN
+Pv
+ka
+rN
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+bI
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+bI
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+Yu
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Yu
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(46,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Nk
+tE
+tE
+tE
+ar
+wV
+LN
+LN
+LN
+LN
+Jd
+Ts
+Jd
+LN
+LN
+Jd
+Vp
+Jd
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+tE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+sN
+bF
+bF
+bF
+bF
+bF
+qI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+zg
+Lh
+Lh
+Lh
+nV
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(47,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+tE
+tE
+tE
+tE
+tE
+Iy
+LN
+LN
+LN
+LN
+Jd
+pX
+Jd
+LN
+LN
+Jd
+PV
+Jd
+LN
+NH
+wV
+tE
+tE
+tE
+tE
+tE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+sN
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+qI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(48,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Ly
+tE
+tE
+tE
+tE
+Iy
+LN
+LN
+LN
+LN
+Jd
+pX
+Jd
+LN
+LN
+Jd
+PV
+Jd
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+tE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+sN
+zC
+on
+zC
+jY
+zC
+zC
+ZH
+zC
+zC
+qI
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+uM
+NS
+qS
+ub
+uM
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+cb
+cb
+cb
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+NB
+NS
+qS
+ub
+NB
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(49,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+OZ
+tE
+tE
+tE
+tE
+Iy
+LN
+LN
+LN
+LN
+Jd
+pX
+Jd
+Wu
+LN
+Jd
+PV
+Jd
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+tE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+ET
+zC
+zC
+zC
+zC
+Vz
+zC
+zC
+zC
+zC
+Kb
+Lh
+Lh
+Lh
+Lh
+qS
+zC
+qG
+xU
+zC
+YB
+bf
+qG
+bf
+tA
+zC
+zC
+bL
+BL
+XQ
+bL
+qS
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+Lh
+Il
+fZ
+AH
+ml
+eG
+Lh
+Lh
+Rr
+Lh
+Lh
+Lh
+Lh
+qS
+Sg
+wM
+hi
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+Yn
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(50,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+pf
+tE
+Nk
+tE
+Nh
+wV
+wa
+vj
+LN
+LN
+Jd
+pX
+Jd
+LN
+LN
+Jd
+PV
+Jd
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+tE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+ET
+zC
+jY
+on
+Vz
+bZ
+iL
+zC
+ZH
+zC
+Kb
+Lh
+Lh
+Lh
+Lh
+BO
+EL
+KV
+Pt
+RD
+Tt
+xU
+qG
+RD
+ks
+yx
+tZ
+bL
+EL
+kh
+bL
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+fZ
+Cq
+qU
+Aw
+ml
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+nZ
+wM
+Sg
+wM
+Sg
+wM
+Sg
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(51,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+uA
+tE
+tE
+tE
+LI
+wV
+Pw
+vj
+LN
+LN
+Jd
+HA
+Jd
+LN
+LN
+Jd
+HA
+Jd
+LN
+LN
+wV
+tE
+tE
+tE
+tE
+Yr
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+TA
+Vz
+Vz
+Vz
+Vz
+Vv
+Vz
+Vz
+Vz
+Vz
+GS
+Lh
+Lh
+Lh
+Lh
+ln
+HM
+qG
+Yp
+WZ
+mi
+bf
+qG
+hC
+zC
+zC
+zC
+Nt
+bL
+XQ
+bL
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+hd
+qU
+qU
+qU
+it
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ln
+wM
+wM
+wM
+wM
+wM
+wM
+wM
+je
+HT
+wM
+wM
+wM
+wM
+wM
+wM
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(52,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+tE
+tE
+ih
+tE
+tE
+wV
+br
+LN
+xL
+LN
+Jd
+FZ
+Jd
+LN
+LN
+Jd
+FZ
+Jd
+LN
+NH
+wV
+iV
+tE
+tE
+tE
+Yr
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+ET
+zC
+zC
+zC
+KP
+Vz
+Vz
+zC
+zC
+zC
+Kb
+Lh
+Lh
+Lh
+Lh
+BO
+bL
+cZ
+WZ
+bk
+bf
+Iv
+aD
+ks
+zC
+tZ
+bf
+RD
+UZ
+XQ
+bL
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+mu
+Dh
+qU
+kF
+gz
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+Sg
+wM
+Sg
+wM
+Sg
+wM
+hi
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(53,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+nb
+tE
+tE
+tE
+Nh
+wV
+wa
+vj
+LN
+LN
+LN
+zs
+LN
+LN
+LN
+LN
+zs
+LN
+LN
+LN
+wV
+uk
+tE
+tE
+tE
+Yr
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+ET
+zC
+zC
+zC
+zC
+Vz
+zC
+zC
+zC
+ZE
+Kb
+Lh
+Lh
+Lh
+Lh
+qS
+ri
+qg
+qg
+bL
+bL
+Oo
+bk
+bf
+PC
+bf
+RD
+KV
+EL
+PC
+bk
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Lh
+ti
+mu
+Rq
+gz
+bm
+Lh
+Lh
+xu
+Lh
+Lh
+Lh
+Lh
+Yn
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+Sg
+wM
+hi
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(54,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+cX
+tE
+tE
+tE
+LI
+wV
+ze
+LN
+LN
+LN
+LN
+Fr
+Pn
+LN
+LN
+iG
+WD
+LN
+LN
+LN
+wV
+iV
+tE
+tE
+tE
+RM
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+dP
+zC
+HW
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+dU
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+uM
+NS
+qS
+ub
+uM
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+Lh
+Lh
+KM
+KM
+KM
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+NB
+NS
+qS
+ub
+NB
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(55,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+wV
+eV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+CX
+LN
+LN
+zs
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+eV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+dP
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+dU
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+cI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(56,1,1) = {"
+nC
+rQ
+wV
+vf
+kd
+tY
+wV
+Md
+qO
+qO
+qO
+qO
+iW
+wV
+WR
+CJ
+Vk
+Vk
+Vk
+Kn
+Vk
+Vk
+Kn
+Vk
+CJ
+yn
+wV
+YG
+bG
+Rj
+YG
+YG
+sz
+wV
+vf
+kd
+tY
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+dP
+Mh
+Mh
+Mh
+Mh
+Mh
+dU
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+zg
+Lh
+Lh
+Lh
+nV
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(57,1,1) = {"
+nC
+rQ
+wV
+rM
+Iw
+rM
+wV
+tX
+tE
+tE
+tE
+tE
+YL
+wV
+WR
+Vk
+Wl
+Vk
+Vk
+Kn
+Vk
+Vk
+Kn
+Vk
+Vk
+Vk
+wV
+YG
+YG
+YG
+YG
+YG
+UT
+wV
+rM
+Iw
+rM
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+Av
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Av
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+Ss
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Ss
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(58,1,1) = {"
+nC
+rQ
+wV
+Iw
+Iw
+dd
+wV
+nj
+tE
+tE
+tE
+sh
+qo
+wV
+Vk
+Vk
+Vk
+Vk
+hB
+OT
+Co
+nx
+OT
+Bu
+Vk
+Vk
+xd
+YG
+YG
+YG
+YG
+YG
+WY
+wV
+VH
+Iw
+Iw
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+bf
+hC
+bf
+bf
+xz
+hC
+hC
+hC
+hC
+hC
+bk
+bk
+bk
+hC
+Sj
+hC
+yq
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(59,1,1) = {"
+nC
+rQ
+wV
+wV
+eV
+wV
+wV
+Td
+iy
+rw
+tE
+tE
+dw
+wV
+Px
+wV
+wV
+Vk
+VK
+tE
+tE
+No
+Yj
+TR
+Vk
+Vk
+wV
+YG
+YG
+AW
+YG
+tr
+YG
+wV
+wV
+eV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+zC
+ML
+ZK
+qG
+bf
+bf
+yq
+hC
+hC
+hC
+bk
+hC
+jy
+hC
+bf
+hC
+hC
+hC
+hC
+wF
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+xY
+xY
+xY
+xY
+xY
+Hw
+Hw
+Sc
+xY
+xY
+xY
+Sc
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+wF
+nI
+Lh
+Lh
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(60,1,1) = {"
+nC
+rQ
+wV
+zE
+tE
+tE
+wV
+aC
+tE
+tE
+tE
+tE
+YL
+wV
+Vi
+Us
+wV
+Vk
+VK
+No
+tE
+Qy
+tE
+TR
+Vk
+Vk
+wV
+YG
+YG
+YG
+YG
+YG
+YG
+wV
+hx
+tE
+zE
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+fI
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+hC
+bf
+bf
+hC
+xf
+hC
+bf
+yq
+hC
+KV
+Dd
+WZ
+Ag
+Yp
+bf
+Pt
+bk
+hC
+xz
+hC
+hC
+qS
+Lh
+Lh
+Lh
+Zx
+Zx
+cN
+NZ
+cN
+Zx
+Zx
+Lh
+Lh
+Lh
+qS
+xY
+xY
+xY
+xY
+Sc
+RI
+Hw
+cE
+Hw
+Hw
+xY
+xY
+xY
+RI
+Sc
+RI
+RI
+RI
+xY
+xY
+xY
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(61,1,1) = {"
+nC
+rQ
+wV
+wV
+tE
+tE
+uc
+Rk
+tE
+tE
+tE
+tE
+YL
+wV
+vV
+Cx
+wV
+Vk
+Hl
+Nb
+Io
+Io
+VU
+Vn
+Vk
+Vk
+xd
+YG
+YG
+YM
+YG
+AW
+YG
+bT
+tE
+zv
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+sI
+Lh
+Lh
+Lh
+wl
+iZ
+jq
+jq
+jq
+Py
+wl
+Lh
+Lh
+Lh
+wl
+hC
+hC
+hC
+bf
+qG
+qG
+bf
+bf
+hC
+FX
+hC
+Iv
+WZ
+bf
+yq
+WZ
+WZ
+dF
+bf
+PC
+hC
+wl
+Lh
+Lh
+Lh
+wl
+pE
+jz
+jz
+jz
+ap
+wl
+Lh
+Lh
+Lh
+wl
+xY
+xY
+Sc
+RI
+Hw
+bp
+Hw
+YE
+YE
+yy
+FQ
+Hw
+xJ
+Hw
+xY
+xY
+Hw
+xY
+xY
+Sc
+xY
+wl
+Lh
+Lh
+Lh
+au
+EW
+rQ
+rQ
+rQ
+nC
+"}
+(62,1,1) = {"
+nC
+rQ
+wV
+wV
+wV
+tE
+wV
+Rk
+Si
+DF
+nA
+tE
+UE
+wV
+Vi
+PH
+wV
+Vk
+Vk
+Vk
+Vk
+Vk
+Vk
+Vk
+Vk
+oA
+wV
+Rj
+YG
+YG
+YG
+YG
+YG
+wV
+oR
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Mr
+gt
+Lh
+Lh
+Lh
+Lh
+Db
+yg
+jq
+jq
+jq
+by
+Db
+Lh
+Lh
+Lh
+Db
+hC
+AB
+Pt
+hN
+zC
+vb
+xf
+EL
+EL
+EL
+yW
+bf
+WZ
+WZ
+OR
+EL
+an
+bL
+bf
+hC
+hC
+Db
+Lh
+Lh
+Lh
+Db
+pE
+jz
+jz
+jz
+ap
+Db
+Lh
+Lh
+Lh
+Db
+xY
+RI
+RI
+Hw
+bp
+Hw
+Hw
+YE
+Ce
+Kg
+Hw
+YE
+Ce
+Hw
+Hw
+YE
+YE
+Hw
+xY
+RI
+xY
+Db
+Lh
+Lh
+Lh
+Lh
+LA
+EW
+rQ
+rQ
+nC
+"}
+(63,1,1) = {"
+nC
+rQ
+rQ
+wV
+wV
+wV
+wV
+Rk
+UY
+UM
+qD
+tE
+UE
+wV
+ke
+ky
+wV
+ga
+Vk
+Vk
+Vk
+Vk
+ga
+Vk
+QD
+GZ
+wV
+PB
+YG
+AW
+YG
+AW
+YG
+wV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+rW
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+Jh
+jq
+kZ
+jq
+Vw
+VY
+Lh
+Lh
+Lh
+VY
+hC
+hC
+qG
+TT
+zC
+zC
+qG
+qG
+XH
+bf
+zW
+hC
+aF
+EL
+EL
+XH
+WZ
+mi
+PC
+xB
+hC
+VY
+Lh
+Lh
+Lh
+VY
+pE
+jz
+jz
+jz
+ap
+VY
+Lh
+Lh
+Lh
+VY
+xY
+xY
+xY
+Hw
+Hw
+Hw
+NU
+xJ
+YE
+bp
+Hw
+YE
+pg
+Ce
+Hw
+Hw
+Hw
+bp
+Hw
+xY
+xY
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+rW
+qS
+rQ
+nC
+"}
+(64,1,1) = {"
+nC
+rQ
+rQ
+rQ
+wV
+wV
+wV
+Rk
+zk
+bg
+cx
+tE
+UE
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+Cy
+YG
+YG
+YG
+YG
+YG
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+Bk
+jq
+JH
+jq
+tx
+qS
+Lh
+Lh
+Lh
+qS
+hC
+Tt
+qG
+zC
+gh
+zC
+bf
+jn
+qG
+gI
+EL
+EL
+EL
+EL
+EL
+EL
+Bb
+fP
+qg
+jJ
+hC
+qS
+Lh
+Lh
+Lh
+NZ
+pE
+jz
+jz
+jz
+ap
+NZ
+Lh
+Lh
+Lh
+qS
+xY
+xY
+xY
+xY
+xY
+YE
+YE
+YE
+Ce
+Hw
+cE
+Hw
+Hw
+YE
+Hw
+Ce
+Hw
+xY
+xY
+RI
+xY
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(65,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+Rk
+tE
+tE
+tE
+tE
+pM
+wV
+Bq
+PZ
+PZ
+We
+OP
+YW
+Cj
+up
+We
+PZ
+PZ
+PZ
+wV
+YG
+YG
+YG
+wV
+Ao
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Br
+jq
+QN
+jq
+tR
+wl
+Lh
+Lh
+Lh
+wl
+Tt
+bf
+vb
+bf
+zC
+tZ
+bf
+XQ
+qG
+XQ
+FW
+TT
+gh
+rm
+WZ
+sw
+zC
+zj
+hC
+XH
+bf
+wl
+Lh
+Lh
+Lh
+wl
+jz
+jz
+qk
+jz
+jz
+wl
+Lh
+Lh
+Lh
+wl
+xY
+xY
+Hw
+cE
+xY
+xY
+Ce
+YE
+NU
+pg
+Hw
+YE
+Hw
+Hw
+YE
+Hw
+xY
+xY
+RI
+xY
+xY
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(66,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+Rk
+sh
+tE
+tE
+tE
+YL
+YS
+Hj
+Hj
+Hj
+Hj
+YO
+Hj
+Hj
+Hj
+lv
+Hj
+Hj
+Hj
+Fi
+YG
+YG
+YG
+wV
+TK
+WU
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+RO
+RO
+RO
+RO
+RO
+Db
+Lh
+Lh
+Lh
+Ov
+Tt
+hC
+dn
+EL
+Xq
+aF
+bL
+bL
+qG
+qG
+bf
+zC
+st
+QR
+WZ
+tA
+yC
+zC
+zC
+lH
+bf
+Ov
+Lh
+Lh
+Lh
+Db
+jz
+qk
+AR
+qk
+jz
+Db
+Lh
+Lh
+Lh
+FD
+xY
+xY
+Hw
+Hw
+xY
+xY
+Hw
+va
+YE
+YE
+Ce
+Hw
+YE
+pg
+YE
+Hw
+Hw
+xY
+Sc
+xY
+xY
+FD
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(67,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+Xg
+Sf
+Sf
+Sf
+fp
+wV
+Hj
+Hj
+Hj
+tE
+tE
+tE
+tE
+tE
+tE
+Hj
+Hj
+Hj
+wV
+Tc
+YG
+qu
+wV
+dA
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+im
+im
+im
+im
+im
+VY
+Lh
+Lh
+Lh
+VY
+Tt
+Tt
+bL
+bf
+aL
+bk
+ZP
+Jy
+EL
+dW
+ny
+zC
+zC
+bL
+bL
+zC
+hC
+Pt
+WZ
+PC
+bf
+VY
+Lh
+Lh
+Lh
+VY
+jz
+jz
+qk
+jz
+jz
+VY
+Lh
+Lh
+Lh
+VY
+xY
+xY
+cE
+va
+xY
+xY
+Hw
+Hw
+YE
+Hw
+Hw
+yy
+YE
+YE
+Hw
+xY
+xY
+xY
+xY
+xY
+Hw
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(68,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+Hj
+Hj
+tE
+wq
+tE
+tE
+wq
+tE
+FF
+Hj
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+im
+RN
+mb
+im
+im
+qS
+Lh
+Lh
+Lh
+qS
+bf
+bf
+XQ
+qG
+KV
+bL
+mG
+EL
+bf
+qG
+qG
+TT
+vb
+zC
+zC
+jR
+zW
+bf
+WZ
+zV
+bf
+qS
+Lh
+Lh
+Lh
+Zx
+qA
+qA
+qA
+qA
+jz
+Zx
+Lh
+Lh
+Lh
+qS
+xY
+xY
+Hw
+Hw
+xY
+xY
+cE
+Hw
+xY
+Hw
+va
+Hw
+NU
+Ce
+NU
+va
+xY
+xY
+xY
+Hw
+bp
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+LL
+qS
+rQ
+nC
+"}
+(69,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+oV
+wV
+wV
+Hj
+Hj
+tE
+hn
+tE
+tE
+hn
+tE
+Hj
+Hj
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+im
+im
+Ze
+im
+im
+BO
+Lh
+Lh
+Lh
+wl
+bf
+Tt
+bL
+zC
+zC
+yC
+TT
+zj
+zC
+rm
+EL
+qG
+bL
+XQ
+tA
+ZP
+bL
+EL
+Dw
+ks
+hC
+BO
+Lh
+Lh
+Lh
+Zx
+DX
+jz
+MS
+qA
+jz
+Zx
+Lh
+Lh
+Lh
+wl
+xY
+xY
+Hw
+Kg
+Hw
+Hw
+va
+xY
+xY
+Hw
+xY
+Hw
+Hw
+YE
+YE
+Hw
+Hw
+cE
+Kg
+Hw
+Hw
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(70,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+dQ
+IB
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+IB
+Lw
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+im
+im
+RN
+im
+im
+ek
+Lh
+Lh
+Lh
+Db
+hC
+YB
+Oa
+PC
+tA
+bL
+zC
+zC
+gh
+zC
+GQ
+qG
+EL
+zC
+vb
+hC
+dF
+EL
+zC
+zC
+hC
+ln
+Lh
+Lh
+Lh
+Zx
+Zx
+iv
+Zx
+Zx
+iv
+Zx
+Lh
+Lh
+Lh
+Db
+xY
+xY
+xY
+Hw
+xJ
+Hw
+NU
+xY
+xY
+Hw
+xY
+xY
+Cc
+Hw
+Ce
+NU
+Hw
+Hw
+Hw
+Hw
+Hw
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(71,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+wV
+eV
+wV
+wV
+wV
+wV
+eV
+wV
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+im
+im
+Ze
+im
+im
+BO
+Lh
+Lh
+Lh
+VY
+hC
+bf
+bL
+bk
+tZ
+PC
+zC
+tZ
+zC
+zC
+vb
+eT
+bL
+Qh
+WZ
+bL
+cZ
+bf
+zC
+Tt
+hC
+BO
+Lh
+Lh
+Lh
+Zx
+jB
+jz
+jB
+jz
+jz
+Zx
+Lh
+Lh
+Lh
+VY
+xY
+xY
+xY
+Hw
+Kg
+Hw
+Hw
+xY
+xY
+Hw
+xJ
+xY
+Hw
+YE
+Hw
+Hw
+xY
+RI
+Hw
+Hw
+Hw
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(72,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+wV
+fV
+Iw
+Iw
+wV
+wV
+Iw
+Iw
+Iw
+wV
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+im
+xA
+mb
+im
+im
+qS
+Lh
+Lh
+Lh
+qS
+hC
+bf
+dn
+zC
+kh
+PC
+vb
+BC
+Kq
+dn
+st
+zC
+st
+zC
+WZ
+dn
+bL
+ZP
+st
+Tt
+hC
+qS
+Lh
+Lh
+Lh
+Zx
+gE
+jz
+gE
+jz
+jz
+Zx
+Lh
+Lh
+Lh
+qS
+xY
+xY
+xY
+xY
+xY
+Hw
+Kg
+NU
+xY
+Hw
+FQ
+xY
+cE
+va
+Hw
+xY
+xY
+RI
+Hw
+Hw
+Kg
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(73,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+CA
+CA
+CA
+wV
+wV
+CA
+CA
+CA
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+im
+im
+im
+im
+im
+wl
+Lh
+Lh
+Lh
+wl
+hC
+bf
+Tt
+ks
+zC
+OK
+zC
+zC
+ad
+zC
+zC
+zC
+an
+zC
+zC
+dn
+ZP
+bL
+bL
+Tt
+hC
+wl
+Lh
+Lh
+Lh
+Zx
+cq
+jz
+cq
+jz
+jz
+Zx
+Lh
+Lh
+Lh
+wl
+xY
+xY
+xY
+xY
+xY
+xY
+Hw
+Hw
+xY
+xY
+Hw
+xY
+Hw
+Cc
+Kg
+xY
+xY
+Hw
+Hw
+xY
+Hw
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(74,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+wV
+uv
+uv
+uv
+wV
+wV
+uv
+uv
+uv
+wV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+Zt
+Zt
+Zt
+Zt
+Zt
+Db
+Lh
+Lh
+Lh
+Ov
+hC
+Iv
+hC
+hC
+zC
+zC
+vb
+zC
+zC
+zC
+fP
+fP
+WZ
+zC
+TT
+XQ
+bL
+xz
+bL
+Tt
+Iv
+Ov
+Lh
+Lh
+Lh
+Zx
+fF
+jz
+fF
+jz
+jz
+Zx
+Lh
+Lh
+Lh
+FD
+xY
+xY
+Hw
+Hw
+xY
+Hw
+yy
+Hw
+xY
+xY
+Hw
+xY
+Hw
+Hw
+xY
+xY
+bp
+Hw
+xY
+xY
+xY
+FD
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(75,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+sb
+jq
+JD
+jq
+nr
+VY
+Lh
+Lh
+Lh
+VY
+hC
+RD
+bf
+bf
+zC
+zC
+qG
+bf
+zC
+YB
+bf
+qG
+bf
+tA
+zC
+zC
+bL
+BL
+XQ
+Oa
+bf
+VY
+Lh
+Lh
+Lh
+Zx
+jz
+jz
+jz
+jz
+jz
+Zx
+Lh
+Lh
+Lh
+VY
+xY
+xY
+Hw
+Hw
+Hw
+Hw
+Hw
+Cc
+Hw
+xY
+xY
+xY
+xY
+xJ
+Hw
+xY
+Hw
+RI
+xY
+xY
+xY
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(76,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+Gz
+jq
+CR
+jq
+By
+qS
+Lh
+Lh
+Lh
+qS
+Tt
+hC
+jJ
+RD
+EL
+EL
+SI
+Pt
+mv
+Tt
+bf
+qG
+XH
+ks
+zC
+zC
+bL
+EL
+kh
+bL
+hC
+qS
+Lh
+Lh
+Lh
+Zx
+IQ
+IQ
+IQ
+IQ
+IQ
+Zx
+Lh
+Lh
+Lh
+qS
+xY
+xY
+Hw
+xY
+Hw
+Cc
+cE
+Kg
+Hw
+Sc
+xY
+xY
+Sc
+Sc
+xY
+xY
+Hw
+xY
+Hw
+Hw
+xY
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(77,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Uz
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Go
+jq
+tK
+jq
+GF
+wl
+Lh
+Lh
+Lh
+wl
+Tt
+Tt
+hm
+hC
+Tt
+Bs
+qG
+Yp
+WZ
+mi
+bf
+qG
+hC
+zC
+zC
+vb
+Nt
+Oa
+XQ
+bL
+jD
+wl
+Lh
+Lh
+Lh
+Zx
+fL
+jz
+jz
+jz
+fL
+Zx
+Lh
+Lh
+Lh
+wl
+RI
+RI
+xY
+xY
+Hw
+NU
+yy
+NU
+Hw
+xY
+xY
+Sc
+xY
+xY
+xY
+Hw
+bp
+Hw
+Hw
+Sc
+xY
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Uz
+qS
+rQ
+nC
+"}
+(78,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+Mo
+Lh
+Lh
+Lh
+Lh
+Db
+Vw
+jq
+jq
+jq
+rA
+Db
+Lh
+Lh
+Lh
+Db
+hC
+Tt
+HM
+ZP
+bL
+bL
+cZ
+WZ
+bk
+bf
+Iv
+qG
+ks
+zC
+zC
+bf
+RD
+UZ
+XQ
+bL
+bL
+Db
+Lh
+Lh
+Lh
+Zx
+CM
+jz
+jz
+jz
+CM
+Zx
+Lh
+Lh
+Lh
+Db
+xY
+RI
+xY
+Hw
+Hw
+Hw
+Hw
+Hw
+Kg
+Hw
+xY
+xY
+xY
+xY
+Hw
+Hw
+Hw
+cE
+RI
+xY
+xY
+Db
+Lh
+Lh
+Lh
+Lh
+yZ
+fu
+rQ
+rQ
+nC
+"}
+(79,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+ON
+Lh
+Lh
+Lh
+VY
+SG
+jq
+jq
+jq
+Un
+VY
+Lh
+Lh
+Lh
+VY
+hC
+Tt
+hC
+hC
+hC
+hC
+qg
+qg
+bL
+bL
+Qh
+bk
+bf
+PC
+mv
+RD
+KV
+EL
+PC
+bk
+bL
+VY
+Lh
+Lh
+Lh
+Zx
+gU
+jz
+jz
+jz
+gU
+Zx
+Lh
+Lh
+Lh
+VY
+xY
+xY
+Sc
+Hw
+Hw
+NU
+Hw
+Cc
+Hw
+Hw
+Hw
+xY
+Sc
+xY
+Hw
+cE
+Hw
+Hw
+xY
+xY
+xY
+VY
+Lh
+Lh
+Lh
+HO
+fu
+rQ
+rQ
+rQ
+nC
+"}
+(80,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+fI
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+hC
+Tt
+Tt
+Tt
+aO
+Tt
+hC
+hC
+bk
+Df
+gI
+bL
+dn
+jJ
+JS
+bk
+qg
+Wv
+hC
+hC
+bL
+qS
+Lh
+Lh
+Lh
+Zx
+Zx
+Zx
+iv
+Zx
+Zx
+Zx
+Lh
+Lh
+Lh
+qS
+xY
+xY
+Hw
+Hw
+RI
+RI
+Hw
+Hw
+Hw
+xY
+Sc
+xY
+xY
+xY
+bp
+Hw
+Sc
+RI
+xY
+xY
+xY
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(81,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+hC
+hC
+hC
+hC
+hC
+Tt
+Tt
+hC
+hC
+bk
+bk
+hC
+hC
+hC
+bk
+EL
+EL
+hC
+bL
+DW
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+xY
+xY
+xY
+xY
+Sc
+xY
+xY
+Hw
+xY
+xY
+xY
+xY
+Hw
+Hw
+Hw
+xY
+xY
+xY
+xY
+DW
+nI
+Lh
+Lh
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(82,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+hC
+hC
+hC
+hC
+hC
+hm
+hC
+hC
+hC
+bk
+bk
+bk
+bk
+bk
+hC
+hC
+hC
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+xY
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(83,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+Av
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Av
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+Ss
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+Ss
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(84,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+fW
+mf
+El
+Vh
+uT
+mf
+mf
+mf
+mf
+mf
+mf
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Gs
+zg
+Lh
+Lh
+Lh
+nV
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+zg
+Lh
+Lh
+Lh
+nV
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(85,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+mf
+oE
+mf
+mf
+mf
+mf
+mf
+lZ
+yY
+Gg
+yY
+yY
+Yv
+hK
+JY
+QQ
+fT
+rQ
+rQ
+Zq
+Lh
+Lh
+Gs
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(86,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+WE
+yY
+mf
+oS
+tN
+YP
+mf
+Oh
+yY
+CS
+yY
+yY
+Yl
+yY
+Ar
+QQ
+zO
+rQ
+rQ
+qS
+Lh
+eh
+cI
+Lh
+Lh
+cb
+cb
+cb
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+Hx
+NS
+qS
+ub
+Hx
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+cb
+cb
+cb
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+ao
+NS
+qS
+ub
+ao
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(87,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+hI
+yY
+oE
+yY
+yY
+yY
+mf
+ZA
+yY
+yY
+yY
+yY
+Ji
+ZV
+Lr
+QQ
+SR
+rQ
+rQ
+db
+Lh
+Rr
+Lh
+Lh
+Il
+Sd
+tU
+TW
+eG
+Lh
+Lh
+Rr
+Lh
+Lh
+Lh
+Lh
+qS
+gI
+bf
+zC
+st
+qG
+bf
+zC
+YB
+bf
+qG
+bf
+tA
+zC
+st
+bL
+qS
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+Lh
+Il
+fZ
+AH
+ml
+eG
+Lh
+Lh
+Rr
+Lh
+Lh
+Lh
+Lh
+qS
+CH
+JN
+JN
+CH
+JN
+iq
+Kx
+JN
+dZ
+eH
+JN
+eW
+JN
+JN
+aA
+qS
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(88,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+fW
+mf
+mf
+mf
+mf
+rQ
+rQ
+fW
+mf
+yY
+yY
+Yl
+yY
+yY
+yY
+mf
+sB
+yY
+yY
+yY
+yY
+zH
+mf
+mf
+mf
+mf
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+kJ
+Sd
+ix
+ix
+hy
+TW
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+Iv
+RD
+EL
+EL
+KV
+Pt
+RD
+Tt
+bf
+qG
+RD
+ks
+zC
+zC
+bL
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+fZ
+Cq
+qU
+Aw
+ml
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+JN
+JN
+JN
+JN
+JN
+eW
+JN
+CH
+JN
+JN
+CH
+JN
+JN
+iq
+JN
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(89,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+mf
+aU
+HX
+OV
+mf
+mf
+mf
+mf
+mf
+mf
+mf
+mf
+oU
+yY
+yY
+mf
+Ub
+yY
+yY
+yY
+Xr
+LY
+mf
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+kJ
+EH
+ix
+UN
+ix
+wO
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ln
+bL
+hC
+Tt
+pk
+Oo
+Yp
+WZ
+mi
+Iv
+Ge
+hC
+zC
+zC
+st
+tZ
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+hd
+qU
+qU
+qU
+it
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ln
+JN
+dZ
+CH
+JN
+JN
+JN
+eW
+ft
+JN
+JN
+Bo
+JN
+MM
+JN
+JN
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(90,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Pr
+ox
+yY
+yY
+yY
+IP
+pU
+Qa
+NC
+yY
+Ei
+mf
+mf
+mf
+Wk
+ZI
+mf
+mf
+mf
+Wk
+ZI
+mf
+mf
+mf
+mf
+mf
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+kJ
+Ka
+ix
+ix
+ix
+lQ
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+bL
+dF
+bL
+bL
+cZ
+WZ
+Re
+bf
+Iv
+qG
+ks
+zC
+zC
+bf
+RD
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+mu
+Dh
+qU
+kF
+gz
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+JN
+JN
+JN
+JN
+ZL
+JN
+Bo
+JN
+Kx
+JN
+JN
+ZL
+JN
+iq
+JN
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(91,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Yx
+Gp
+yY
+yY
+yY
+mf
+vs
+RY
+vs
+vs
+yY
+lw
+qE
+yY
+yY
+yY
+yY
+qE
+yY
+yY
+yY
+Ew
+sd
+vP
+QQ
+fT
+rQ
+rQ
+rQ
+Zq
+Lh
+xu
+Lh
+Lh
+ti
+ae
+DT
+lQ
+bm
+Lh
+Lh
+xu
+Lh
+Lh
+Lh
+Lh
+qS
+KV
+hC
+hC
+hC
+qg
+qg
+bL
+bL
+Oo
+bk
+bf
+PC
+RD
+RD
+KV
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Lh
+ti
+mu
+Rq
+gz
+bm
+Lh
+Lh
+xu
+Lh
+Lh
+Lh
+Lh
+qS
+eH
+JN
+JN
+Bo
+JN
+DQ
+JN
+JN
+JN
+JN
+JN
+JN
+DQ
+Bo
+eW
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(92,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Yx
+Gp
+bn
+yY
+pa
+mf
+dz
+Pa
+Pa
+Pa
+yY
+mn
+yY
+eB
+yY
+HJ
+yY
+yY
+yY
+yY
+yY
+Yl
+yY
+yY
+QQ
+zO
+rQ
+rQ
+rQ
+qS
+Lh
+oN
+so
+Lh
+Lh
+KM
+KM
+KM
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+Hx
+NS
+qS
+ub
+Hx
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+Lh
+Lh
+KM
+KM
+KM
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+ao
+NS
+qS
+ub
+ao
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(93,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Yx
+Gp
+yY
+yY
+yY
+mf
+VA
+yY
+yY
+yY
+zf
+mf
+GI
+yY
+yY
+yY
+yY
+Xr
+yY
+yY
+yY
+Ew
+hH
+Za
+QQ
+SR
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+oN
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+cI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+cI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(94,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Tm
+aU
+yY
+Pa
+yY
+mf
+UW
+lU
+yU
+dt
+mf
+mf
+mf
+mf
+Op
+HZ
+mf
+mf
+mf
+Op
+HZ
+mf
+mf
+mf
+mf
+mf
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+xv
+zg
+Lh
+Lh
+Lh
+nV
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+zg
+Lh
+Lh
+Lh
+nV
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(95,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+mf
+uz
+VX
+fY
+mf
+mf
+mf
+mf
+mf
+mf
+mf
+mf
+yY
+yY
+yY
+mf
+QK
+yY
+yY
+yY
+oJ
+in
+mf
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+WG
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+WG
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+gk
+qS
+ub
+sR
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+sR
+NS
+qS
+gk
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(96,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+fW
+mf
+mf
+mf
+mf
+rQ
+rQ
+fW
+mf
+yY
+yY
+Dq
+yY
+yY
+yY
+mf
+IX
+yY
+yY
+yY
+UW
+mf
+mf
+mf
+mf
+mf
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+JN
+JN
+JN
+JN
+aA
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+Kx
+JN
+CH
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ce
+yd
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+wF
+nw
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(97,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+KT
+yY
+gZ
+yY
+yY
+yY
+mf
+aU
+yY
+yY
+yY
+yY
+mf
+hK
+yY
+QQ
+fT
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+JN
+Bo
+dj
+JN
+JN
+JN
+CH
+JN
+JN
+JN
+JN
+JN
+eH
+JN
+JN
+JN
+JN
+JN
+JN
+wF
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ID
+yd
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+hk
+gS
+pB
+pB
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+wF
+nI
+Lh
+Lh
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(98,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+yY
+yY
+Dq
+bC
+Uj
+aU
+mf
+aU
+yY
+BS
+yY
+yY
+am
+yY
+yY
+QQ
+zO
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+NF
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+JN
+JN
+CH
+JN
+JN
+CH
+JN
+iq
+Kx
+JN
+JN
+eH
+JN
+eW
+JN
+JN
+aA
+JN
+JN
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+ln
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+MO
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+MO
+gS
+gS
+gS
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(99,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+mf
+gZ
+gZ
+mf
+mf
+mf
+mf
+mf
+FE
+aU
+aU
+aU
+yY
+mf
+ql
+yY
+QQ
+SR
+rQ
+Mr
+sI
+Lh
+Lh
+Lh
+wl
+CH
+JN
+Vz
+JN
+Ow
+wl
+Lh
+Lh
+Lh
+wl
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+eW
+JN
+CH
+JN
+JN
+CH
+JN
+JN
+iq
+JN
+JN
+JN
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+au
+EW
+rQ
+rQ
+rQ
+nC
+"}
+(100,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+tP
+tP
+qS
+rQ
+rQ
+rQ
+fW
+mf
+da
+uY
+pR
+mf
+mf
+mf
+mf
+mf
+mf
+Mr
+gt
+Lh
+Lh
+Lh
+Lh
+Db
+JN
+MM
+Vz
+AL
+bN
+Db
+Lh
+Lh
+Lh
+Db
+JN
+DQ
+eW
+aA
+JN
+JN
+CH
+JN
+JN
+JN
+eW
+JN
+JN
+JN
+Bo
+JN
+MM
+JN
+JN
+JN
+JN
+Db
+Lh
+Lh
+Lh
+Db
+gS
+MO
+gS
+gS
+hk
+Db
+Lh
+Lh
+Lh
+Db
+gS
+MO
+gS
+Ya
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+gS
+Db
+Lh
+Lh
+Lh
+Lh
+LA
+EW
+rQ
+rQ
+nC
+"}
+(101,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+iQ
+rz
+rz
+iQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+rW
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+aA
+Zh
+Vz
+dj
+JN
+VY
+Lh
+Lh
+Lh
+VY
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+Bo
+JN
+Kx
+JN
+JN
+JN
+JN
+iq
+JN
+eH
+JN
+VY
+Lh
+Lh
+Lh
+VY
+gS
+hk
+gS
+Ya
+gS
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+gS
+gS
+gS
+pB
+gS
+gS
+gS
+pB
+gS
+MO
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+pB
+gS
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+rW
+qS
+rQ
+nC
+"}
+(102,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+tP
+tP
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+JN
+Ow
+Vz
+CH
+dj
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+JN
+JN
+eH
+JN
+JN
+Bo
+JN
+DQ
+JN
+JN
+JN
+JN
+JN
+JN
+DQ
+Bo
+eW
+Kx
+JN
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+vU
+hk
+gS
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+gS
+gS
+MO
+hk
+gS
+gS
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+PN
+gS
+gS
+gS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(103,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+YX
+sM
+sM
+Lh
+Lh
+Lh
+Lh
+sM
+sM
+YX
+db
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+JN
+eH
+Vz
+JN
+eS
+wl
+Lh
+Lh
+Lh
+wl
+JN
+JN
+JN
+JN
+JN
+iq
+JN
+eW
+JN
+eW
+aA
+JN
+eH
+JN
+JN
+iq
+JN
+MM
+JN
+JN
+JN
+wl
+Lh
+Lh
+Lh
+wl
+gS
+jg
+gS
+gS
+MO
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(104,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+FV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+dj
+hM
+Vz
+Ow
+AL
+Db
+Lh
+Lh
+Lh
+GO
+JN
+JN
+CH
+JN
+JN
+Kx
+JN
+JN
+JN
+JN
+JN
+JN
+CH
+MM
+JN
+Bo
+dj
+JN
+JN
+JN
+JN
+GO
+Lh
+Lh
+Lh
+Cz
+gS
+gS
+gS
+gS
+gS
+Cz
+Lh
+Lh
+Lh
+Bn
+gS
+gS
+Ya
+MO
+gS
+gS
+gS
+gS
+gS
+MO
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Bn
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(105,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+Zq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+JN
+JN
+Vz
+aA
+dj
+VY
+Lh
+Lh
+Lh
+VY
+JN
+JN
+JN
+JN
+CH
+JN
+JN
+JN
+Ps
+ip
+sQ
+ip
+Pd
+JN
+JN
+JN
+JN
+eW
+JN
+JN
+JN
+VY
+Lh
+Lh
+Lh
+VY
+gS
+MO
+gS
+gS
+gS
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+hk
+gS
+gS
+gS
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(106,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+qS
+LS
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+DM
+iE
+Vz
+mr
+Kx
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+eW
+JN
+iq
+JN
+JN
+Ps
+FO
+Vz
+eR
+Vz
+ns
+Pd
+JN
+JN
+Bo
+JN
+JN
+JN
+JN
+qS
+Lh
+Lh
+Lh
+qS
+gS
+Ya
+vU
+gS
+gS
+qS
+Lh
+Lh
+Lh
+qS
+gS
+PN
+gS
+gS
+gS
+hk
+gS
+gS
+jg
+gS
+gS
+pB
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+LL
+qS
+rQ
+nC
+"}
+(107,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nT
+rz
+nT
+Lh
+Lh
+Lh
+tz
+tz
+tz
+tz
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+JN
+vM
+Vz
+dj
+Ow
+wl
+Lh
+Lh
+Lh
+wl
+JN
+JN
+JN
+JN
+JN
+dj
+JN
+Qp
+Vz
+eR
+eR
+eR
+Vz
+Gr
+WO
+ip
+ip
+ip
+ip
+RJ
+ip
+BO
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(108,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+ws
+ps
+ps
+gb
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+bN
+JN
+Vz
+eH
+CH
+Db
+Lh
+Lh
+Lh
+Db
+JN
+CH
+JN
+JN
+Bo
+JN
+JN
+ZN
+eR
+eR
+eR
+eR
+Vz
+Vz
+Vz
+Vz
+Vz
+Vz
+Vz
+Vz
+Vz
+ln
+Lh
+Lh
+Lh
+Db
+gS
+gS
+gS
+gS
+gS
+Db
+Lh
+Lh
+Lh
+Db
+gS
+gS
+pB
+gS
+jg
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+MO
+gS
+gS
+gS
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(109,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nT
+rz
+nT
+Lh
+Lh
+Lh
+sM
+sM
+sM
+sM
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+JN
+dj
+Vz
+JN
+Ow
+VY
+Lh
+Lh
+Lh
+VY
+JN
+JN
+JN
+JN
+iq
+JN
+JN
+Ni
+Vz
+eR
+eR
+eR
+Vz
+km
+sV
+sV
+ZU
+sV
+sV
+sV
+sV
+BO
+Lh
+Lh
+Lh
+VY
+gS
+gS
+vU
+jg
+gS
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+PN
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(110,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+iQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+CH
+WM
+Vz
+XB
+dj
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+CH
+JN
+eH
+JN
+JN
+Ta
+yp
+Vz
+eR
+Vz
+kr
+Fy
+JN
+CH
+JN
+JN
+CH
+JN
+JN
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+MO
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+hk
+gS
+pB
+gS
+gS
+gS
+gS
+gS
+gS
+MO
+gS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(111,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+db
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Ow
+aA
+Vz
+Ow
+JI
+wl
+Lh
+Lh
+Lh
+wl
+JN
+JN
+JN
+eW
+JN
+aA
+JN
+JN
+Ta
+sV
+sV
+sV
+fo
+JN
+JN
+CH
+JN
+JN
+JN
+JN
+JN
+wl
+Lh
+Lh
+Lh
+wl
+gS
+hk
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+rQ
+nC
+"}
+(112,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+uw
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Ql
+FV
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Db
+JN
+dj
+Vz
+dj
+eH
+Db
+Lh
+Lh
+Lh
+GO
+JN
+CH
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+Bo
+Bo
+JN
+JN
+JN
+eW
+JN
+aA
+JN
+JN
+CH
+GO
+Lh
+Lh
+Lh
+Cz
+gS
+gS
+MO
+gS
+Ya
+Cz
+Lh
+Lh
+Lh
+Bn
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+Bn
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+db
+rQ
+nC
+"}
+(113,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+YX
+tz
+tz
+Lh
+Lh
+Lh
+Lh
+tz
+tz
+YX
+Zq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+VY
+JN
+CH
+Vz
+JN
+JN
+VY
+Lh
+Lh
+Lh
+VY
+JN
+iq
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+CH
+JN
+JN
+JN
+Bo
+JN
+JN
+JN
+MM
+eW
+JN
+JN
+VY
+Lh
+Lh
+Lh
+VY
+gS
+jg
+gS
+vU
+gS
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+PN
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+VY
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+nC
+"}
+(114,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+nT
+nT
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+qS
+hU
+JN
+Vz
+Ow
+iE
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+Kx
+iq
+JN
+JN
+JN
+eW
+JN
+JN
+JN
+JN
+JN
+eW
+JN
+JN
+JN
+JN
+eH
+JN
+JN
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+MO
+gS
+MO
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+pB
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Zq
+rQ
+nC
+"}
+(115,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+iQ
+rz
+rz
+iQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Uz
+Lh
+Lh
+Lh
+Lh
+Lh
+wl
+Kx
+AL
+Vz
+JN
+AL
+wl
+Lh
+Lh
+Lh
+wl
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+eH
+JN
+iq
+JN
+JN
+JN
+JN
+JN
+JN
+DQ
+JN
+eW
+JN
+DQ
+wl
+Lh
+Lh
+Lh
+wl
+gS
+Ya
+hk
+gS
+gS
+wl
+Lh
+Lh
+Lh
+wl
+gS
+gS
+gS
+gS
+gS
+Ya
+gS
+gS
+gS
+MO
+gS
+gS
+gS
+Ya
+pB
+gS
+gS
+gS
+gS
+gS
+gS
+wl
+Lh
+Lh
+Lh
+Lh
+Lh
+Uz
+qS
+rQ
+nC
+"}
+(116,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+nT
+nT
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+Mo
+Lh
+Lh
+Lh
+Lh
+Db
+JN
+Ow
+Vz
+Bo
+CH
+Db
+Lh
+Lh
+Lh
+Db
+JN
+JN
+eW
+JN
+JN
+JN
+MM
+JN
+JN
+JN
+CH
+JN
+eW
+JN
+JN
+JN
+iq
+dj
+eW
+JN
+JN
+Db
+Lh
+Lh
+Lh
+Db
+gS
+MO
+gS
+gS
+gS
+Db
+Lh
+Lh
+Lh
+Db
+gS
+gS
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+pB
+pB
+gS
+gS
+gS
+PN
+gS
+gS
+gS
+MO
+gS
+Db
+Lh
+Lh
+Lh
+Lh
+yZ
+fu
+rQ
+rQ
+nC
+"}
+(117,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+ON
+Lh
+Lh
+Lh
+VY
+AL
+JN
+Vz
+Kx
+JN
+VY
+Lh
+Lh
+Lh
+VY
+JN
+JN
+JN
+JN
+JN
+JN
+eW
+eW
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+iq
+iq
+JN
+JN
+JN
+JN
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+gS
+gS
+hk
+VY
+Lh
+Lh
+Lh
+VY
+gS
+gS
+MO
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+VY
+Lh
+Lh
+Lh
+HO
+fu
+rQ
+rQ
+rQ
+nC
+"}
+(118,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+NF
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+dj
+DQ
+JN
+CH
+Kx
+MM
+JN
+eW
+CH
+JN
+JN
+JN
+qS
+Lh
+Lh
+Lh
+qS
+qS
+BO
+ln
+BO
+qS
+qS
+Lh
+Lh
+Lh
+qS
+gS
+gS
+gS
+gS
+PN
+gS
+gS
+gS
+gS
+jg
+gS
+gS
+gS
+gS
+gS
+MO
+gS
+jg
+gS
+gS
+gS
+qS
+Lh
+Lh
+Lh
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(119,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+DW
+nI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Fe
+nw
+gS
+gS
+gS
+gS
+gS
+MO
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+pB
+gS
+DW
+nI
+Lh
+Lh
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(120,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+JN
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+wF
+nw
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+ce
+yd
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(121,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+WG
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+WG
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ey
+qS
+ub
+sR
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+kc
+NS
+qS
+ub
+sR
+NS
+qS
+ey
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(122,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+qS
+qS
+qS
+qS
+qS
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+zg
+Lh
+Lh
+Lh
+nV
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(123,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+Lh
+qS
+qS
+HG
+HG
+HG
+qS
+ac
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(124,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+qS
+qS
+qS
+jz
+jz
+jz
+qS
+aw
+qS
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+ok
+NS
+qS
+ub
+ok
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+cb
+cb
+cb
+Lh
+Lh
+xv
+yc
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+TJ
+NS
+qS
+ub
+TJ
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+eh
+cI
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(125,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+qS
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+qS
+Lh
+Lh
+Lh
+Lh
+qS
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+Yn
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+Lh
+Il
+fZ
+AH
+ml
+eG
+Lh
+Lh
+Rr
+Lh
+Lh
+Lh
+Lh
+qS
+gS
+BK
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Cm
+gS
+gS
+yK
+qS
+Lh
+Lh
+Lh
+Lh
+Rr
+Lh
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(126,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+aj
+jz
+qS
+hF
+hF
+hF
+hF
+lR
+qS
+jz
+aj
+Lh
+Lh
+Lh
+Lh
+BO
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+fZ
+Cq
+qU
+Aw
+ml
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+Ai
+gS
+Nc
+gS
+Pq
+Wh
+Wh
+Wh
+Wh
+Wh
+Kw
+gS
+gS
+jg
+gS
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(127,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+qS
+qS
+qS
+LJ
+LJ
+LJ
+LJ
+qS
+qS
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+ln
+dq
+dq
+dq
+Fd
+dq
+dq
+dq
+Fd
+dq
+dq
+dq
+Fd
+dq
+dq
+dq
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+hd
+qU
+qU
+qU
+it
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+ln
+gS
+MO
+gS
+BK
+ph
+xY
+xY
+Rb
+xY
+xY
+IW
+gS
+yK
+gS
+gS
+ln
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(128,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Ii
+jz
+qS
+Wn
+Wn
+Wn
+Wn
+NY
+qS
+jz
+Ii
+Lh
+Lh
+Lh
+Lh
+BO
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kJ
+mu
+Dh
+qU
+kF
+gz
+rO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+BO
+gS
+jg
+gS
+mE
+LG
+bz
+bz
+bz
+bz
+bz
+Fh
+Cm
+gS
+gS
+Cm
+BO
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(129,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+Lh
+qS
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+jz
+qS
+Lh
+Lh
+Lh
+Lh
+Yn
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Lh
+ti
+mu
+Rq
+gz
+bm
+Lh
+Lh
+xu
+Lh
+Lh
+Lh
+Lh
+qS
+gS
+MO
+BK
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+Ai
+gS
+gS
+qS
+Lh
+Lh
+Lh
+Lh
+xu
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(130,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+Lh
+qS
+qS
+qS
+aw
+qS
+aw
+qS
+aw
+qS
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+ok
+NS
+qS
+ub
+ok
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+Lh
+Lh
+KM
+KM
+KM
+Lh
+Lh
+eh
+cI
+Lh
+Lh
+Lh
+Lh
+qS
+ub
+kc
+NS
+qS
+ub
+TJ
+NS
+qS
+ub
+TJ
+NS
+qS
+ub
+kc
+NS
+qS
+Lh
+Lh
+Lh
+Lh
+oN
+so
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(131,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+db
+Lh
+Lh
+qS
+qS
+Wr
+qS
+nY
+qS
+Wr
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+yc
+Lh
+Lh
+Lh
+Lh
+Lh
+Gs
+cI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+oN
+db
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(132,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+qS
+qS
+qS
+qS
+qS
+qS
+qS
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+xv
+zg
+Lh
+Lh
+Lh
+nV
+Id
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(133,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FN
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+Uz
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+FN
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+ws
+ps
+gb
+qS
+Uz
+Lh
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(134,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+FV
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+RH
+Iq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+Mo
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+RH
+Iq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+Mo
+Lh
+Lh
+Lh
+Lh
+FV
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(135,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+Zq
+kC
+mT
+Dm
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+kC
+mT
+Dm
+rj
+Iq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+sI
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+Lh
+rj
+Iq
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+LA
+sI
+Lh
+Lh
+Lh
+Zq
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(136,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+qS
+ws
+ps
+gb
+qS
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(137,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(138,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(139,1,1) = {"
+nC
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+nC
+"}
+(140,1,1) = {"
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+"}

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -197,13 +197,13 @@
 		)
 
 	lateload_gateway = list(
-		list("Carp Farm"),
-		list("Snow Field"),
-		list("Listening Post"),
-		list(list("Honleth Highlands A", "Honleth Highlands B")),
-		list("Arynthi Lake Underground A","Arynthi Lake A"),
-		list("Arynthi Lake Underground B","Arynthi Lake B"),
-		list("Wild West")
+		list("Gateway - Carp Farm"),
+		list("Gateway - Snow Field"),
+		list("Gateway - Listening Post"),
+		list(list("Gateway - Honleth Highlands A", "Gateway - Honleth Highlands B")),
+		list("Gateway - Arynthi Lake Underground A","Gateway - Arynthi Lake A"),
+		list("Gateway - Arynthi Lake Underground B","Gateway - Arynthi Lake B"),
+		list("Gateway - Wild West")
 		)
 
 	lateload_overmap = list(
@@ -211,13 +211,13 @@
 		)
 
 	lateload_redgate = list(
-		list("Teppi Ranch"),
-		list("Innland"),
-		list("Abandoned Island"),
-		list("Dark Adventure"),
-		list("Eggnog Town Underground","Eggnog Town"),
-		list("Star Dog"),
-		list("Hotsprings")
+		list("Redgate - Teppi Ranch"),
+		list("Redgate - Innland"),
+//		list("Redgate - Abandoned Island"),	//This will come back later
+		list("Redgate - Dark Adventure"),
+		list("Redgate - Eggnog Town Underground","Redgate - Eggnog Town"),
+		list("Redgate - Star Dog"),
+		list("Redgate - Hotsprings")
 		)
 
 	lateload_gb_north = list(

--- a/maps/offmap_vr/common_offmaps.dm
+++ b/maps/offmap_vr/common_offmaps.dm
@@ -135,64 +135,64 @@
 */
 #include "../gateway_vr/zoo.dm"
 /datum/map_template/common_lateload/gateway/zoo
-	name = "Zoo"
+	name = "Gateway - Zoo"
 	desc = "Gigantic space zoo"
-	mappath = 'maps/gateway_vr/zoo.dmm'
+	mappath = 'maps/gateway_vr/zoo_b.dmm'
 
 #include "../gateway_vr/carpfarm.dm"
 /datum/map_template/common_lateload/gateway/carpfarm
-	name = "Carp Farm"
+	name = "Gateway - Carp Farm"
 	desc = "Asteroid base surrounded by carp"
 	mappath = 'maps/gateway_vr/carpfarm.dmm'
 
 #include "../gateway_vr/snowfield.dm"
 /datum/map_template/common_lateload/gateway/snowfield
-	name = "Snow Field"
+	name = "Gateway - Snow Field"
 	desc = "An old base in middle of snowy wasteland"
 	mappath = 'maps/gateway_vr/snowfield.dmm'
 
 #include "../gateway_vr/listeningpost.dm"
 /datum/map_template/common_lateload/gateway/listeningpost
-	name = "Listening Post"
+	name = "Gateway - Listening Post"
 	desc = "Asteroid-bound mercenary listening post"
 	mappath = 'maps/gateway_vr/listeningpost.dmm'
 
 #include "../gateway_vr/variable/honlethhighlands.dm"
 /datum/map_template/common_lateload/gateway/honlethhighlands_a
-	name = "Honleth Highlands A"
+	name = "Gateway - Honleth Highlands A"
 	desc = "The cold surface of some planet."
 	mappath = 'maps/gateway_vr/variable/honlethhighlands_a.dmm'
 
 /datum/map_template/common_lateload/gateway/honlethhighlands_b
-	name = "Honleth Highlands B"
+	name = "Gateway - Honleth Highlands B"
 	desc = "The cold surface of some planet."
 	mappath = 'maps/gateway_vr/variable/honlethhighlands_b.dmm'
 
 
 #include "../gateway_vr/variable/arynthilake.dm"
 /datum/map_template/common_lateload/gateway/arynthilake
-	name = "Arynthi Lake A"
+	name = "Gateway - Arynthi Lake A"
 	desc = "A grassy surface with some abandoned structures."
 	mappath = 'maps/gateway_vr/variable/arynthilake_a.dmm'
 
 /datum/map_template/common_lateload/gateway/arynthilakeunderground
-	name = "Arynthi Lake Underground A"
+	name = "Gateway - Arynthi Lake Underground A"
 	desc = "A grassy surface with some abandoned structures."
 	mappath = 'maps/gateway_vr/variable/arynthilakeunderground_a.dmm'
 
 /datum/map_template/common_lateload/gateway/arynthilake_b
-	name = "Arynthi Lake B"
+	name = "Gateway - Arynthi Lake B"
 	desc = "A grassy surface with some abandoned structures."
 	mappath = 'maps/gateway_vr/variable/arynthilake_b.dmm'
 
 /datum/map_template/common_lateload/gateway/arynthilakeunderground_b
-	name = "Arynthi Lake Underground B"
+	name = "Gateway - Arynthi Lake Underground B"
 	desc = "A grassy surface with some abandoned structures."
 	mappath = 'maps/gateway_vr/variable/arynthilakeunderground_b.dmm'
 
 #include "../gateway_vr/wildwest.dm"
 /datum/map_template/common_lateload/gateway/wildwest
-	name = "Wild West"
+	name = "Gateway - Wild West"
 	desc = "A classic."
 	mappath = 'maps/gateway_vr/wildwest.dmm'
 
@@ -243,44 +243,43 @@
 	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_REDGATE, 64, 64)
 
 /datum/map_template/common_lateload/redgate/teppi_ranch
-	name = "Teppi Ranch"
+	name = "Redgate - Teppi Ranch"
 	desc = "An abandoned teppi ranch!"
 	mappath = 'maps/redgate/teppiranch.dmm'
 
 /datum/map_template/common_lateload/redgate/innland
-	name = "Innland"
+	name = "Redgate - Innland"
 	desc = "Caves and grass and a tavern, woah!"
 	mappath = 'maps/redgate/innland.dmm'
 
 /datum/map_template/common_lateload/redgate/abandonedisland
-	name = "Abandoned Island"
+	name = "Redgate - Abandoned Island"
 	desc = "It seems like it used to be people here!"
 	mappath = 'maps/redgate/abandonedisland.dmm'
 
 /datum/map_template/common_lateload/redgate/darkadventure
-	name = "Dark Adventure"
+	name = "Redgate - Dark Adventure"
 	desc = "This place seems broken!"
 	mappath = 'maps/redgate/darkadventure.dmm'
 
-
 /datum/map_template/common_lateload/redgate/stardog
-	name = "Star Dog"
+	name = "Redgate - Star Dog"
 	desc = "That's a big dog!"
 	mappath = 'maps/redgate/stardog.dmm'
 
 #include "../redgate/eggnogtown.dm"
 /datum/map_template/common_lateload/redgate/eggnogtown
-	name = "Eggnog Town"
+	name = "Redgate - Eggnog Town"
 	desc = "A comfortable snowy town."
 	mappath = 'maps/redgate/eggnogtown.dmm'
 
 /datum/map_template/common_lateload/redgate/eggnogtownunderground
-	name = "Eggnog Town Underground"
+	name = "Redgate - Eggnog Town Underground"
 	desc = "A comfortable snowy town."
 	mappath = 'maps/redgate/eggnogtownunderground.dmm'
 
 /datum/map_template/common_lateload/redgate/hotsprings
-	name = "Hotsprings"
+	name = "Redgate - Hotsprings"
 	desc = "This place is rather cosy for somewhere so abandoned!"
 	mappath = 'maps/redgate/hotsprings.dmm'
 

--- a/maps/redgate/abandonedisland.dmm
+++ b/maps/redgate/abandonedisland.dmm
@@ -145,7 +145,7 @@
 /turf/simulated/floor/wood,
 /area/redgate/wilds)
 "bx" = (
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/mud,
 /area/redgate/wilds)
 "by" = (
 /obj/fiftyspawner/phoron,
@@ -269,6 +269,10 @@
 "xM" = (
 /obj/random/mob/semirandom_mob_spawner/vore/retaliate,
 /turf/simulated/floor/outdoors/grass/seasonal,
+/area/redgate/wilds)
+"yR" = (
+/obj/effect/fake_sun,
+/turf/simulated/floor/water/deep,
 /area/redgate/wilds)
 "zB" = (
 /obj/random/mob/semirandom_mob_spawner/fish/b,
@@ -611,7 +615,7 @@ ba
 ba
 ba
 ba
-ba
+yR
 ba
 "}
 (3,1,1) = {"
@@ -4803,7 +4807,7 @@ SJ
 aO
 aO
 aX
-aX
+xL
 xL
 aX
 aX
@@ -4947,7 +4951,7 @@ aO
 aX
 aX
 xL
-aX
+xL
 xL
 xL
 aX
@@ -5090,7 +5094,7 @@ aO
 aO
 xL
 xL
-aX
+xL
 xL
 aX
 aX
@@ -5232,7 +5236,7 @@ aO
 aO
 aX
 aX
-aX
+xL
 xL
 xL
 aX
@@ -6228,7 +6232,7 @@ aO
 aO
 aO
 xL
-aX
+xL
 aX
 aX
 aX
@@ -9290,7 +9294,7 @@ aY
 aO
 aN
 aN
-aN
+aO
 aO
 aO
 xL
@@ -9432,8 +9436,8 @@ aY
 aO
 aO
 aO
-aN
-aN
+aO
+aO
 aO
 xL
 aO
@@ -9574,7 +9578,7 @@ aO
 aO
 aO
 aN
-aN
+aO
 aO
 aO
 xL
@@ -17239,7 +17243,7 @@ aZ
 aZ
 aY
 aY
-bx
+xL
 aO
 aO
 aO
@@ -17807,8 +17811,8 @@ aZ
 aZ
 aZ
 aY
-bx
-bx
+xL
+xL
 aO
 aO
 aN
@@ -17949,8 +17953,8 @@ aZ
 aZ
 aY
 aY
-bx
-bx
+xL
+xL
 aO
 aO
 aN
@@ -18091,8 +18095,8 @@ aZ
 aZ
 aZ
 aY
-bx
-bx
+xL
+xL
 aO
 aO
 aO
@@ -18233,8 +18237,8 @@ aZ
 aZ
 aZ
 aY
-bx
-bx
+xL
+xL
 aO
 aO
 aO
@@ -18375,9 +18379,9 @@ aZ
 aZ
 aZ
 aY
-bx
-bx
-bx
+xL
+xL
+xL
 aO
 aO
 aO
@@ -18517,10 +18521,10 @@ aZ
 aZ
 aZ
 bd
-bx
-bx
-bx
-bx
+xL
+xL
+xL
+xL
 aO
 aO
 aO
@@ -18659,14 +18663,14 @@ aZ
 aZ
 aZ
 aY
-bx
-bx
-bx
-bx
-bx
-bx
-bx
-bx
+xL
+xL
+xL
+xL
+xL
+xL
+xL
+xL
 aO
 aO
 aO
@@ -18801,8 +18805,8 @@ aZ
 aZ
 aZ
 aZ
-bx
-bx
+xL
+xL
 aY
 aY
 aY

--- a/maps/stellar_delight/stellar_delight_defines.dm
+++ b/maps/stellar_delight/stellar_delight_defines.dm
@@ -154,13 +154,13 @@
 		)
 
 	lateload_gateway = list(
-		list("Carp Farm"),
-		list("Snow Field"),
-		list("Listening Post"),
-		list(list("Honleth Highlands A", "Honleth Highlands B")),
-		list("Arynthi Lake Underground A","Arynthi Lake A"),
-		list("Arynthi Lake Underground B","Arynthi Lake B"),
-		list("Wild West")
+		list("Gateway - Carp Farm"),
+		list("Gateway - Snow Field"),
+		list("Gateway - Listening Post"),
+		list(list("Gateway - Honleth Highlands A", "Gateway - Honleth Highlands B")),
+		list("Gateway - Arynthi Lake Underground A","Gateway - Arynthi Lake A"),
+		list("Gateway - Arynthi Lake Underground B","Gateway - Arynthi Lake B"),
+		list("Gateway - Wild West")
 		)
 
 	lateload_overmap = list(
@@ -168,13 +168,13 @@
 		)
 
 	lateload_redgate = list(
-		list("Teppi Ranch"),
-		list("Innland"),
-		list("Abandoned Island"),
-		list("Dark Adventure"),
-		list("Eggnog Town Underground","Eggnog Town"),
-		list("Star Dog"),
-		list("Hotsprings")
+		list("Redgate - Teppi Ranch"),
+		list("Redgate - Innland"),
+//		list("Redgate - Abandoned Island"),	//This will come back later
+		list("Redgate - Dark Adventure"),
+		list("Redgate - Eggnog Town Underground","Redgate - Eggnog Town"),
+		list("Redgate - Star Dog"),
+		list("Redgate - Hotsprings")
 		)
 
 	ai_shell_restricted = TRUE

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -184,13 +184,13 @@
 		)
 
 	lateload_gateway = list(
-		list("Carp Farm"),
-		list("Snow Field"),
-		list("Listening Post"),
-		list(list("Honleth Highlands A", "Honleth Highlands B")),
-		list("Arynthi Lake Underground A","Arynthi Lake A"),
-		list("Arynthi Lake Underground B","Arynthi Lake B"),
-		list("Wild West")
+		list("Gateway - Carp Farm"),
+		list("Gateway - Snow Field"),
+		list("Gateway - Listening Post"),
+		list(list("Gateway - Honleth Highlands A", "Gateway - Honleth Highlands B")),
+		list("Gateway - Arynthi Lake Underground A","Gateway - Arynthi Lake A"),
+		list("Gateway - Arynthi Lake Underground B","Gateway - Arynthi Lake B"),
+		list("Gateway - Wild West")
 		)
 
 	lateload_overmap = list(
@@ -198,13 +198,13 @@
 		)
 
 	lateload_redgate = list(
-		list("Teppi Ranch"),
-		list("Innland"),
-		list("Abandoned Island"),
-		list("Dark Adventure"),
-		list("Eggnog Town Underground","Eggnog Town"),
-		list("Star Dog"),
-		list("Hotsprings")
+		list("Redgate - Teppi Ranch"),
+		list("Redgate - Innland"),
+//		list("Redgate - Abandoned Island"),	//This will come back later
+		list("Redgate - Dark Adventure"),
+		list("Redgate - Eggnog Town Underground","Redgate - Eggnog Town"),
+		list("Redgate - Star Dog"),
+		list("Redgate - Hotsprings")
 		)
 
 	ai_shell_restricted = TRUE


### PR DESCRIPTION
Tweaks a couple things relating to gateway and redgate maps

Renames all of the map templates to have Gateway or Redgate prefixes, that way it's more clear what they are intended for when referred to in game

Removes 'Abandoned Island' from the redgate rotation pending a redesign. Also touches up a couple things with it.

Makes a 140x140 compatible version of the zoo gateway map. Does not add this to rotation for now, I would like to further revamp this later.