### PR TITLE
Vore Panel Health Check

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -876,17 +876,26 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 		if("Health Check")
 			var/mob/living/carbon/human/H = target
 			var/target_health = round((H.health/H.getMaxHealth())*100)
+			var/condition
+			var/condition_consequences
 			to_chat(usr, "<span class= 'warning'>\The [target] is at [target_health]% health.</span>")
-			if(H.weakened)
-				to_chat(usr, "<span class= 'warning'>\The [target] is currently weakened, this does not stop them from hearing emotes or emoting themselves.</span>")
-			if(H.blinded && H.paralysis)
-				to_chat(usr, "<span class= 'warning'>\The [target] is currently blinded and paralysed, they will not be able to hear emotes or emote themselves.</span>")
-			else if(H.blinded)
-				to_chat(usr, "<span class= 'warning'>\The [target] is currently blind, they will not be able to see emotes.</span>")
-			else if(H.paralysis)
-				to_chat(usr, "<span class= 'warning'>\The [target] is currently paralysed, they will not be able to emote themselves.</span>")
+			if(H.blinded)
+				condition += "blinded"
+				condition_consequences += "hear emotes"
+			if(H.paralysis)
+				if(condition)
+					condition += " and "
+					condition_consequences += " or "
+				condition += "paralysed"
+				condition_consequences += "make emotes"
 			if(H.sleeping)
-				to_chat(usr, "<span class= 'warning'>\The [target] is currently sleeping, they will not be able to hear emotes or emote themselves.</span>")
+				if(condition)
+					condition += " and "
+					condition_consequences += " or "
+				condition += "sleeping"
+				condition_consequences += "hear or do anything"
+			if(condition)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently [condition], they will not be able to [condition_consequences].</span>")
 			return
 
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -726,6 +726,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 	var/list/available_options = list("Examine", "Eject", "Move", "Transfer")
 	if(ishuman(target))
 		available_options += "Transform"
+		available_options += "Health Check"
 	if(isliving(target))
 		var/mob/living/datarget = target
 		if(datarget.client)
@@ -872,12 +873,27 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					b.absorb_living(ourtarget)
 				if("Cancel")
 					return
+		if("Health Check")
+			var/mob/living/carbon/human/H = target
+			var/target_health = round((H.health/H.getMaxHealth())*100)
+			to_chat(usr, "<span class= 'warning'>\The [target] is at [target_health]% health.</span>")
+			if(H.weakened)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently weakened, this does not stop them from hearing emotes or emoting themselves.</span>")
+			if(H.blinded && H.paralysis)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently blinded and paralysed, they will not be able to hear emotes or emote themselves.</span>")
+			else if(H.blinded)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently blind, they will not be able to see emotes.</span>")
+			else if(H.paralysis)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently paralysed, they will not be able to emote themselves.</span>")
+			if(H.sleeping)
+				to_chat(usr, "<span class= 'warning'>\The [target] is currently sleeping, they will not be able to hear emotes or emote themselves.</span>")
+			return
+
 
 /datum/vore_look/proc/set_attr(mob/user, params)
 	if(!host.vore_selected)
 		tgui_alert_async(usr, "No belly selected to modify.")
 		return FALSE
-
 	var/attr = params["attribute"]
 	switch(attr)
 		if("b_name")


### PR DESCRIPTION
Added a new option to humanoid mobs in vore belly contents: Health Check.

Using this on a mob in your belly returns a very simple readout of their health as a percentage. It also gives notice when they are weakened, paralysed, blinded or sleeping, so that the pred can know whether or not they'll be able to emote/hear emotes.

![image](https://github.com/VOREStation/VOREStation/assets/98125273/50ea119f-7d32-46b5-8e56-0a7335427430)
![image](https://github.com/VOREStation/VOREStation/assets/98125273/b76fbe0b-a350-45f3-a19a-290399a9fbdb)
