### PR TITLE
Edible retaliate mobs

### DIFF
--- a/code/modules/ai/ai_holder_subtypes/simple_mob_ai.dm
+++ b/code/modules/ai/ai_holder_subtypes/simple_mob_ai.dm
@@ -18,6 +18,7 @@
 	can_flee = TRUE
 	violent_breakthrough = FALSE
 	base_wander_delay = 8 //vorestation edit, to make pets slow.
+	belly_attack = FALSE //They already don't fight back, so this ensures that catgirls and similar are still edible when they are spawned as retaliate or aggressive by semi-random mob spawners.
 
 // Won't wander away as quickly, ideal for event-spawned mobs like carp or drones.
 /datum/ai_holder/simple_mob/event
@@ -149,6 +150,9 @@
 
 /datum/ai_holder/simple_mob/retaliate/chill
 	base_wander_delay = 8
+
+/datum/ai_holder/simple_mob/retaliate/edible
+	belly_attack = FALSE
 
 // Simple mobs that retaliate and support others in their faction who get attacked.
 /datum/ai_holder/simple_mob/retaliate/cooperative

--- a/code/modules/ai/ai_holder_targeting_vr.dm
+++ b/code/modules/ai/ai_holder_targeting_vr.dm
@@ -11,6 +11,9 @@
 	forgive_resting = TRUE
 	cooperative = FALSE
 
+/datum/ai_holder/simple_mob/vore/edible
+	belly_attack = FALSE
+
 /datum/ai_holder/simple_mob/vore/micro_hunter
 	micro_hunt = TRUE
 	micro_hunt_size = 0.8

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
@@ -131,6 +131,7 @@
 	retaliate = TRUE
 	speak_chance = 0.5
 	wander = TRUE
+	belly_attack = FALSE
 
 /mob/living/simple_mob/vore/alienanimals/catslug/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
@@ -40,7 +40,7 @@
 	attacktext = list("nipped", "squeaked at")
 	friendly = list("nuzzles", "nibbles", "leans on")
 
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate/edible
 
 	has_langs = list(LANGUAGE_ANIMAL)
 	say_list_type = /datum/say_list/squirrel

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bat.dm
@@ -17,7 +17,7 @@
 	attacktext = list("bites","scratches")
 
 	say_list_type = /datum/say_list/bat
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate/edible
 
 	faction = "vampire"
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/peasant.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/peasant.dm
@@ -17,7 +17,7 @@
 	attacktext = list("punched","kicked")
 
 	say_list_type = /datum/say_list/peasant
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate/edible
 
 	var/random_skin = 1
 	var/list/skins = list(

--- a/code/modules/mob/living/simple_mob/subtypes/vore/sheep.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/sheep.dm
@@ -33,7 +33,7 @@
 	mount_offset_x = 0
 
 	say_list_type = /datum/say_list/sheep
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate/edible
 
 //	var/harvestable_wool = TRUE			//Relating to wool growth and shearing down below.
 //	var/wool_growth = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
@@ -17,7 +17,7 @@
 	attacktext = list("swatted","bapped")
 
 	say_list_type = /datum/say_list/succubus
-	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate/edible
 
 	var/random_skin = 1
 	var/list/skins = list(

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
@@ -16,7 +16,7 @@
 	attacktext = list("bites","sucks","drinks from")
 
 	say_list_type = /datum/say_list/count
-	ai_holder_type = /datum/ai_holder/simple_mob/vore
+	ai_holder_type = /datum/ai_holder/simple_mob/vore/edible
 
 	var/random_skin = 1
 	var/list/skins = list(

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolfgirl.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolfgirl.dm
@@ -30,6 +30,9 @@
 	vore_pounce_chance = 40
 	vore_icons = SA_ICON_LIVING
 
+/datum/ai_holder/simple_mob/retaliate/cooperative/wolfgirl
+	belly_attack = FALSE
+
 /datum/ai_holder/simple_mob/retaliate/cooperative/wolfgirl/on_hear_say(mob/living/speaker, message)
 
 	if(!speaker.client)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
@@ -66,6 +66,7 @@
 
 /datum/ai_holder/simple_mob/retaliate/wolftaur
 	base_wander_delay = 8
+	belly_attack = FALSE
 
 /mob/living/simple_mob/vore/wolftaur/init_vore()
 	..()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4272,6 +4272,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
+#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4272,6 +4272,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
Makes some mobs that are retaliate or vore hostile stop fighting whilst inside a belly. Specifically: Squirrels, bats, peasants, sheep, succubi, vampires, wolfgirls and wolftaurs.

Also adds this to passive mobs, which won't change anything normally as they don't fight when eaten. However, it will mean that catgirls and lamia, which are normally passive, will stop fighting in a belly if spawned via the semirandom mob spawner.