### PR TITLE
Time: Stamped

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -17,6 +17,7 @@
 	S["tgui_input_lock"]		>> pref.tgui_input_lock
 	S["tgui_large_buttons"]		>> pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	>> pref.tgui_swapped_buttons
+	S["chat_timestamp"]			>> pref.chat_timestamp
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]				<< pref.UI_style
@@ -33,6 +34,7 @@
 	S["tgui_input_lock"]		<< pref.tgui_input_lock
 	S["tgui_large_buttons"]		<< pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	<< pref.tgui_swapped_buttons
+	S["chat_timestamp"]			<< pref.chat_timestamp
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style			= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
@@ -49,6 +51,7 @@
 	pref.tgui_input_lock	= sanitize_integer(pref.tgui_input_lock, 0, 1, initial(pref.tgui_input_lock))
 	pref.tgui_large_buttons	= sanitize_integer(pref.tgui_large_buttons, 0, 1, initial(pref.tgui_large_buttons))
 	pref.tgui_swapped_buttons	= sanitize_integer(pref.tgui_swapped_buttons, 0, 1, initial(pref.tgui_swapped_buttons))
+	pref.chat_timestamp		= sanitize_integer(pref.chat_timestamp, 0, 1, initial(pref.chat_timestamp))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. = "<b>UI Style:</b> <a href='?src=\ref[src];select_style=1'><b>[pref.UI_style]</b></a><br>"
@@ -65,6 +68,7 @@
 	. += "<b>TGUI Input Lock:</b> <a href='?src=\ref[src];tgui_input_lock=1'><b>[(pref.tgui_input_lock) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	. += "<b>TGUI Large Buttons:</b> <a href='?src=\ref[src];tgui_large_buttons=1'><b>[(pref.tgui_large_buttons) ? "Enabled (default)" : "Disabled"]</b></a><br>"
 	. += "<b>TGUI Swapped Buttons:</b> <a href='?src=\ref[src];tgui_swapped_buttons=1'><b>[(pref.tgui_swapped_buttons) ? "Enabled" : "Disabled (default)"]</b></a><br>"
+	. += "<b>Chat Timestamps:</b> <a href='?src=\ref[src];chat_timestamps=1'><b>[(pref.chat_timestamp) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b>"
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -148,6 +152,10 @@
 
 	else if(href_list["tgui_swapped_buttons"])
 		pref.tgui_swapped_buttons = !pref.tgui_swapped_buttons
+		return TOPIC_REFRESH
+
+	else if(href_list["chat_timestamps"])
+		pref.chat_timestamp = !pref.chat_timestamp
 		return TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -32,6 +32,7 @@ var/list/preferences_datums = list()
 	var/tgui_input_lock = FALSE
 	var/tgui_large_buttons = TRUE
 	var/tgui_swapped_buttons = FALSE
+	var/chat_timestamp = FALSE
 
 	//character preferences
 	var/real_name						//our character's name

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -390,6 +390,16 @@
 	to_chat(src, span_notice("You have toggled TGUI input lock: [prefs.tgui_input_lock ? "ON" : "OFF"] \n \
 	This setting determines whether pressing enter on TGUI input sends the input, or creates a newline."))
 
+/client/verb/toggle_chat_timestamps()
+	set name = "Toggle Chat Timestamps"
+	set category = "Preferences"
+	set desc = "Toggles whether or not messages in chat will display timestamps. Enabling this will not add timestamps to messages that have already been sent."
+
+	prefs.chat_timestamp = !prefs.chat_timestamp	//There is no preference datum for tgui input lock, nor for any TGUI prefs.
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	to_chat(src, span_notice("You have toggled chat timestamps: [prefs.chat_timestamp ? "ON" : "OFF"]."))
+
 /client/verb/toggle_status_indicators()
 	set name = "Toggle Status Indicators"
 	set category = "Preferences"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -138,15 +138,28 @@
 		ai_holder.on_hear_say(speaker, multilingual_to_message(message_pieces))
 
 /mob/proc/on_hear_say(var/message)
-	to_chat(src, "<span class='game say'>[message]</span>")
-	if(teleop)
+	var/time = say_timestamp()
+	if(client)
+		if(client.prefs.chat_timestamp)
+			to_chat(src, "<span class='game say'>[time] [message]</span>")
+		else
+			to_chat(src, "<span class='game say'>[message]</span>")
+	else if(teleop)
 		to_chat(teleop, "<span class='game say'>[create_text_tag("body", "BODY:", teleop.client)][message]</span>")
+	else
+		to_chat(src, "<span class='game say'>[message]</span>")
 
 /mob/living/silicon/on_hear_say(var/message)
 	var/time = say_timestamp()
-	to_chat(src, "<span class='game say'>[time] [message]</span>")
-	if(teleop)
-		to_chat(teleop, "<span class='game say'>[create_text_tag("body", "BODY:", teleop.client)][time] [message]</span>")
+	if(client)
+		if(client.prefs.chat_timestamp)
+			to_chat(src, "<span class='game say'>[time] [message]</span>")
+		else
+			to_chat(src, "<span class='game say'>[message]</span>")
+	else if(teleop)
+		to_chat(teleop, "<span class='game say'>[create_text_tag("body", "BODY:", teleop.client)][message]</span>")
+	else
+		to_chat(src, "<span class='game say'>[message]</span>")
 
 // Checks if the mob's own name is included inside message.  Handles both first and last names.
 /mob/proc/check_mentioned(var/message)
@@ -199,7 +212,7 @@
 		on_hear_radio(part_a, part_b, speaker_name, track, part_c, message, part_d, part_e)
 
 /proc/say_timestamp()
-	return "<span class='say_quote'>\[[stationtime2text()]\]</span>"
+	return "<span class='say_quote'>\[[time2text(world.timeofday, "hh:mm")]\]</span>"
 
 /mob/proc/on_hear_radio(part_a, part_b, speaker_name, track, part_c, formatted, part_d, part_e)
 	var/final_message = "[part_b][speaker_name][part_c][formatted][part_d]"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -46,6 +46,7 @@
 	return ..()
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
+	var/time = say_timestamp()
 
 	if(!client && !teleop)	return
 
@@ -68,9 +69,12 @@
 	if(stat == UNCONSCIOUS || sleeping > 0)
 		to_chat(src, "<span class='filter_notice'><I>... You can almost hear someone talking ...</I></span>")
 	else
-		to_chat(src,msg)
-		if(teleop)
+		if(client.prefs.chat_timestamp)
+			to_chat(src,"[time] [msg]")
+		else if(teleop)
 			to_chat(teleop, create_text_tag("body", "BODY:", teleop.client) + "[msg]")
+		else
+			to_chat(src,msg)
 	return
 
 // Show a message to all mobs and objects in sight of this one


### PR DESCRIPTION
Adds optional timestamps in local/user time (defaults to off) to many common messages, most notably say/whisper/emote/subtle, It will also apply to a few other messages, but there are many cases where it won't such as the many and various uses of visible_message. I didn't feel like untangling all of those, and honestly they're not the focus of this.

If people reaaaaaally want timestamps on visible_messages too I can see about trying to wrangle that, but it could get messy. to_chat is another bucket of fish entirely and would be way more extensive, so I don't think that's feasible.

This also changes timestamps on AI/cyborg/silicon messages to be local/user time, and makes them toggled by the timestamp pref.