### PR TITLE
HOT Paper Scooping ACTION: the SEQUEL

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -59,11 +59,12 @@
 
 	return
 
-/obj/item/weapon/clipboard/afterattack(turf/T as turf)
+/obj/item/weapon/clipboard/afterattack(turf/T as turf, mob/user as mob)
 	for(var/obj/item/weapon/paper/P in T)
 		P.loc = src
 		toppaper = P
 		update_icon()
+		to_chat(user, "<span class='notice'>You clip the [P] onto \the [src].</span>")
 
 /obj/item/weapon/clipboard/attack_self(mob/user as mob)
 	var/dat = "<title>Clipboard</title>"

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -75,10 +75,11 @@
 			name = "folder[(n_name ? text("- '[n_name]'") : null)]"
 	return
 
-/obj/item/weapon/folder/afterattack(turf/T as turf)
+/obj/item/weapon/folder/afterattack(turf/T as turf, mob/user as mob)
 	for(var/obj/item/weapon/paper/P in T)
 		P.loc = src
 		update_icon()
+		to_chat(user, "<span class='notice'>You tuck the [P] into \the [src].</span>")
 
 /obj/item/weapon/folder/attack_self(mob/user as mob)
 	var/dat = "<title>[name]</title>"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -525,6 +525,18 @@
 		tape.stick(src, user)
 		return
 
+	if(istype(P, /obj/item/weapon/clipboard))
+		var/obj/item/weapon/clipboard/CB = P
+		src.loc = CB
+		CB.toppaper = src
+		CB.update_icon()
+		to_chat(user, "<span class='notice'>You clip the [src] onto \the [CB].</span>")
+
+	if(istype(P, /obj/item/weapon/folder))
+		src.loc = P
+		P.update_icon()
+		to_chat(user, "<span class='notice'>You tuck the [src] into \the [P].</span>")
+
 	if(istype(P, /obj/item/weapon/paper) || istype(P, /obj/item/weapon/photo))
 		if (istype(P, /obj/item/weapon/paper/carbon))
 			var/obj/item/weapon/paper/carbon/C = P


### PR DESCRIPTION
Some slight improvements to #15343; adds chat feedback when scooping papers with a clipboard or folder, and also allows you to use a clipboard or folder on a paper to pick it up, as an inverse of using papers on clipboards/folders.