### PR TITLE
Makes it so that tesla's zaps no longer respect LOS

### DIFF
--- a/code/game/objects/structures/flora/trees.dm
+++ b/code/game/objects/structures/flora/trees.dm
@@ -124,7 +124,7 @@
 	if(Proj.get_structure_damage())
 		adjust_health(-Proj.get_structure_damage(), TRUE)
 
-/obj/structure/flora/tree/tesla_act(power, explosive)
+/obj/structure/flora/tree/tesla_act(power, ignore_los, explosive)
 	adjust_health(-power / 100, TRUE) // Kills most trees in one lightning strike.
 	..()
 
@@ -295,4 +295,3 @@
 		set_light(bulbs, 1, "#33ccff")	// 5 variants, missing bulbs. 5th has no bulbs, so no glow.
 		add_overlay(mutable_appearance(icon, "[base_state][bulbs]_glow"))
 		add_overlay(emissive_appearance(icon, "[base_state][bulbs]_glow"))
-	

--- a/code/modules/admin/verbs/lightning_strike.dm
+++ b/code/modules/admin/verbs/lightning_strike.dm
@@ -72,14 +72,14 @@
 		return
 
 	if(ground) // All is well.
-		ground.tesla_act(LIGHTNING_POWER, FALSE)
+		ground.tesla_act(LIGHTNING_POWER, FALSE, FALSE)
 		return
 
 	else if(coil) // Otherwise lets bounce off the tesla coil.
-		coil.tesla_act(LIGHTNING_POWER, TRUE)
+		coil.tesla_act(LIGHTNING_POWER, FALSE, TRUE)
 
 	else // Striking the turf directly.
-		tesla_zap(T, zap_range = LIGHTNING_ZAP_RANGE, power = LIGHTNING_POWER, explosive = FALSE, stun_mobs = TRUE)
+		tesla_zap(T, zap_range = LIGHTNING_ZAP_RANGE, power = LIGHTNING_POWER, explosive = FALSE, stun_mobs = TRUE, ignore_los = FALSE)
 
 	// Some extra effects.
 	// Some apply to those within zap range, others if they were a bit farther away.

--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	if(prob(20))
 		set_broken()
 
-/obj/machinery/gravity_generator/tesla_act(power, tesla_flags)
+/obj/machinery/gravity_generator/tesla_act(power, ignore_los, tesla_flags)
 	..()
 	qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
@@ -96,7 +96,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/station/Initialize()
 	. = ..()
 	setup_parts()
-	middle.add_overlay("activated")	
+	middle.add_overlay("activated")
 
 //
 // Generator an admin can spawn
@@ -408,7 +408,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/proc/update_list()
 	levels.Cut()
 	var/my_z = get_z(src)
-	
+
 	//Actually doing it special this time instead of letting using_map decide
 	if(using_map.use_overmap)
 		var/obj/effect/overmap/visitable/S = get_overmap_sector(my_z)
@@ -418,7 +418,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 			levels = GetConnectedZlevels(my_z)
 	else
 		levels = GetConnectedZlevels(my_z)
-		
+
 	for(var/z in levels)
 		if(!GLOB.gravity_generators["[z]"])
 			GLOB.gravity_generators["[z]"] = list()

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -161,7 +161,7 @@
 	// L.dust() - Changing to do fatal elecrocution instead
 	L.electrocute_act(500, src, def_zone = BP_TORSO)
 
-/proc/tesla_zap(atom/source, zap_range = 3, power, explosive = FALSE, stun_mobs = TRUE)
+/proc/tesla_zap(atom/source, zap_range = 3, power, explosive = FALSE, stun_mobs = TRUE, ignore_los = FALSE)
 	if(!source) // Some mobs and maybe some objects delete themselves when they die.
 		return
 	. = source.dir
@@ -197,7 +197,14 @@
 										/obj/structure/grille,
 										/obj/machinery/the_singularitygen/tesla))
 
-	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))
+	var/list/things_we_will_shock
+
+	if(ignore_los)
+		things_we_will_shock = orange(source, zap_range+2)
+	else
+		things_we_will_shock = oview(source, zap_range+2)
+
+	for(var/A in typecache_filter_multi_list_exclusion(things_we_will_shock, things_to_shock, blacklisted_tesla_types))
 		if(istype(A, /obj/machinery/power/tesla_coil))
 			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
@@ -278,10 +285,10 @@
 
 	//per type stuff:
 	if(closest_tesla_coil)
-		closest_tesla_coil.tesla_act(power, explosive, stun_mobs)
+		closest_tesla_coil.tesla_act(power, ignore_los, explosive, stun_mobs)
 
 	else if(closest_grounding_rod)
-		closest_grounding_rod.tesla_act(power, explosive, stun_mobs)
+		closest_grounding_rod.tesla_act(power, ignore_los, explosive, stun_mobs)
 
 	else if(closest_mob)
 		var/shock_damage = CLAMP(round(power/400), 10, 90) + rand(-5, 5)
@@ -292,25 +299,23 @@
 			var/mob/living/silicon/S = closest_mob
 			if(stun_mobs)
 				S.emp_act(3 /*EMP_LIGHT*/)
-			tesla_zap(closest_mob, 7, power / 1.5, explosive, stun_mobs) // metallic folks bounce it further
+			tesla_zap(closest_mob, 7, power / 1.5, explosive, stun_mobs, ignore_los) // metallic folks bounce it further
 		else
-			tesla_zap(closest_mob, 5, power / 1.5, explosive, stun_mobs)
+			tesla_zap(closest_mob, 5, power / 1.5, explosive, stun_mobs, ignore_los)
 
 	else if(closest_machine)
-		drain_energy = TRUE // VOREStation Edit - Safety First! Drain Tesla fast when its loose
-		closest_machine.tesla_act(power, explosive, stun_mobs)
+		drain_energy = TRUE
+		closest_machine.tesla_act(power, ignore_los, explosive, stun_mobs)
 
 	else if(closest_blob)
-		drain_energy = TRUE // VOREStation Edit - Safety First! Drain Tesla fast when its loose
-		closest_blob.tesla_act(power, explosive, stun_mobs)
+		drain_energy = TRUE
+		closest_blob.tesla_act(power, ignore_los, explosive, stun_mobs)
 
 	else if(closest_structure)
-		drain_energy = TRUE // VOREStation Edit - Safety First! Drain Tesla fast when its loose
-		closest_structure.tesla_act(power, explosive, stun_mobs)
+		drain_energy = TRUE
+		closest_structure.tesla_act(power, ignore_los, explosive, stun_mobs)
 
-	// VOREStation Edit Start - Safety First! Drain Tesla fast when its loose
 	if(drain_energy && istype(source, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/EB = source
 		if (EB.energy > 0)
 			EB.energy -= min(EB.energy, max(10, round(EB.energy * 0.05)))
-	// VOREStation Edit End

--- a/code/modules/power/tesla/generator.dm
+++ b/code/modules/power/tesla/generator.dm
@@ -9,6 +9,6 @@
 	. = ..()
 	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
 
-/obj/machinery/the_singularitygen/tesla/tesla_act(power, explosive = FALSE)
+/obj/machinery/the_singularitygen/tesla/tesla_act(power, ignore_los, explosive = FALSE)
 	if(explosive)
 		energy += power

--- a/code/modules/power/tesla/tesla_act.dm
+++ b/code/modules/power/tesla/tesla_act.dm
@@ -5,10 +5,10 @@
 /obj
 	var/being_shocked = FALSE
 
-/obj/proc/tesla_act(var/power)
+/obj/proc/tesla_act(var/power, var/los)
 	being_shocked = TRUE
 	var/power_bounced = power / 2
-	tesla_zap(src, 3, power_bounced)
+	tesla_zap(src, 3, power_bounced, ignore_los = los)
 	//addtimer(CALLBACK(src, PROC_REF(reset_shocked)), 10)
 	//schedule_task_with_source_in(10, src, PROC_REF(reset_shocked))
 	spawn(10) reset_shocked()
@@ -22,12 +22,12 @@
 	..()
 	adjust_integrity(-power/400)
 
-/obj/machinery/nuclearbomb/tesla_act(power, explosive)
+/obj/machinery/nuclearbomb/tesla_act(power, ignore_los, explosive)
 	..()
 	if(explosive)
 		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
-/obj/machinery/tesla_act(power, explosive = FALSE)
+/obj/machinery/tesla_act(power, ignore_los, explosive = FALSE)
 	..()
 	if(prob(85) && explosive)
 		explosion(loc, 0, 2, 4, /*flame_range = 2,*/ adminlog = FALSE/*, smoke = FALSE*/) // VOREStation Edit - No devastation range
@@ -42,7 +42,7 @@
 	..()
 	qdel(src) //to prevent bomb testing camera from exploding over and over forever
 
-/obj/machinery/light/tesla_act(power, explosive = FALSE)
+/obj/machinery/light/tesla_act(power, ignore_los, explosive = FALSE)
 	if(explosive)
 		explosion(loc, 0, 0, 0/*, flame_range = 5*/, adminlog = FALSE)
 		qdel(src)


### PR DESCRIPTION
Title. DOES NOT apply to regular lightning strikes, only tesla zaps.

Makes it more destructive when loose, and also reduces effectiveness of certain engine setups.