### PR TITLE
fix(nif_tgui): Fixes TGUI interact on ghosts

### DIFF
--- a/code/modules/nifsoft/nif_tgui.dm
+++ b/code/modules/nifsoft/nif_tgui.dm
@@ -98,6 +98,8 @@
  * Standard TGUI stub to open the NIF.js template.
  */
 /obj/item/device/nif/tgui_interact(mob/user, datum/tgui/ui, datum/tgui/parent_ui)
+	if(!ishuman(user))
+		return FALSE
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NIF", name)


### PR DESCRIPTION
Normally, TGUI is fine to be observed by ghosts - thus attack_ghost() calls it on left click in addition to examining.

Unfortunately, NIFs require ishuman() vars to be accessed, causing runtime errors.

Unfortunately x2, the way TGUI is set-up, observers override tgui_state checks that would enforce ishuman() state checks.

Therefore, we must modify tgui_interact to reject attempts to call the interface for non-human mobs.