### PR TITLE
Fixes to Rain City

### DIFF
--- a/maps/redgate/cybercity.dmm
+++ b/maps/redgate/cybercity.dmm
@@ -473,10 +473,6 @@
 "aLg" = (
 /turf/simulated/wall/tgmc/window/darkwall,
 /area/redgate/city/police)
-"aLw" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/redgate/city/house7)
 "aLy" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/under/sexymime,
@@ -2551,7 +2547,11 @@
 /area/redgate/city/house14)
 "dBp" = (
 /obj/structure/table/rack,
-/mob/living/simple_mob/vore/aggressive/mimic,
+/mob/living/simple_mob/vore/aggressive/mimic{
+	health = 75;
+	melee_damage_lower = 4;
+	melee_damage_upper = 7
+	},
 /turf/simulated/floor/tiled/eris/white/gray_perforated,
 /area/redgate/city/warehouse)
 "dBW" = (
@@ -6543,7 +6543,9 @@
 /turf/simulated/floor/wood,
 /area/redgate/city/house4)
 "iKi" = (
-/mob/living/simple_mob/vore/alienanimals/skeleton/alt,
+/mob/living/simple_mob/vore/alienanimals/skeleton/alt{
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	},
 /turf/simulated/floor/plating,
 /area/redgate/city/dump)
 "iLu" = (
@@ -11071,7 +11073,9 @@
 /turf/simulated/floor/outdoors/grass,
 /area/redgate/city/streets)
 "oCK" = (
-/mob/living/simple_mob/animal/passive/mouse/rat,
+/mob/living/simple_mob/animal/passive/mouse/rat{
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	},
 /turf/simulated/floor/wood/alt/panel,
 /area/redgate/city/rats)
 "oDk" = (
@@ -12808,7 +12812,9 @@
 /turf/simulated/wall/tgmc/window/darkwall,
 /area/redgate/city/house8)
 "qJn" = (
-/mob/living/simple_mob/animal/passive/mouse/rat,
+/mob/living/simple_mob/animal/passive/mouse/rat{
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	},
 /turf/simulated/floor/outdoors/sidewalk/slab/city,
 /area/redgate/city/streets)
 "qJF" = (
@@ -37684,8 +37690,8 @@ weI
 weI
 rEQ
 hiy
-aLw
-aLw
+hiy
+hiy
 weI
 qfb
 qfb


### PR DESCRIPTION
Changed the AI of small rats and the skeleton to be retaliate.

Reduced the strength of the mimic.