### PR TITLE
Char Setup: Reset Buttons

### DIFF
--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -87,6 +87,7 @@
 	. += "<a href='?src=\ref[src];always_random_name=1'>Always Random Name: [pref.be_random_name ? "Yes" : "No"]</a><br>"
 	. += "<b>Nickname:</b> "
 	. += "<a href='?src=\ref[src];nickname=1'><b>[pref.nickname]</b></a>"
+	. += "(<a href='?src=\ref[src];reset_nickname=1'>Clear</A>)"
 	. += "<br>"
 	. += "<b>Biological Sex:</b> <a href='?src=\ref[src];bio_gender=1'><b>[gender2text(pref.biological_gender)]</b></a><br>"
 	. += "<b>Pronouns:</b> <a href='?src=\ref[src];id_gender=1'><b>[gender2text(pref.identifying_gender)]</b></a><br>"
@@ -126,6 +127,12 @@
 			else
 				to_chat(user, "<span class='warning'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</span>")
 				return TOPIC_NOACTION
+
+	else if(href_list["reset_nickname"])
+		var/nick_choice = tgui_alert(usr, "Wipe your Nickname? This will completely remove any chosen nickname(s).","Wipe Nickname",list("Yes","No"))
+		if(nick_choice == "Yes")
+			pref.nickname = null
+		return TOPIC_REFRESH
 
 	else if(href_list["bio_gender"])
 		var/new_gender = tgui_input_list(user, "Choose your character's biological sex:", "Character Preference", get_genders(), pref.biological_gender)

--- a/code/modules/client/preference_setup/general/05_background.dm
+++ b/code/modules/client/preference_setup/general/05_background.dm
@@ -58,11 +58,14 @@
 		. += "<span class='danger'>You are banned from using character records.</span><br>"
 	else
 		. += "Medical Records:<br>"
-		. += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br><br>"
+		. += "<a href='?src=\ref[src];set_medical_records=1'>[TextPreview(pref.med_record,40)]</a><br>"
+		. += " (<a href='?src=\ref[src];reset_medrecord=1'>Reset</A>)<br><br>"
 		. += "Employment Records:<br>"
-		. += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><br><br>"
+		. += "<a href='?src=\ref[src];set_general_records=1'>[TextPreview(pref.gen_record,40)]</a><br>"
+		. += "(<a href='?src=\ref[src];reset_emprecord=1'>Reset</A>)<br><br>"
 		. += "Security Records:<br>"
 		. += "<a href='?src=\ref[src];set_security_records=1'>[TextPreview(pref.sec_record,40)]</a><br>"
+		. += "(<a href='?src=\ref[src];reset_secrecord=1'>Reset</A>)"
 
 /datum/category_item/player_setup_item/general/background/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["econ_status"])
@@ -147,6 +150,24 @@
 		var/sec_medical = strip_html_simple(tgui_input_text(user,"Enter security information here.","Character Preference", html_decode(pref.sec_record), MAX_RECORD_LENGTH, TRUE, prevent_enter = TRUE), MAX_RECORD_LENGTH)
 		if(sec_medical && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.sec_record = sec_medical
+		return TOPIC_REFRESH
+
+	else if(href_list["reset_medrecord"])
+		var/resetmed_choice = tgui_alert(usr, "Wipe your Medical Records? This cannot be reverted if you have not saved your character recently! You may wish to make a backup first.","Reset Records",list("Yes","No"))
+		if(resetmed_choice == "Yes")
+			pref.med_record = null
+		return TOPIC_REFRESH
+
+	else if(href_list["reset_emprecord"])
+		var/resetemp_choice = tgui_alert(usr, "Wipe your Employment Records? This cannot be reverted if you have not saved your character recently! You may wish to make a backup first.","Reset Records",list("Yes","No"))
+		if(resetemp_choice == "Yes")
+			pref.gen_record = null
+		return TOPIC_REFRESH
+
+	else if(href_list["reset_secrecord"])
+		var/resetsec_choice = tgui_alert(usr, "Wipe your Security Records? This cannot be reverted if you have not saved your character recently! You may wish to make a backup first.","Reset Records",list("Yes","No"))
+		if(resetsec_choice == "Yes")
+			pref.sec_record = null
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -323,7 +323,7 @@
 	. += "<a href='?src=\ref[src];custom_exclaim=1'>Set Exclaim Verb</a>"
 	. += "(<a href='?src=\ref[src];reset_exclaim=1'>Reset</A>)"
 	. += "<br>"
-	. += "<b>Custom heat Discomfort: </b>"
+	. += "<b>Custom Heat Discomfort: </b>"
 	. += "<a href='?src=\ref[src];custom_heat=1'>Set Heat Messages</a>"
 	. += "(<a href='?src=\ref[src];reset_heat=1'>Reset</A>)"
 	. += "<br>"


### PR DESCRIPTION
Quick and dirty addition of some reset buttons for nickname and all three record groups, as I mentioned maybe adding a little while ago.

The html for flavour text is a bit more complex and I'm not sure how best to approach that, but I would like to do a similar function for that, to ensure that when an entry is wiped the values are properly nulled and not just left as `""` or `" "`.

Also corrects the capitalization of Custom **H**eat Discomfort message under the misc. tab since that didn't match the rest of that lot and it was vaguely bothering me.