### PR TITLE
Tweaks RESPAWN MESSAGE to appear AFTER the MOTD, makes Quit the Round more clear

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -406,7 +406,6 @@
 				to_chat(src,"<span class='notice'>Your job has been free'd up, and you can rejoin as another character or quit. Thanks for properly quitting round, it helps the server!</span>")
 
 	// Beyond this point, you're going to respawn
-	to_chat(usr, config.respawn_message)
 
 	if(!client)
 		log_game("[usr.key] AM failed due to disconnect.")
@@ -425,7 +424,9 @@
 		qdel(M)
 		return
 
+	M.has_respawned = TRUE //When we returned to main menu, send respawn message
 	M.key = key
+
 	if(M.mind)
 		M.mind.reset()
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -366,7 +366,9 @@
 		if(choice == "No, wait")
 			return
 		else if(mind.assigned_role)
-			var/extra_check = tgui_alert(usr, "Do you want to Quit This Round before you return to lobby? This will properly remove you from manifest, as well as prevent resleeving.","Quit This Round",list("Quit Round","Cancel"))
+			var/extra_check = tgui_alert(usr, "Do you want to Quit This Round before you return to lobby?\
+			This will properly remove you from manifest, as well as prevent resleeving. BEWARE: Pressing 'NO' will STILL return you to lobby!",
+			"Quit This Round",list("Quit Round","No"))
 			if(extra_check == "Quit Round")
 				//Update any existing objectives involving this mob.
 				for(var/datum/objective/O in all_objectives)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -31,6 +31,10 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 	if(join_motd)
 		to_chat(src, "<div class=\"motd\">[join_motd]</div>")
 
+	if(has_respawned)
+		to_chat(usr, config.respawn_message)
+		has_respawned = FALSE
+
 	if(!mind)
 		mind = new /datum/mind(key)
 		mind.active = 1
@@ -53,7 +57,7 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 
 /mob/new_player/proc/version_warnings()
 	var/problems // string to store message to present to player as a problem
-	
+
 	// TODO: Move this to a config file at some point maybe? What would the structure of that look like?
 	switch(client.byond_build)
 		// http://www.byond.com/forum/post/2711510
@@ -62,7 +66,7 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 		// http://www.byond.com/forum/post/2711748
 		if(1562 to 1563)
 			problems = "frequent known crashes related to animations"
-		
+
 		// Don't have a thread, just a lot of player reports.
 		if(1564 to 1565) // Fixed in 1566 which isn't released as of this commit
 			if(world.byond_build == 1564)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -6,6 +6,7 @@
 	var/totalPlayers = 0		//Player counts for the Lobby tab
 	var/totalPlayersReady = 0
 	var/show_hidden_jobs = 0	//Show jobs that are set to "Never" in preferences
+	var/has_respawned = FALSE	//Determines if we're using RESPAWN_MESSAGE
 	var/datum/browser/panel
 	universal_speak = 1
 


### PR DESCRIPTION
### What this does

This changes the ordering of the "If you're respawning as the same character or job hopping (changing jobs without an HoP), make sure you've waited at least 30 minutes. Don't abuse this function for non-vore related deaths & avoid using metaknowledge." and the MOTD message. Ergo, ensuring that the respawn message appears AFTER the MOTD, therefore making sure players will see it.

Also clarifies the quit the round question as it seemed like a bug and one assumed it's a double-check of "ARE YOU SURE". 

### Why we need this

See staff discussion on MOTD.
As the MOTD fills the whole chat hiding this crucial bit of information.
We should ensure players see crucial bits of information and hopefully read it.

### Commits

https://github.com/VOREStation/VOREStation/commit/2b955ceff4a0c14ed8969877832d98df287993fd
Previously, the message implied that saying no/cancelling acts as a double-check for leaving the round. Now, it's clear that pressing No will still kick you out.

https://github.com/VOREStation/VOREStation/commit/740f23bf0e0c56226c87ce9c953169b43282063e
Creates a new var on new player mob that tracks if we have quit the round/abandoned our ghost mob to return to lobby or if we have done our first login.

On leaving a previously occupied mob, regardless if we clear manifest or not (previous functionality), the respawn message is sent.

However, this is no longer done by the abandon_mob() procedure as that causes the MOTD to cover it up. Instead, by setting the has_respawned var to true, we request Login() for new_player mobs (aka lobby joiners) to see it.