### PR TITLE
Makes energy ball explode upon fizzling out

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -22,6 +22,7 @@
 	var/produced_power
 	var/energy_to_raise = 32
 	var/energy_to_lower = -20
+	var/unsafe_dissipation = FALSE
 
 /obj/singularity/energy_ball/New(loc, starting_energy = 50, is_miniball = FALSE)
 	..()
@@ -42,6 +43,9 @@
 
 	for(var/obj/singularity/energy_ball/EB as anything in orbiting_balls)
 		qdel(EB)
+
+	if(unsafe_dissipation)
+		explosion(loc, 1, 3, 6)
 
 	. = ..()
 
@@ -93,6 +97,7 @@
 	if (energy <= 0)
 		log_game("TESLA([x],[y],[z]) Collapsed entirely.")
 		investigate_log("collapsed.", I_SINGULO)
+		unsafe_dissipation = TRUE
 		qdel(src)
 		return TRUE
 


### PR DESCRIPTION
This is more of an alternative proposal to previous tesla-related PR, that changes it in ways that is more in-line with staff stance on engine situation.

Makes tesla release a moderate-sized explosion upon fizzling out due to running out of energy. Only applies to 'main' ball and does not explode at all if tesla is destroyed for any reason other than running out of energy.

Tested explosion sizes, they dont appear to be too devastating, but enough to be pretty damaging around the area tesla itself is in. If it explodes that way when in containment, it will not reach engine observation room, but the setup itself is getting wrecked reliably. Of course, there's RNG involved, but I doubt the few tests I did, I always hit the lowball.