### PR TITLE
Fix for specific wolftaur and vampire icon states

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/bat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bat.dm
@@ -5,6 +5,9 @@
 
 	icon_state = "bat"
 	icon = 'icons/mob/vore.dmi'
+	icon_living = "bat"
+	icon_rest = "batasleep"
+	icon_dead = "bat-dead"
 
 	harm_intent_damage = 5
 	melee_damage_lower = 2

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
@@ -8,6 +8,8 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 3
 	melee_damage_upper = 7
+	maxHealth = 150
+	health = 150
 
 	response_help = "caresses"
 	response_disarm = "wafts"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vampire.dm
@@ -71,15 +71,27 @@
 /mob/living/simple_mob/vore/vampire/count
 	random_skin = 0
 	icon_state = "count"
+	icon_living = "count"
+	icon_rest = "countasleep"
+	icon_dead = "count-dead"
 
 /mob/living/simple_mob/vore/vampire/countess
 	random_skin = 0
 	icon_state = "countess"
+	icon_living = "countess"
+	icon_rest = "countessasleep"
+	icon_dead = "countess-dead"
 
 /mob/living/simple_mob/vore/vampire/count_nude
 	random_skin = 0
 	icon_state = "countnude"
+	icon_living = "countnude"
+	icon_rest = "countnudeasleep"
+	icon_dead = "countnude-dead"
 
 /mob/living/simple_mob/vore/vampire/countess_nude
 	random_skin = 0
 	icon_state = "countessnude"
+	icon_living = "countessnude"
+	icon_rest = "countessnudeasleep"
+	icon_dead = "countessnude-dead"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
@@ -88,40 +88,70 @@
 	desc = "What the hell is this outfit!?"
 	icon_state = "wolftaurclown"
 	random_skin = 0
+	icon_living = "wolftaurclown"
+	icon_rest = "wolftaurclown_rest"
+	icon_dead = "wolftaurclown-dead"
 
 /mob/living/simple_mob/vore/wolftaur/white
 	icon_state = "wolftaurwhite"
 	random_skin = 0
+	icon_living = "wolftaurwhite"
+	icon_rest = "wolftaurwhite_rest"
+	icon_dead = "wolftaurwhite-dead"
 
 /mob/living/simple_mob/vore/wolftaur/whiteclothed
 	icon_state = "wolftaurwhitec"
 	random_skin = 0
+	icon_living = "wolftaurwhitec"
+	icon_rest = "wolftaurwhitec_rest"
+	icon_dead = "wolftaurwhitec-dead"
 
 /mob/living/simple_mob/vore/wolftaur/brown
 	icon_state = "wolftaurbrown"
 	random_skin = 0
+	icon_living = "wolftaurbrown"
+	icon_rest = "wolftaurbrown_rest"
+	icon_dead = "wolftaurbrown-dead"
 
 /mob/living/simple_mob/vore/wolftaur/brownclothed
 	icon_state = "wolftaurbrownc"
 	random_skin = 0
+	icon_living = "wolftaurbrownc"
+	icon_rest = "wolftaurbrownc_rest"
+	icon_dead = "wolftaurbrownc-dead"
 
 /mob/living/simple_mob/vore/wolftaur/black
 	icon_state = "wolftaurblack"
 	random_skin = 0
+	icon_living = "wolftaurblack"
+	icon_rest = "wolftaurblack_rest"
+	icon_dead = "wolftaurblack-dead"
 
 /mob/living/simple_mob/vore/wolftaur/blackclothed
 	icon_state = "wolftaurblackc"
 	random_skin = 0
+	icon_living = "wolftaurblackc"
+	icon_rest = "wolftaurblackc_rest"
+	icon_dead = "wolftaurblackc-dead"
 
 /mob/living/simple_mob/vore/wolftaur/red
 	icon_state = "wolftaurwood"
 	random_skin = 0
+	icon_living = "wolftaurwood"
+	icon_rest = "wolftaurwood_rest"
+	icon_dead = "wolftaurwood-dead"
 
 /mob/living/simple_mob/vore/wolftaur/redclothed
 	icon_state = "wolftaurwoodc"
 	random_skin = 0
+	icon_living = "wolftaurwoodc"
+	icon_rest = "wolftaurwoodc_rest"
+	icon_dead = "wolftaurwoodc-dead"
 
 /mob/living/simple_mob/vore/wolftaur/dark
 	icon_state = "wolftaurdark"
 	random_skin = 0
+	icon_living = "wolftaurdark"
+	icon_rest = "wolftaurdark_rest"
+	icon_dead = "wolftaurdark-dead"
 


### PR DESCRIPTION
Wolftaur and vampire mobs that were specifically chosen and not randomly picked did not have sprites chosen for living, rest and dead variables. This has been fixed.