### PR TITLE
Tesla Component Examine Tweaks

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -80,6 +80,20 @@
 
 	src.set_dir(turn(src.dir, 270))
 
+/obj/structure/bed/chair/verb/rotate_counterclockwise()
+	set name = "Rotate Chair Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if(!usr || !isturf(usr.loc))
+		return
+	if(usr.stat || usr.restrained())
+		return
+	if(ismouse(usr) || (isobserver(usr) && !config.ghost_interaction))
+		return
+
+	src.set_dir(turn(src.dir, 90))
+
 /obj/structure/bed/chair/shuttle
 	name = "chair"
 	icon_state = "shuttlechair"

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -30,7 +30,6 @@
 
 	var/integrity = 80
 
-
 /obj/machinery/power/emitter/verb/rotate_clockwise()
 	set name = "Rotate Emitter Clockwise"
 	set category = "Object"
@@ -40,6 +39,17 @@
 		to_chat(usr, "It is fastened to the floor!")
 		return 0
 	src.set_dir(turn(src.dir, 270))
+	return 1
+
+/obj/machinery/power/emitter/verb/rotate_counterclockwise()
+	set name = "Rotate Emitter Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored || usr:stat)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	src.set_dir(turn(src.dir, 90))
 	return 1
 
 /obj/machinery/power/emitter/Initialize()
@@ -274,7 +284,7 @@
 	. = ..()
 	switch(state)
 		if(0)
-			. += "<span class='warning'>It is not secured in place at all!</span>"
+			. += "<span class='warning'>It is not secured in place!</span>"
 		if(1)
 			. += "<span class='warning'>It has been bolted down securely, but not welded into place.</span>"
 		if(2)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -44,7 +44,7 @@ field_generator power level display
 	. = ..()
 	switch(state)
 		if(0)
-			. += "<span class='warning'>It is not secured in place at all!</span>"
+			. += "<span class='warning'>It is not secured in place!</span>"
 		if(1)
 			. += "<span class='warning'>It has been bolted down securely, but not welded into place.</span>"
 		if(2)

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -12,7 +12,10 @@
 
 /obj/machinery/the_singularitygen/examine()
 	. = ..()
-	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+	if(anchored)
+		. += "<span class='warning'>It is not secured!</span>"
+	else
+		. += "<span class='notice'>It has been securely bolted down and is ready for operation.</span>"
 
 /obj/machinery/the_singularitygen/process()
 	var/turf/T = get_turf(src)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -23,7 +23,10 @@
 
 /obj/machinery/power/tesla_coil/examine()
 	. = ..()
-	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+	if(anchored)
+		. += "<span class='warning'>It is not secured!</span>"
+	else
+		. += "<span class='notice'>It has been securely bolted down and is ready for operation.</span>"
 
 /obj/machinery/power/tesla_coil/New()
 	..()
@@ -113,7 +116,10 @@
 
 /obj/machinery/power/grounding_rod/examine()
 	. = ..()
-	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+	if(anchored)
+		. += "<span class='warning'>It is not secured!</span>"
+	else
+		. += "<span class='notice'>It has been securely bolted down and is ready for operation.</span>"
 
 /obj/machinery/power/grounding_rod/pre_mapped
 	anchored = TRUE

--- a/code/modules/power/tesla/generator.dm
+++ b/code/modules/power/tesla/generator.dm
@@ -5,10 +5,6 @@
 	icon_state = "TheSingGen"
 	creation_type = /obj/singularity/energy_ball
 
-/obj/machinery/the_singularitygen/tesla/examine()
-	. = ..()
-	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
-
 /obj/machinery/the_singularitygen/tesla/tesla_act(power, explosive = FALSE)
 	if(explosive)
 		energy += power


### PR DESCRIPTION
All the tesla talk reminds me that there were some leftover issues in #14837 that need resolving. So here's a PR to do that! Wow!

- Wording for some of the examines has been tweaked.
- Coils, grounding rods, and the generator 'core' unit will now use warning (red) formatting if unsecured.
- The tesla generator 'core' will no longer report its anchored status twice when examined.
- Emitters can be rotated CCW as well as CW. As can chairs. Why? Convenience.