### PR TITLE
Throw Notices

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -18,6 +18,7 @@
 	S["tgui_large_buttons"]		>> pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	>> pref.tgui_swapped_buttons
 	S["chat_timestamp"]			>> pref.chat_timestamp
+	S["throwmode_loud"]			>> pref.throwmode_loud
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]				<< pref.UI_style
@@ -35,6 +36,7 @@
 	S["tgui_large_buttons"]		<< pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	<< pref.tgui_swapped_buttons
 	S["chat_timestamp"]			<< pref.chat_timestamp
+	S["throwmode_loud"]			<< pref.throwmode_loud
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style			= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
@@ -52,6 +54,7 @@
 	pref.tgui_large_buttons	= sanitize_integer(pref.tgui_large_buttons, 0, 1, initial(pref.tgui_large_buttons))
 	pref.tgui_swapped_buttons	= sanitize_integer(pref.tgui_swapped_buttons, 0, 1, initial(pref.tgui_swapped_buttons))
 	pref.chat_timestamp		= sanitize_integer(pref.chat_timestamp, 0, 1, initial(pref.chat_timestamp))
+	pref.throwmode_loud		= sanitize_integer(pref.throwmode_loud, 0, 1, initial(pref.throwmode_loud))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. = "<b>UI Style:</b> <a href='?src=\ref[src];select_style=1'><b>[pref.UI_style]</b></a><br>"
@@ -69,6 +72,7 @@
 	. += "<b>TGUI Large Buttons:</b> <a href='?src=\ref[src];tgui_large_buttons=1'><b>[(pref.tgui_large_buttons) ? "Enabled (default)" : "Disabled"]</b></a><br>"
 	. += "<b>TGUI Swapped Buttons:</b> <a href='?src=\ref[src];tgui_swapped_buttons=1'><b>[(pref.tgui_swapped_buttons) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	. += "<b>Chat Timestamps:</b> <a href='?src=\ref[src];chat_timestamps=1'><b>[(pref.chat_timestamp) ? "Enabled" : "Disabled (default)"]</b></a><br>"
+	. += "<b>Throw Mode Messages:</b> <a href='?src=\ref[src];throwmode_loudness=1'><b>[(pref.throwmode_loud) ? "Loud" : "Quiet (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b>"
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -156,6 +160,10 @@
 
 	else if(href_list["chat_timestamps"])
 		pref.chat_timestamp = !pref.chat_timestamp
+		return TOPIC_REFRESH
+
+	else if(href_list["throwmode_loudness"])
+		pref.throwmode_loud = !pref.throwmode_loud
 		return TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -33,6 +33,7 @@ var/list/preferences_datums = list()
 	var/tgui_large_buttons = TRUE
 	var/tgui_swapped_buttons = FALSE
 	var/chat_timestamp = FALSE
+	var/throwmode_loud = FALSE
 
 	//character preferences
 	var/real_name						//our character's name

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -400,6 +400,16 @@
 
 	to_chat(src, span_notice("You have toggled chat timestamps: [prefs.chat_timestamp ? "ON" : "OFF"]."))
 
+/client/verb/toggle_throwmode_messages()
+	set name = "Toggle Throw Mode Messages"
+	set category = "Preferences"
+	set desc = "Toggles whether or not activating throw mode (hotkey: R) will announce you're preparing to throw your current handheld item, or catch an incoming item if your hand is empty."
+
+	prefs.throwmode_loud = !prefs.throwmode_loud	//There is no preference datum for tgui input lock, nor for any TGUI prefs.
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	to_chat(src, span_notice("You have toggled throw mode messages: [prefs.throwmode_loud ? "ON" : "OFF"]."))
+
 /client/verb/toggle_status_indicators()
 	set name = "Toggle Status Indicators"
 	set category = "Preferences"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1149,11 +1149,16 @@
 
 /mob/proc/throw_mode_off()
 	src.in_throw_mode = 0
+	src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
 	if(src.throw_icon) //in case we don't have the HUD and we use the hotkey
 		src.throw_icon.icon_state = "act_throw_off"
 
 /mob/proc/throw_mode_on()
 	src.in_throw_mode = 1
+	if(src.get_active_hand())
+		src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
+	else
+		src.visible_message("<span class='warning'>[src] looks ready to catch anything thrown at them!</span>","<span class='notice'>You get ready to catch anything thrown at you.</span>")
 	if(src.throw_icon)
 		src.throw_icon.icon_state = "act_throw_on"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1149,16 +1149,20 @@
 
 /mob/proc/throw_mode_off()
 	src.in_throw_mode = 0
-	src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
+	if(client)
+		if(client.prefs.throwmode_loud)
+			src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
 	if(src.throw_icon) //in case we don't have the HUD and we use the hotkey
 		src.throw_icon.icon_state = "act_throw_off"
 
 /mob/proc/throw_mode_on()
 	src.in_throw_mode = 1
-	if(src.get_active_hand())
-		src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
-	else
-		src.visible_message("<span class='warning'>[src] looks ready to catch anything thrown at them!</span>","<span class='notice'>You get ready to catch anything thrown at you.</span>")
+	if(client)
+		if(client.prefs.throwmode_loud)
+			if(src.get_active_hand())
+				src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
+			else
+				src.visible_message("<span class='warning'>[src] looks ready to catch anything thrown at them!</span>","<span class='notice'>You get ready to catch anything thrown at you.</span>")
 	if(src.throw_icon)
 		src.throw_icon.icon_state = "act_throw_on"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1150,7 +1150,7 @@
 /mob/proc/throw_mode_off()
 	src.in_throw_mode = 0
 	if(client)
-		if(client.prefs.throwmode_loud)
+		if(a_intent == I_HELP || client.prefs.throwmode_loud)
 			src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
 	if(src.throw_icon) //in case we don't have the HUD and we use the hotkey
 		src.throw_icon.icon_state = "act_throw_off"
@@ -1158,7 +1158,7 @@
 /mob/proc/throw_mode_on()
 	src.in_throw_mode = 1
 	if(client)
-		if(client.prefs.throwmode_loud)
+		if(a_intent == I_HELP || client.prefs.throwmode_loud)
 			if(src.get_active_hand())
 				src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
 			else


### PR DESCRIPTION
Adds visible_message prompts when you go to activate throw mode, showing nearby characters whether you're about to throw something or if you're ready to catch something.

![image](https://cdn.discordapp.com/attachments/1138986141190729821/1153836861786177597/image.png)

Could be gamed slightly by preparing to throw with an empty hand, then switching, but I feel like that's better than no notice at all.