### PR TITLE
Scel and lunging

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/scel.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/scel.dm
@@ -71,7 +71,7 @@
 	vore_escape_chance = 5
 	vore_pounce_chance = 100
 	vore_active = 1
-	vore_icons = 2
+	vore_icons = 1
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 	vore_capacity = 2
 	swallowTime = 50
@@ -89,6 +89,7 @@
 	verbs |= /mob/living/proc/glow_toggle
 	verbs |= /mob/living/proc/glow_color
 	verbs |= /mob/living/proc/long_vore
+	verbs |= /mob/living/proc/target_lunge
 	movement_cooldown = -1
 
 /mob/living/simple_mob/vore/scel/init_vore()
@@ -143,6 +144,8 @@
 
 /mob/living/simple_mob/vore/scel/do_special_attack(atom/A)
 	. = TRUE
+	if(ckey)
+		return
 	if(prob(50))
 		lunge(A)
 	else


### PR DESCRIPTION
Added a new proc that imitates the leapers lunge attack, which can be given to mobs to use as an ability when player controlled.

Added the lunge ability to player controlled scel.

Fixed scel going invisible when they eat more than one prey.

Fixed scel automatically and randomly using special attacks when controlled by a player.

---
:cl:Upstream
add: added a new proc that imitates the leapers lunge attack, which can be given to mobs to use as an ability when player controlled.
add: added the lunge ability to player controlled scel.
fix: fixed scel going invisible when they eat more than one prey.
fix: fixed scel automatically and randomly using special attacks when controlled by a player.
/:cl: