### PR TITLE
fix: Fixes ghosts being able to interact with NIFs

### DIFF
--- a/code/modules/nifsoft/nif_tgui.dm
+++ b/code/modules/nifsoft/nif_tgui.dm
@@ -98,6 +98,8 @@
  * Standard TGUI stub to open the NIF.js template.
  */
 /obj/item/device/nif/tgui_interact(mob/user, datum/tgui/ui, datum/tgui/parent_ui)
+	if(!isliving(user)
+		return FALSE
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NIF", name)


### PR DESCRIPTION
/atom/proc/attack_ghost() should call examine()

However, /obj/ redefines attack_ghost() to first attempt to call TGUI then call examine.

Unfortunately, NIFs do not have a ghost screen given their TGUI interface should be inaccessible until they're implanted.

The only way to access their TGUI interface unless they're implanted is ghost_attack, therefore we just make sure we're mob/living to block that.

I checked borg/AI attacks, they're safe