### PR TITLE
Revise OOC notes panel

### DIFF
--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -44,7 +44,7 @@
 		if(isanimal(bound_mob))
 			. += "<span class = 'notice'>[bound_mob.health / bound_mob.maxHealth * 100]%</span>"
 		if(bound_mob.ooc_notes)
-			. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[bound_mob];ooc_notes=1'>\[View\]</a>"
+			. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[bound_mob];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[src];print_ooc_notes_to_chat=1'>\[Print\]</a>"
 		. += "<span class='deptradio'><a href='?src=\ref[bound_mob];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>"
 
 //Command! This lets the owner toggle hostile on AI controlled mobs, or send a silent command message to your bound mob, wherever they may be.

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -93,7 +93,7 @@
 	. += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a> <b>Birthday:</b> <a href='?src=\ref[src];bday_month=1'>[pref.bday_month]</a><b>/</b><a href='?src=\ref[src];bday_day=1'>[pref.bday_day]</a> - <b>Announce?:</b> <a href='?src=\ref[src];bday_announce=1'>[pref.bday_announce ? "Yes" : "No"]</a><br>"
 	. += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
 	if(config.allow_Metadata)
-		. += "<b>OOC Notes:</b> <a href='?src=\ref[src];metadata=1'> Edit </a><br>"
+		. += "<b>OOC Notes: <a href='?src=\ref[src];edit_ooc_notes=1'>Edit</a><a href='?src=\ref[src];edit_ooc_note_likes=1'>Likes</a><a href='?src=\ref[src];edit_ooc_note_dislikes=1'>Dislikes</a></b><br>"
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/general/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -208,27 +208,18 @@
 		pref.spawnpoint = choice
 		return TOPIC_REFRESH
 
-	else if(href_list["metadata"])
-//		var/new_metadata = strip_html_simple(tgui_input_text(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , html_decode(pref.metadata), multiline = TRUE, prevent_enter = TRUE)) //VOREStation Edit
-		if(CanUseTopic(user))
-			ooc_notes_window(user)
-//			pref.metadata = new_metadata
-			return TOPIC_HANDLED
 	else if(href_list["edit_ooc_notes"])
 		var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see, such as Roleplay-preferences. This will not be saved permanently unless you click save in the Character Setup panel!", "Game Preference" , html_decode(pref.metadata), multiline = TRUE,  prevent_enter = TRUE))
 		if(new_metadata && CanUseTopic(user))
 			pref.metadata = new_metadata
-			ooc_notes_window(usr)
 	else if(href_list["edit_ooc_note_likes"])
 		var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your LIKED roleplay preferences. This will not be saved permanently unless you click save in the Character Setup panel!", "Game Preference" , html_decode(pref.metadata_likes), multiline = TRUE,  prevent_enter = TRUE))
 		if(new_metadata && CanUseTopic(user))
 			pref.metadata_likes = new_metadata
-			ooc_notes_window(usr)
 	else if(href_list["edit_ooc_note_dislikes"])
 		var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your DISLIKED roleplay preferences. This will not be saved permanently unless you click save in the Character Setup panel!", "Game Preference" , html_decode(pref.metadata_dislikes), multiline = TRUE,  prevent_enter = TRUE))
 		if(new_metadata && CanUseTopic(user))
 			pref.metadata_dislikes = new_metadata
-			ooc_notes_window(usr)
 	return ..()
 
 /datum/category_item/player_setup_item/general/basic/proc/get_genders()
@@ -243,131 +234,3 @@
 	possible_genders = possible_genders.Copy()
 	possible_genders |= NEUTER
 	return possible_genders
-
-/datum/category_item/player_setup_item/general/basic/proc/ooc_notes_window(mob/user)
-	//I tried to get it to accept things like emojis and all that, but, it wouldn't do! It would be cool if it did.
-	var/notes = replacetext(html_decode(pref.metadata), "\n", "<BR>")
-	var/likes = replacetext(html_decode(pref.metadata_likes), "\n", "<BR>")
-	var/dislikes = replacetext(html_decode(pref.metadata_dislikes), "\n", "<BR>")
-	var/dat = {"
-	<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
-	<html>
-		<head>
-			<style>
-				body {
-					margin-top:5px;
-					font-family:Verdana;
-					color:white;
-					font-size:13px;
-					background-image:url('ooc_notes.png');
-					background-repeat:repeat-x;
-					background-color:#272727;
-					background-position:center top;
-				}
-				table {
-					font-size:13px;
-					margin-left:-2px;
-				}
-				h2 {
-					font-size:15px;
-				}
-				.collapsible {
-					background-color: #263d20;
-					color: white;
-					padding: 5px;
-					width: 100%;
-					border: none;
-					text-align: left;
-					outline: none;
-					font-size: 20px;
-				}
-				.collapsible_b {
-					background-color: #3f1a1a;
-					color: white;
-					padding: 5px;
-					width: 100%;
-					border: none;
-					text-align: left;
-					outline: none;
-					font-size: 20px;
-				}
-
-				.content {
-					padding: 5;
-					width: 100%;
-					background-color: #363636;
-				}
-
-				.button {
-					background-color: #40628a;
-					text-align: center;
-				}
-				td.button {
-					border: 1px solid #161616;
-					background-color: #40628a;
-					text-align: center;
-				}
-				a.button {
-					color:white;
-					text-decoration: none;
-				}
-
-				</style>
-			</head>"}
-
-	dat += {"<body>
-			<p><b>Save your changes in the character setup!</b></p>
-			<b><font size='3px'>[pref.real_name]'s OOC notes</font></b><br>"}
-	dat += {"
-			<br>
-			<table>
-				<td class="button">
-					<a href='byond://?src=\ref[src];edit_ooc_notes=1' class='button'>Edit</a>
-				</td>
-			</table>
-			"}
-
-	dat += {"
-		<br>
-		<p>[notes]</p>
-		<head>
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<body>
-
-		<div class="collapsible"><b>Likes</b></div>"}
-	dat += {"
-			<table>
-				<td class="button">
-					<a href='byond://?src=\ref[src];edit_ooc_note_likes=1' class='button'>Edit</a>
-				</td>
-			</table>
-			"}
-
-	dat += {"
-		<div class="content">
-		  <p>[likes]</p>
-		</div>"}
-	dat += {"
-	<br>
-	<div class="collapsible_b"><b>Dislikes</b></div>"}
-	dat += {"
-			<table>
-				<td class="button">
-					<a href='byond://?src=\ref[src];edit_ooc_note_dislikes=1' class='button'>Edit</a>
-				</td>
-			</table>
-			"}
-
-	dat += {"
-		<div class="content">
-		  <p>[dislikes]</p>
-		</div>
-			</body>
-		</html>
-		<br><br>
-		<p><b>This only updates your character save file, to update your notes in the round use the Set OOC Metainfo verb!</b></p>
-		"}
-
-	user << browse("<html><head><title>OOC Notes: [pref.real_name]</title></head>[dat]</html>", "window=[pref.real_name]mvp;size=500x600;can_resize=1;can_minimize=0")
-
-	onclose(usr, "[pref.real_name]")

--- a/code/modules/client/verbs/character_directory.dm
+++ b/code/modules/client/verbs/character_directory.dm
@@ -77,7 +77,10 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			name = H.real_name
 			species = "[H.custom_species ? H.custom_species : H.species.name]"
 			ooc_notes = H.ooc_notes
-			ooc_notes += "\n\n LIKES\n\n[H.ooc_notes_likes]\n\nDISLIKES\n\n[H.ooc_notes_dislikes]"
+			if(H.ooc_notes_likes)
+				ooc_notes += "\n\nLIKES\n\n[H.ooc_notes_likes]"
+			if(H.ooc_notes_dislikes)
+				ooc_notes += "\n\nDISLIKES\n\n[H.ooc_notes_dislikes]"
 			flavor_text = H.flavor_texts["general"]
 
 		if(isAI(C.mob))
@@ -85,7 +88,11 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			name = A.name
 			species = "Artificial Intelligence"
 			ooc_notes = A.ooc_notes
-			ooc_notes += "\n\nLIKES\n\n[A.ooc_notes_likes]\n\nDISLIKES\n\n[A.ooc_notes_dislikes]"
+			if(A.ooc_notes_likes)
+				ooc_notes += "\n\nLIKES\n\n[A.ooc_notes_likes]"
+			if(A.ooc_notes_dislikes)
+				ooc_notes += "\n\nDISLIKES\n\n[A.ooc_notes_dislikes]"
+
 			flavor_text = null // No flavor text for AIs :c
 
 		if(isrobot(C.mob))
@@ -95,7 +102,11 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			name = R.name
 			species = "[R.modtype] [R.braintype]"
 			ooc_notes = R.ooc_notes
-			ooc_notes += "\n\nLIKES\n\n[R.ooc_notes_likes]\n\nDISLIKES\n\n[R.ooc_notes_dislikes]"
+			if(R.ooc_notes_likes)
+				ooc_notes += "\n\nLIKES\n\n[R.ooc_notes_likes]"
+			if(R.ooc_notes_dislikes)
+				ooc_notes += "\n\nDISLIKES\n\n[R.ooc_notes_dislikes]"
+
 			flavor_text = R.flavor_text
 
 		// It's okay if we fail to find OOC notes and flavor text

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -435,7 +435,7 @@
 		msg += "Custom link: [custom_link]"
 
 	if(ooc_notes)
-		msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>"
+		msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[src];print_ooc_notes_to_chat=1'>\[Print\]</a>"
 	msg += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>"
 	// VOREStation End
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -84,8 +84,6 @@
 		to_chat(usr, "<span class='filter_notice'>Character preferences saved.</span>")
 
 /mob/living/proc/print_ooc_notes_to_chat()
-	if(usr != src)
-		return
 	if(!ooc_notes)
 		return
 	var/msg = ooc_notes

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -36,8 +36,21 @@
 		to_chat(usr, "<span class='filter_notice'>OOC notes updated. Don't forget to save!</span>")
 		log_admin("[key_name(usr)] updated their OOC notes mid-round.")
 		ooc_notes_window(usr)
+		set_metainfo_likes(FALSE)
+		set_metainfo_dislikes(FALSE)
 
-/mob/living/proc/set_metainfo_likes()
+/mob/living/verb/set_metainfo_panel()
+	if(usr != src)
+		return
+	var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see, such as Roleplay-preferences. This will not be saved permanently unless you click save in the OOC notes panel!", "Game Preference" , html_decode(ooc_notes), multiline = TRUE,  prevent_enter = TRUE))
+	if(new_metadata && CanUseTopic(usr))
+		ooc_notes = new_metadata
+		client.prefs.metadata = new_metadata
+		to_chat(usr, "<span class='filter_notice'>OOC notes updated. Don't forget to save!</span>")
+		log_admin("[key_name(usr)] updated their OOC notes mid-round.")
+		ooc_notes_window(usr)
+
+/mob/living/proc/set_metainfo_likes(var/reopen = TRUE)
 	if(usr != src)
 		return
 	var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your LIKED roleplay preferences. This will not be saved permanently unless you click save in the OOC notes panel!", "Game Preference" , html_decode(ooc_notes_likes), multiline = TRUE,  prevent_enter = TRUE))
@@ -46,9 +59,10 @@
 		client.prefs.metadata_likes = new_metadata
 		to_chat(usr, "<span class='filter_notice'>OOC note likes have been updated. Don't forget to save!</span>")
 		log_admin("[key_name(usr)] updated their OOC note likes mid-round.")
-		ooc_notes_window(usr)
+		if(reopen)
+			ooc_notes_window(usr)
 
-/mob/living/proc/set_metainfo_dislikes()
+/mob/living/proc/set_metainfo_dislikes(var/reopen = TRUE)
 	if(usr != src)
 		return
 	var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your DISLIKED roleplay preferences. This will not be saved permanently unless you click save in the OOC notes panel!", "Game Preference" , html_decode(ooc_notes_dislikes), multiline = TRUE,  prevent_enter = TRUE))
@@ -57,7 +71,8 @@
 		client.prefs.metadata_dislikes = new_metadata
 		to_chat(usr, "<span class='filter_notice'>OOC note dislikes have been updated. Don't forget to save!</span>")
 		log_admin("[key_name(usr)] updated their OOC note dislikes mid-round.")
-		ooc_notes_window(usr)
+		if(reopen)
+			ooc_notes_window(usr)
 
 /mob/living/proc/save_ooc_panel()
 	if(usr != src)
@@ -67,6 +82,18 @@
 		return
 	if(client.prefs.save_character())
 		to_chat(usr, "<span class='filter_notice'>Character preferences saved.</span>")
+
+/mob/living/proc/print_ooc_notes_to_chat()
+	if(usr != src)
+		return
+	if(!ooc_notes)
+		return
+	var/msg = ooc_notes
+	if(ooc_notes_likes)
+		msg += "<br><br><b>LIKES</b><br><br>[ooc_notes_likes]"
+	if(ooc_notes_dislikes)
+		msg += "<br><br><b>DISLIKES</b><br><br>[ooc_notes_dislikes]"
+	to_chat(src, "<span class='filter_notice'>[src]'s Metainfo:<br>[msg]</span>")
 
 /mob/living/verb/set_custom_link()
 	set name = "Set Custom Link"

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -91,7 +91,7 @@
 		msg += "<br><br><b>LIKES</b><br><br>[ooc_notes_likes]"
 	if(ooc_notes_dislikes)
 		msg += "<br><br><b>DISLIKES</b><br><br>[ooc_notes_dislikes]"
-	to_chat(src, "<span class='filter_notice'>[src]'s Metainfo:<br>[msg]</span>")
+	to_chat(usr, "<span class='filter_notice'>[src]'s Metainfo:<br>[msg]</span>")
 
 /mob/living/verb/set_custom_link()
 	set name = "Set Custom Link"

--- a/code/modules/mob/living/ooc_notes.dm
+++ b/code/modules/mob/living/ooc_notes.dm
@@ -101,12 +101,14 @@
 			</html>
 			"}
 
-//	user << browse("<html><head><title>OOC Notes: [src]</title></head>[dat]</html>", "window=[src.name]ooc_notes;size=500x600;can_resize=1;can_minimize=1")
+	var/key = "ooc_notes[src.real_name]"	//Generate a unique key so we can make unique clones of windows, that way we can have more than one
+	if(src.ckey)
+		key = "[key][src.ckey]"				//Add a ckey if they have one, in case their name is the same
 
-//	onclose(usr, "[src.name]")
+	winclone(user, "ooc_notes", key)		//Allows us to have more than one OOC notes panel open
 
-	winshow(user, "ooc_notes", TRUE)
-	var/datum/browser/popup = new(user, "ooc_notes_panel", "OOC Notes: [src.name]", 500, 600)
-	popup.set_content(dat)
+	winshow(user, key, TRUE)				//Register our window
+	var/datum/browser/popup = new(user, key, "OOC Notes: [src.name]", 500, 600)		//Create the window
+	popup.set_content(dat)	//Populate window contents
 	popup.open(FALSE) // Skip registring onclose on the browser pane
-	onclose(user, "ooc_notes", src) // We want to register on the window itself
+	onclose(user, key, src) // We want to register on the window itself

--- a/code/modules/mob/living/ooc_notes.dm
+++ b/code/modules/mob/living/ooc_notes.dm
@@ -10,77 +10,43 @@
 	<html>
 		<head>
 			<style>
-				body {
-					margin-top:5px;
-					font-family:Verdana;
-					color:white;
-					font-size:13px;
-					background-image:url('ooc_notes.png');
-					background-repeat:repeat-x;
-					background-color:#272727;
-					background-position:center top;
-				}
-				table {
-					font-size:13px;
-					margin-left:-2px;
-				}
-				h2 {
-					font-size:15px;
-				}
 				.collapsible {
 					background-color: #263d20;
 					color: white;
-					padding: 5px;
 					width: 100%;
-					border: none;
 					text-align: left;
-					outline: none;
 					font-size: 20px;
 				}
 				.collapsible_b {
 					background-color: #3f1a1a;
 					color: white;
-					padding: 5px;
 					width: 100%;
-					border: none;
 					text-align: left;
-					outline: none;
 					font-size: 20px;
 				}
-
 				.content {
 					padding: 5;
 					width: 100%;
 					background-color: #363636;
 				}
 
-				.button {
-					background-color: #40628a;
-					text-align: center;
-				}
-				td.button {
-					border: 1px solid #161616;
-					background-color: #40628a;
-					text-align: center;
-				}
-				a.button {
-					color:white;
-					text-decoration: none;
-				}
-
 				</style>
 			</head>"}
 
-	dat += {"<body>
-			<b><font size='3px'>[src.name]'s OOC notes</font></b><br>"}
+	dat += {"<body><table>"}
 	if(user == src)
 		dat += {"
-				<table>
-					<td class="button">
-						<a href='byond://?src=\ref[src];save_ooc_panel=1' class='button'>Save Character Preferences</a>
-					</td>
-				</table>
-				"}
+			<td class="button">
+				<a href='byond://?src=\ref[src];save_ooc_panel=1' class='button'>Save Character Preferences</a>
+			</td>
+			"}
+	dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];print_ooc_notes_to_chat=1' class='button'>Print to chat</a>
+			</td>
+			</table>
+			"}
+
 	if(user == src)
 		dat += {"
 				<br>
@@ -95,10 +61,10 @@
 		<br>
 		<p>[notes]</p>
 		<head>
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<body>
+		<meta name="viewport" content="width=device-width, initial-scale=1">"}
 
-		<div class="collapsible"><b>Likes</b></div>"}
+	if(likes || user == src)
+		dat += {"<div class="collapsible"><b><center>Likes</center></b></div>"}
 	if(user == src)
 		dat += {"
 				<table>
@@ -113,9 +79,10 @@
 			<div class="content">
 			  <p>[likes]</p>
 			</div>"}
-	dat += {"
-	<br>
-	<div class="collapsible_b"><b>Dislikes</b></div>"}
+	if(dislikes || user == src)
+		dat += {"
+		<br>
+		<div class="collapsible_b"><b><center>Dislikes</center></b></div>"}
 	if(user == src)
 		dat += {"
 				<table>
@@ -134,6 +101,12 @@
 			</html>
 			"}
 
-	user << browse("<html><head><title>OOC Notes: [src]</title></head>[dat]</html>", "window=[src.name]mvp;size=500x600;can_resize=1;can_minimize=1")
+//	user << browse("<html><head><title>OOC Notes: [src]</title></head>[dat]</html>", "window=[src.name]ooc_notes;size=500x600;can_resize=1;can_minimize=1")
 
-	onclose(usr, "[src.name]")
+//	onclose(usr, "[src.name]")
+
+	winshow(user, "ooc_notes", TRUE)
+	var/datum/browser/popup = new(user, "ooc_notes_panel", "OOC Notes: [src.name]", 500, 600)
+	popup.set_content(dat)
+	popup.open(FALSE) // Skip registring onclose on the browser pane
+	onclose(user, "ooc_notes", src) // We want to register on the window itself

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1060,7 +1060,7 @@
 	if(custom_link)
 		. += "Custom link: [custom_link]"
 	if(ooc_notes)
-		. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>"
+		. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[src];print_ooc_notes_to_chat=1'>\[Print\]</a>"
 	. += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>"
 
 
@@ -1071,7 +1071,7 @@
 		src.Examine_OOC()
 	if(href_list["edit_ooc_notes"])
 		if(usr == src)
-			set_metainfo()
+			set_metainfo_panel()
 	if(href_list["edit_ooc_note_likes"])
 		if(usr == src)
 			set_metainfo_likes()
@@ -1081,8 +1081,8 @@
 	if(href_list["save_ooc_panel"])
 		if(usr == src)
 			save_ooc_panel()
-
-
+	if(href_list["print_ooc_notes_to_chat"])
+		print_ooc_notes_to_chat()
 	return ..()
 
 /mob/living/proc/display_voreprefs(mob/user)	//Called by Topic() calls on instances of /mob/living (and subtypes) containing vore_prefs as an argument

--- a/code/modules/vore/eating/silicon_vr.dm
+++ b/code/modules/vore/eating/silicon_vr.dm
@@ -105,4 +105,4 @@
 			. += "[flavor_text]"
 
 		if(master.ooc_notes)
-			. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[master];ooc_notes=1'>\[View\]</a>"
+			. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[master];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[master];print_ooc_notes_to_chat=1'>\[Print\]</a>"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1501,6 +1501,24 @@ window "preferences_window"
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
 
+window "ooc_notes"
+	elem "ooc_notes"
+		type = MAIN
+		pos = 25,25
+		size = 500x600
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		is-visible = false
+		saved-params = "pos;is-minimized;is-maximized"
+		statusbar = false
+	elem "ooc_notes_panel"
+		type = BROWSER
+		pos = 0,0
+		size = 500x600
+		anchor1 = 0,0
+		anchor2 = 80,100
+		saved-params = ""
+
 window "infowindow"
 	elem "infowindow"
 		type = MAIN


### PR DESCRIPTION
Revises the OOC notes panel a bit, and removes the OOC notes panel from character setup, in favor of just adding buttons to set the likes and dislikes there, rather than maintaining two different versions of the panel. This also makes the 'set ooc metainfo' verb open 3 dialogues, so you can set your OOC notes, likes, and dislikes in the round without using the OOC panel if you want to. Setting things for likes and dislikes is not required, but it will still ask you in those cases.

Additionally, adds a 'print to chat' button to the panel, and to examine for the OOC notes.

Changes the way the window is sent to the client so that it behaves more like character setup. This should mitigate edge cases where the panel appears off screen when SS13 is not being displayed on the primary monitor.

Also, for the print to chat, character directory, and any OOC notes panel that isn't yours, the LIKES and DISLIKES sections will show up conditionally depending on if they are actually set up. If there's nothing there, then they won't show up.

Still doesn't allow for emojis and the like, but other than that it's working better than before!

![image](https://github.com/VOREStation/VOREStation/assets/24854483/f3729e70-76eb-4d9c-a89d-1786c5f5d147)
![image](https://github.com/VOREStation/VOREStation/assets/24854483/d0864cd1-a68a-4784-89c6-beb12811b385)
![image](https://github.com/VOREStation/VOREStation/assets/24854483/be064481-e1a4-440b-b644-16a160e48217)
![image](https://github.com/VOREStation/VOREStation/assets/24854483/72bf0823-594b-43a5-9b2e-86cc5a8fb718)
![image](https://github.com/VOREStation/VOREStation/assets/24854483/c335c16e-d2eb-40ed-ba5b-b378e6db1c60)


