### PR TITLE
Being outdoors doesn't mean you can be dark forever

### DIFF
--- a/code/modules/lighting/lighting_fake_sun_vr.dm
+++ b/code/modules/lighting/lighting_fake_sun_vr.dm
@@ -1,3 +1,5 @@
+var/static/list/fake_sunlight_zs = list()
+
 /obj/effect/fake_sun
 	name = "fake sun"
 	desc = "Deletes itself, but first updates all the lighting on outdoor turfs."
@@ -140,6 +142,7 @@
 	sun.set_alpha(round(CLAMP01(choice["brightness"])*255,1))
 
 	if(do_sun)
+		fake_sunlight_zs |= z
 		for(var/turf/T as anything in turfs_to_use)
 			sun.apply_to_turf(T)
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -97,8 +97,12 @@
 ///Setter for the byond luminosity var
 /turf/proc/set_luminosity(new_luminosity, force)
 	// SSplanets handles outdoor turfs
-	if((is_outdoors() && !force) || outdoors_adjacent)
+	if(force)
+		luminosity = new_luminosity
 		return
+	if(is_outdoors() || outdoors_adjacent)
+		if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs))
+			return
 
 	luminosity = new_luminosity
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -96,12 +96,8 @@
 
 ///Setter for the byond luminosity var
 /turf/proc/set_luminosity(new_luminosity, force)
-	// SSplanets handles outdoor turfs
-	if(force)
-		luminosity = new_luminosity
-		return
-	if(is_outdoors() || outdoors_adjacent)
-		if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs))
+	if((is_outdoors() && !force) || outdoors_adjacent)
+		if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs)) //These are both systems that handle the lighting on their own, so let's not interfere
 			return
 
 	luminosity = new_luminosity

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -97,10 +97,16 @@
 ///Setter for the byond luminosity var
 /turf/proc/set_luminosity(new_luminosity, force)
 	if((is_outdoors() && !force) || outdoors_adjacent)
-		if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs)) //These are both systems that handle the lighting on their own, so let's not interfere
+		if(check_for_sun()) //If another system handles our lighting, don't interfere
 			return
 
 	luminosity = new_luminosity
+
+///Checks planets and fake_suns to see if our turf should be handled by either
+/turf/proc/check_for_sun()
+	if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs))
+		return TRUE
+	return FALSE
 
 ///Calculate on which directions this turfs block view.
 /turf/proc/recalculate_directional_opacity()


### PR DESCRIPTION
Makes it so that outdoors being true doesn't automatically return false on set_luminosity, and instead has it check to see if the turf is included in a planet or a fake_sun's area (if the fake_sun is actually doing the light part). If it's not, then it will set_luminosity as one would expect.

This means that outdoor turfs that DON'T have light can be lit up by lights!

It might be somewhat cool to make it so that planet and fake sun will store the planet lighting information on the turf, so that you can light it up, and have it return to those values if your light goes out. But that's a future pondering.