### PR TITLE
Paper Scooping Minifix

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -527,12 +527,16 @@
 
 	if(istype(P, /obj/item/weapon/clipboard))
 		var/obj/item/weapon/clipboard/CB = P
+		if(src.loc == user)
+			user.drop_from_inventory(src)
 		src.loc = CB
 		CB.toppaper = src
 		CB.update_icon()
 		to_chat(user, "<span class='notice'>You clip the [src] onto \the [CB].</span>")
 
 	if(istype(P, /obj/item/weapon/folder))
+		if(src.loc == user)
+			user.drop_from_inventory(src)
 		src.loc = P
 		P.update_icon()
 		to_chat(user, "<span class='notice'>You tuck the [src] into \the [P].</span>")


### PR DESCRIPTION
Just a little fix for an edge-case I found whilst playing a few days ago. Fixes using a folder/clipboard on a paper that you're holding in your inactive hand not correctly removing the paper from  your hand.