### PR TITLE
Submap Compile Fix

### DIFF
--- a/maps/offmap_vr/om_ships/shelter_6.dmm
+++ b/maps/offmap_vr/om_ships/shelter_6.dmm
@@ -193,7 +193,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/tabiranth)
 "af" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	desc = "A large machine releasing a constant gust of air.";
 	icon = 'icons/obj/survival_pod.dmi';
 	icon_state = "fans";
@@ -1081,7 +1081,8 @@
 "bl" = (
 /obj/machinery/power/smes/buildable/hybrid{
 	input_level = 200000;
-	output_level = 200000
+	output_level = 200000;
+	recharge_rate = 20000
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"


### PR DESCRIPTION
While I was investigating an unrelated bug relating to deployable ships, I noticed there was a compile bug with one of the deployable ships. This fixes that. Also adds a bit more power to an adminbus ship.
