### PR TITLE
Blood Reagents Refactor

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -369,6 +369,7 @@ var/global/list/PDA_Manifest = list()
 		var/datum/data/record/M = CreateMedicalRecord(H.real_name, id, hidden)
 		M.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]" //VOREStation Edit
 		M.fields["b_type"]		= H.b_type
+		M.fields["blood_reagent"]	= H.species.blood_reagents
 		M.fields["b_dna"]		= H.dna.unique_enzymes
 		M.fields["id_gender"]	= gender2text(H.identifying_gender)
 		if(H.get_FBP_type())

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -41,6 +41,7 @@
 		// Medical
 		"id_gender" = "Please select new gender identity:",
 		"blood_type" = "Please select new blood type:",
+		"blood_reagent" = "Please select new blood basis:",
 		"b_dna" = "Please input new DNA:",
 		"mi_dis" = "Please input new minor disabilities:",
 		"mi_dis_d" = "Please summarize minor disabilities:",
@@ -159,6 +160,7 @@
 					medical["fields"] = fields
 					fields[++fields.len] = MED_FIELD("Gender identity", active2.fields["id_gender"], "id_gender", TRUE)
 					fields[++fields.len] = MED_FIELD("Blood Type", active2.fields["b_type"], "blood_type", FALSE)
+					fields[++fields.len] = MED_FIELD("Blood Basis", active2.fields["blood_reagent"], "blood_reagent", FALSE)
 					fields[++fields.len] = MED_FIELD("DNA", active2.fields["b_dna"], "b_dna", TRUE)
 					fields[++fields.len] = MED_FIELD("Brain Type", active2.fields["brain_type"], "brain_type", TRUE)
 					fields[++fields.len] = MED_FIELD("Important Notes", active2.fields["notes"], "notes", TRUE)
@@ -301,6 +303,7 @@
 					R.fields["id"] = active1.fields["id"]
 					R.name = "Medical Record #[R.fields["id"]]"
 					R.fields["b_type"] = "Unknown"
+					R.fields["blood_reagent"] = "Unknown"
 					R.fields["b_dna"] = "Unknown"
 					R.fields["mi_dis"] = "None"
 					R.fields["mi_dis_d"] = "No minor disabilities have been declared."
@@ -431,6 +434,7 @@
 		P.info += {"<br>\n<center><b>Medical Data</b></center>
 		<br>\nGender Identity: [active2.fields["id_gender"]]
 		<br>\nBlood Type: [active2.fields["b_type"]]
+		<br>\nBlood Basis: [active2.fields["blood_reagent"]]
 		<br>\nDNA: [active2.fields["b_dna"]]<br>\n
 		<br>\nMinor Disabilities: [active2.fields["mi_dis"]]
 		<br>\nDetails: [active2.fields["mi_dis_d"]]<br>\n

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -304,14 +304,15 @@
 			var/blood_volume = H.vessel.get_reagent_amount("blood")
 			var/blood_percent =  round((blood_volume / H.species.blood_volume)*100)
 			var/blood_type = H.dna.b_type
+			var/blood_reagent = H.species.blood_reagents
 			if(blood_volume <= H.species.blood_volume*H.species.blood_level_danger)
-				dat += "<span class='danger'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl. Type: [blood_type]</i></span><br>"
+				dat += "<span class='danger'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl. Type: [blood_type]. Basis: [blood_reagent].</i></span><br>"
 			else if(blood_volume <= H.species.blood_volume*H.species.blood_level_warning)
-				dat += "<span class='danger'><i>Warning: Blood Level VERY LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]</i></span><br>"
+				dat += "<span class='danger'><i>Warning: Blood Level VERY LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]. Basis: [blood_reagent].</i></span><br>"
 			else if(blood_volume <= H.species.blood_volume*H.species.blood_level_safe)
-				dat += "<span class='danger'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
+				dat += "<span class='danger'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl. Type: [blood_type]. Basis: [blood_reagent].</span><br>"
 			else
-				dat += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
+				dat += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]. Basis: [blood_reagent].</span><br>"
 		dat += "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span><br>" // VORE Edit: Missed a linebreak here.
 		if(istype(H.species, /datum/species/xenochimera)) // VOREStation Edit Start: Visible feedback for medmains on Xenochimera.
 			if(H.stat == DEAD && H.revive_ready == REVIVING_READY && !H.hasnutriment())

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -5,6 +5,8 @@
 #define ORGANICS	1
 #define SYNTHETICS	2
 
+var/global/list/valid_bloodreagents = list("iron","copper","phoron","silver","gold","slimejelly")	//allowlist-based so people don't make their blood restored by alcohol or something really silly. use reagent IDs!
+
 /datum/preferences
 	var/custom_species	// Custom species name, can't be changed due to it having been used in savefiles already.
 	var/custom_base		// What to base the custom species on
@@ -115,6 +117,7 @@
 	S["neu_traits"]		>> pref.neu_traits
 	S["neg_traits"]		>> pref.neg_traits
 	S["blood_color"]	>> pref.blood_color
+	S["blood_reagents"]		>> pref.blood_reagents
 
 	S["traits_cheating"]	>> pref.traits_cheating
 	S["max_traits"]		>> pref.max_traits
@@ -135,6 +138,7 @@
 	S["neu_traits"]		<< pref.neu_traits
 	S["neg_traits"]		<< pref.neg_traits
 	S["blood_color"]	<< pref.blood_color
+	S["blood_reagents"]		<< pref.blood_reagents
 
 	S["traits_cheating"]	<< pref.traits_cheating
 	S["max_traits"]		<< pref.max_traits
@@ -154,6 +158,7 @@
 	if(!pref.neg_traits) pref.neg_traits = list()
 
 	pref.blood_color = sanitize_hexcolor(pref.blood_color, default="#A10808")
+	pref.blood_reagents	= sanitize_text(pref.blood_reagents, initial(pref.blood_reagents))
 
 	if(!pref.traits_cheating)
 		var/datum/species/S = GLOB.all_species[pref.species]
@@ -253,6 +258,7 @@
 
 	//Any additional non-trait settings can be applied here
 	new_S.blood_color = pref.blood_color
+	new_S.blood_reagents = pref.blood_reagents
 
 	if(pref.species == SPECIES_CUSTOM)
 		//Statistics for this would be nice
@@ -305,6 +311,8 @@
 	. += "<b>Blood Color: </b>" //People that want to use a certain species to have that species traits (xenochimera/promethean/spider) should be able to set their own blood color.
 	. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
 	. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
+	. += "<b>Blood Reagent: </b>"	//Wanna be copper-based? Go ahead.
+	. += "<a href='?src=\ref[src];blood_reagents=1'>[pref.blood_reagents]</a><br>"
 	. += "<br>"
 
 	. += "<b>Custom Say: </b>"
@@ -361,6 +369,12 @@
 		if(choice == "Reset")
 			pref.blood_color = "#A10808"
 		return TOPIC_REFRESH
+
+	else if(href_list["blood_reagents"])
+		var/new_blood_reagents = tgui_input_list(user, "Choose your character's blood restoration reagent:", "Character Preference", valid_bloodreagents)
+		if(new_blood_reagents && CanUseTopic(user))
+			pref.blood_reagents = new_blood_reagents
+			return TOPIC_REFRESH
 
 	else if(href_list["clicked_pos_trait"])
 		var/datum/trait/trait = text2path(href_list["clicked_pos_trait"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -44,6 +44,7 @@ var/list/preferences_datums = list()
 	var/bday_announce = FALSE			//Public announcement for birthdays
 	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
 	var/b_type = "A+"					//blood type (not-chooseable)
+	var/blood_reagents = "iron"				//blood restoration reagents
 	var/backbag = 2						//backpack type
 	var/pdachoice = 1					//PDA type
 	var/h_style = "Bald"				//Hair type

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -508,7 +508,7 @@
 						if (R.fields["id"] == E.fields["id"])
 							if(hasHUD(usr,"medical"))
 								var/list/medical_hud_text = list()
-								medical_hud_text += "<b>Name:</b> [R.fields["name"]]	<b>Blood Type:</b> [R.fields["b_type"]]"
+								medical_hud_text += "<b>Name:</b> [R.fields["name"]]	<b>Blood Type:</b> [R.fields["b_type"]]	<b>Blood Basis:</b> [R.fields["blood_reagent"]]"
 								medical_hud_text += "<b>Species:</b> [R.fields["species"]]"
 								medical_hud_text += "<b>DNA:</b> [R.fields["b_dna"]]"
 								medical_hud_text += "<b>Minor Disabilities:</b> [R.fields["mi_dis"]]"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -42,6 +42,7 @@
 	var/virus_immune
 	var/short_sighted										// Permanent weldervision.
 	var/blood_name = "blood"								// Name for the species' blood.
+	var/blood_reagents = "iron"								// Reagent(s) that restore lost blood. goes by reagent IDs.
 	var/blood_volume = 560									// Initial blood volume.
 	var/bloodloss_rate = 1									// Multiplier for how fast a species bleeds out. Higher = Faster
 	var/blood_level_safe = 0.85								//"Safe" blood level; above this, you're OK

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -36,6 +36,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	assisted_langs = list(LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	// Prometheans are weird, let's just assume they can use basically any language.
 
 	blood_name = "gelatinous ooze"
+	blood_reagents = "slimejelly"
 
 	breath_type = null
 	poison_type = null

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -314,6 +314,7 @@
 	flash_mod = 1.2
 	chemOD_mod = 0.9
 
+	blood_reagents = "copper"
 	bloodloss_rate = 1.5
 
 	ambiguous_genders = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -201,6 +201,7 @@
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 	blood_color = "#240bc4"
+	blood_reagents = "copper"
 	reagent_tag = IS_ZORREN
 	color_mult = 1
 

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -180,6 +180,8 @@
 
 /datum/reagent/proc/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	M.bloodstr.add_reagent(id, removed)
+	if(src.id == M.species.blood_reagents)
+		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 	return
 
 /datum/reagent/proc/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -79,10 +79,6 @@
 	taste_description = "pennies"
 	color = "#6E3B08"
 
-/datum/reagent/copper/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_SKRELL || alien == IS_ZORREN)
-		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
-
 /datum/reagent/ethanol
 	name = "Ethanol" //Parent class for all alcoholic reagents.
 	id = "ethanol"
@@ -245,10 +241,6 @@
 	taste_description = "metal"
 	reagent_state = SOLID
 	color = "#353535"
-
-/datum/reagent/iron/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien != IS_DIONA && alien != IS_SKRELL && alien != IS_ZORREN)
-		M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 
 /datum/reagent/lithium
 	name = "Lithium"


### PR DESCRIPTION
Expands on #15361 by bumping the blood-regen handling up a level and comparing the reagent id to a species-level blood_reagent variable for regen purposes.

You can set your blood regen reagent under the VORE tab alongside blood colour, from a list of pre-approved types. Your chosen reagent will be shown on health analyzers and in your medical records.

Also makes slime jelly the default blood regen reagent for prometheans because why not?