### PR TITLE
Fix for island stairs.

### DIFF
--- a/maps/redgate/islands.dmm
+++ b/maps/redgate/islands.dmm
@@ -572,8 +572,8 @@
 /turf/simulated/floor/water/deep/ocean/diving,
 /area/redgate/islands/ocean)
 "px" = (
-/obj/structure/fake_stairs/west/bottom,
-/obj/structure/fake_stairs/west/bottom{
+/obj/structure/inactive_stairs/west/bottom,
+/obj/structure/inactive_stairs/west/bottom{
 	pixel_y = 16
 	},
 /turf/simulated/floor/tiled{
@@ -852,8 +852,8 @@
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/redgate/islands/ocean)
 "zg" = (
-/obj/structure/fake_stairs/west/top,
-/obj/structure/fake_stairs/west/top{
+/obj/structure/inactive_stairs/west/top,
+/obj/structure/inactive_stairs/west/top{
 	pixel_y = 16
 	},
 /turf/simulated/floor/tiled{

--- a/maps/submaps/_helpers.dm
+++ b/maps/submaps/_helpers.dm
@@ -133,3 +133,55 @@
 	name = "stairs"
 	dir = WEST
 	stepoff_dir = EAST
+
+//Inactive stairs are completely cosmetic versions of fake_stairs
+/obj/structure/inactive_stairs
+	name = "use a subtype! - stairs"
+	icon = 'icons/obj/structures/multiz.dmi'
+	icon_state = "stair"
+	density = 0
+	opacity = 0
+	anchored = 1
+	plane = TURF_PLANE
+	layer = ABOVE_TURF_LAYER
+	appearance_flags = PIXEL_SCALE|KEEP_TOGETHER
+
+/obj/structure/inactive_stairs/north/top
+	name = "stairs"
+	dir = NORTH
+	color = "#B0B0B0"
+	pixel_y = -32
+
+/obj/structure/inactive_stairs/north/bottom
+	name = "stairs"
+	dir = NORTH
+	pixel_y = -32
+
+/obj/structure/inactive_stairs/south/top
+	name = "stairs"
+	dir = SOUTH
+	color = "#B0B0B0"
+
+/obj/structure/inactive_stairs/south/bottom
+	name = "stairs"
+	dir = SOUTH
+
+/obj/structure/inactive_stairs/east/top
+	name = "stairs"
+	dir = EAST
+	color = "#B0B0B0"
+	pixel_x = -32
+
+/obj/structure/inactive_stairs/east/bottom
+	name = "stairs"
+	dir = EAST
+	pixel_x = -32
+
+/obj/structure/inactive_stairs/west/top
+	name = "stairs"
+	dir = WEST
+	color = "#B0B0B0"
+
+/obj/structure/inactive_stairs/west/bottom
+	name = "stairs"
+	dir = WEST


### PR DESCRIPTION
Added a new type of stairs: Inactive stairs.

These stairs do what I thought fake_stairs did: Nothing! They look pretty and you can walk over them, purely for mapping in the appearance of stairs without having people teleport on them.

Replaces the fake_stairs in the islands map, tested and work as expected.