### PR TITLE
Updated Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     unzip \
     make \
     libstdc++6 \
-    && curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip \
+    && curl "https://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip \
     && unzip byond.zip \
     && cd byond \
     && sed -i 's|install:|&\n\tmkdir -p $(MAN_DIR)/man6|' Makefile \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM tgstation/byond:513.1533 as base
+FROM i386/ubuntu:xenial as base
+
+ARG BYOND_MAJOR=514
+ARG BYOND_MINOR=1589
+
+RUN apt-get update \
+    && apt-get install -y \
+    curl \
+    unzip \
+    make \
+    libstdc++6 \
+    && curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip \
+    && unzip byond.zip \
+    && cd byond \
+    && sed -i 's|install:|&\n\tmkdir -p $(MAN_DIR)/man6|' Makefile \
+    && make install \
+    && chmod 644 /usr/local/byond/man/man6/* \
+    && apt-get purge -y --auto-remove curl unzip make \
+    && cd .. \
+    && rm -rf byond byond.zip /var/lib/apt/lists/*
 
 FROM base as rust_g
 
@@ -16,7 +35,7 @@ RUN apt-get install -y --no-install-recommends \
     gcc-multilib \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu \
     && git init \
-    && git remote add origin https://github.com/tgstation/rust-g
+    && git remote add origin https://github.com/VOREStation/rust-g
 
 COPY _build_dependencies.sh .
 
@@ -52,8 +71,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /root/.byond/bin
 
-COPY --from=rust_g /rust_g/target/release/librust_g.so /root/.byond/bin/rust_g
 COPY --from=build /vorestation/ ./
+COPY --from=rust_g /rust_g/target/release/librust_g.so ./librust_g.so
 
 #VOLUME [ "/vorestation/config", "/vorestation/data" ]
 


### PR DESCRIPTION
Changes:

- Replaced the dependency on the tgstation Byond build by integrating their docker file from https://github.com/tgstation/byond-docker/blob/master/Dockerfile directly to no longer being reliant on prebuild Byond images. Any major and minor version of Byond can now be selected directly.

- Changed the remote origin of the rust-g repository to use the vorestation fork instead of the original tgstation repository.

- Changed the rust_g copy of the compiled file to use the new format and direct location which the game looks for first.

- Swapped the copy order of the vorestation files and the librust_g.so.

The latter change was necessary as during the copy command, the vorestation pre-compiled librust_g.so gets copied over. This one causes issues though. (Seemingly compatibility as neither Log_Write nor File_Write works and are the most visible ones throwing errors). As the game first looked in that directory, the rust_g file wasn't used and to get the game to use it, the librust_g.so has to be deleted. It's much easier to simply overwrite the copied over librust_g.so with the newly compiled one.