### PR TITLE
Docking Code Changes

### DIFF
--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -5295,7 +5295,6 @@
 /obj/structure/closet/secure_closet/captains,
 /obj/item/clothing/glasses/omnihud/all,
 /obj/item/weapon/disk/nuclear,
-/obj/item/weapon/paper/dockingcodes/sd,
 /obj/item/device/retail_scanner/command,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -2840,7 +2840,6 @@
 	},
 /obj/structure/closet/secure_closet/hop,
 /obj/item/clothing/glasses/omnihud,
-/obj/item/weapon/paper/dockingcodes/sd,
 /obj/item/device/retail_scanner/command,
 /obj/item/weapon/storage/box/PDAs,
 /turf/simulated/floor/tiled,

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -28748,6 +28748,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/weapon/paper/dockingcodes,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aYu" = (
@@ -29011,7 +29012,6 @@
 /obj/item/device/flashlight/lamp/green{
 	pixel_x = -10
 	},
-/obj/item/weapon/paper/dockingcodes,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aZc" = (
@@ -29517,7 +29517,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/item/weapon/paper/dockingcodes,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "aZV" = (


### PR DESCRIPTION
- Removes docking codes from HOP/SM office
- Makes sure Docking Codes are on the bridge (Stellar Delight already had them, so they just needed to be added on Tether's bridge)
