### PR TITLE
Makes Zorren blood actually based on copper: Iron no longer regens their blood, copper is needed

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -26,6 +26,7 @@
 #define IS_TESHARI 7
 #define IS_SLIME   8
 #define IS_ZADDAT  9
+#define IS_ZORREN  10
 
 #define CE_STABLE "stable" // Inaprovaline
 #define CE_ANTIBIOTIC "antibiotic" // Antibiotics

--- a/code/game/objects/items/devices/scanners/guide.dm
+++ b/code/game/objects/items/devices/scanners/guide.dm
@@ -86,7 +86,7 @@
 	if(organ)
 		dat += "<b>Organ damage</b> - Give Peridaxon. Perform full body scan for targeted organ repair surgery.<br>"
 	if(bloodloss)
-		dat += "<b>Low blood volume</b> - Commence blood transfusion via IV drip or provide blood-restorative chemicals (i.e. Iron)."
+		dat += "<b>Low blood volume</b> - Commence blood transfusion via IV drip or provide blood-restorative chemicals (e.g.: Copper for zorren and skrell, iron for the rest)."
 	if(M.getToxLoss())
 		dat += "<b>Toxins</b> - Give Dylovene or Carthatoline. Vomitting is normal and helpful. Tends to be a symptom of larger issues, such as infection.<br>"
 	if(M.getBruteLoss())

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -201,6 +201,7 @@
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 	blood_color = "#240bc4"
+	reagent_tag = IS_ZORREN
 	color_mult = 1
 
 	genders = list(MALE, FEMALE, PLURAL, NEUTER)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -80,7 +80,7 @@
 	color = "#6E3B08"
 
 /datum/reagent/copper/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_SKRELL)
+	if(alien == IS_SKRELL || alien == IS_ZORREN)
 		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 
 /datum/reagent/ethanol
@@ -247,7 +247,7 @@
 	color = "#353535"
 
 /datum/reagent/iron/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien != IS_DIONA && alien != IS_SKRELL)
+	if(alien != IS_DIONA && alien != IS_SKRELL && alien != IS_ZORREN)
 		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 
 /datum/reagent/lithium


### PR DESCRIPTION
### What this does

Changes zorren to require copper to regain blood rather than iron supplements.
This change is documented in the health analyzer guide, and will be sent to wiki if merged

### Why we need this

Zorren are a haemocyanic species like the skrell and therefore need copper to make blood cells.
This change was requested by head loremaster PontifexMinimus

### Commit Details

[tweak(species/chemistry): Makes zorren need copper for blood](https://github.com/VOREStation/VOREStation/commit/eca94f7854869495d194d0c29136e965a0ad89d8)
- Changes iron reagent to no longer regenerate copper for zorren
- Changes copper reagent to regenerate blood for zorren
- Adds IS_ZORREN reagent_tag define and applies it to species
- Updates medical scanner guide to recommend using copper for zorren and skrell