### PR TITLE
Armour Examine Tweaks

### DIFF
--- a/code/modules/examine/descriptions/armor.dm
+++ b/code/modules/examine/descriptions/armor.dm
@@ -22,7 +22,7 @@
 
 /obj/item/clothing/proc/describe_slowdown()
 	switch(slowdown)
-		if(-1)
+		if(-INFINITY to -0.1)
 			return "It looks like it might actually make you faster!"
 		if(0 || null)
 			return "It doesn't look like it'll impede your mobility."

--- a/code/modules/examine/descriptions/armor.dm
+++ b/code/modules/examine/descriptions/armor.dm
@@ -20,6 +20,28 @@
 			if(100)
 				return "You would be immune to [descriptive_attack_type] if you wore this."
 
+/obj/item/clothing/proc/describe_slowdown()
+	switch(slowdown)
+		if(-1)
+			return "It looks like it might actually make you faster!"
+		if(0 || null)
+			return "It doesn't look like it'll impede your mobility."
+		if(0.5)
+			return "It might slow you down a little bit."
+		if(1)
+			return "It'll slow you down noticeably, but not too much."
+		if(1.5)
+			return "You'll be moving a fair bit slower than everyone else."
+		if(2)
+			return "Your speed will be noticeably impaired by its weight and inflexibility."
+		if(3)
+			return "You'd have a pretty hard time moving in it."
+		if(4)
+			return "It looks heavy enough to seriously impede your mobility."
+		if(5)
+			return "It's heavy enough that moving in it will be extremely difficult!"
+		else
+			return "It's difficult to tell how much it'll influence your speed."
 
 
 /obj/item/clothing/get_description_info()
@@ -43,25 +65,33 @@
 
 	armor_stats += "\n"
 
+	armor_stats += "[describe_slowdown()] \n"
+
 	if(flags & AIRTIGHT)
 		armor_stats += "It is airtight. \n"
 
-	if(min_pressure_protection == 0)
+	if(min_pressure_protection == 0 && max_pressure_protection >= WARNING_HIGH_PRESSURE)	//0 to 325
+		armor_stats += "Wearing this will protect you from the vacuum of space and from high pressures. \n"
+	else if(min_pressure_protection <= WARNING_LOW_PRESSURE && max_pressure_protection >= WARNING_HIGH_PRESSURE) //50 to 325
+		armor_stats += "Wearing this will protect you from both low and high pressures, but not the vacuum of space. \n"
+	else if(min_pressure_protection == 0)
 		armor_stats += "Wearing this will protect you from the vacuum of space. \n"
-	else if(min_pressure_protection != null)
+	else if(min_pressure_protection <= WARNING_LOW_PRESSURE) //50 or below
 		armor_stats += "Wearing this will protect you from low pressures, but not the vacuum of space. \n"
-
-	if(max_pressure_protection != null)
+	else if(max_pressure_protection >= WARNING_HIGH_PRESSURE) //325 or higher
 		armor_stats += "Wearing this will protect you from high pressures. \n"
 
-	if(flags & THICKMATERIAL)
+	if(flags & THICKMATERIAL)	//stops syringes
 		armor_stats += "The material is exceptionally thick. \n"
 
-	if(max_heat_protection_temperature == FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)
-		armor_stats += "It provides very good protection against fire and heat. \n"
-
-	if(min_cold_protection_temperature == SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE)
-		armor_stats += "It provides very good protection against very cold temperatures. \n"
+	if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //30000 or higher and as low as 2
+		armor_stats += "It provides exceptional protection from extremely high and low temperatures alike. \n"
+	else if(max_heat_protection_temperature >= SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //5000 or above, but less than 30000
+		armor_stats += "It provides very good protection against hazardous temperatures at both extremes, but may not be sufficient for very high-intensity situations. \n"
+	else if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)	//30000 or above
+		armor_stats += "It provides exceptional protection from extremely high temperatures. \n"
+	else if(min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE)	//2 or less
+		armor_stats += "It provides exceptional protection against very low temperatures. \n"
 
 	var/list/covers = list()
 	var/list/slots = list()


### PR DESCRIPTION
I had a thought the other day of adding slowdown/mobility adjustment to armour examines, and ended up sliding down a (small) rabbithole of refactoring some other bits in the process. Oops.

This PR:
- Adds clothing slowdown to examine.
- Adjusts some existing examine data to cut down on the number of lines, and provide more accurate/useful values (for example, atmos voidsuits weren't showing as protecting from extremely high temperatures when examined, as their temp protection *exceeds* 30,000).