### PR TITLE
Attempt to prevent players joining with neither OOC notes nor flavour

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -316,10 +316,8 @@ Proc for attack log creation, because really why not
 		. = getCompoundIcon(desired)
 		cached_character_icons[cachekey] = .
 
-//VOREStation Add Start
 /proc/not_has_ooc_text(mob/user)
 	if (config.allow_Metadata && (!user.client?.prefs?.metadata || length(user.client.prefs.metadata) < 15))
 		to_chat(user, "<span class='warning'>Please set informative OOC notes related to RP/ERP preferences. Set them using the 'OOC Notes' button on the 'General' tab in character setup.</span>")
 		return TRUE
 	return FALSE
-//VOREStation Add End

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -316,20 +316,10 @@ Proc for attack log creation, because really why not
 		. = getCompoundIcon(desired)
 		cached_character_icons[cachekey] = .
 
+//VOREStation Add Start
 /proc/not_has_ooc_text(mob/user)
 	if (config.allow_Metadata && (!user.client?.prefs?.metadata || length(user.client.prefs.metadata) < 15))
 		to_chat(user, "<span class='warning'>Please set informative OOC notes related to RP/ERP preferences. Set them using the 'OOC Notes' button on the 'General' tab in character setup.</span>")
 		return TRUE
 	return FALSE
-
-/proc/not_has_flavor_text(mob/user)
-	if (config.require_flavor && (!user.client?.prefs?.flavor_texts["general"] || length(user.client.prefs.flavor_texts["general"]) < 30))
-		to_chat(user, "<span class='warning'>Please set your general flavor text to give a basic description of your character. Set it using the 'Set Flavor text' button on the 'General' tab in character setup, and choosing 'General' category.</span>")
-		return TRUE
-	return FALSE
-
-/proc/not_has_flavor_text_robot(mob/user)
-	if (config.require_flavor && (!user.client?.prefs?.flavour_texts_robot["Default"] || length(user.client.prefs.flavour_texts_robot["Default"]) < 30))
-		to_chat(user, "<span class='warning'>Please set your default robot flavor text to give a basic description of your character. Set it using the 'Set Robot Flavor text' button on the 'General' tab in character setup, and choosing 'Default' category.</span>")
-		return TRUE
-	return FALSE
+//VOREStation Add End

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -219,7 +219,7 @@ Proc for attack log creation, because really why not
 	if(target?.flags & IS_BUSY)
 		to_chat(user, "<span class='warning'>Someone is already doing something with \the [target].</span>")
 		return FALSE
-		
+
 	var/atom/target_loc = null
 	if(target)
 		target_loc = target.loc
@@ -243,7 +243,7 @@ Proc for attack log creation, because really why not
 
 	if(exclusive & TASK_USER_EXCLUSIVE)
 		user.status_flags |= DOING_TASK
-	
+
 	if(target && (exclusive & TASK_TARGET_EXCLUSIVE))
 		target.flags |= IS_BUSY
 
@@ -315,3 +315,21 @@ Proc for attack log creation, because really why not
 	else
 		. = getCompoundIcon(desired)
 		cached_character_icons[cachekey] = .
+
+/proc/not_has_ooc_text(mob/user)
+	if (config.allow_Metadata && (!user.client?.prefs?.metadata || length(user.client.prefs.metadata) < 15))
+		to_chat(user, "<span class='warning'>Please set informative OOC notes related to RP/ERP preferences. Set them using the 'OOC Notes' button on the 'General' tab in character setup.</span>")
+		return TRUE
+	return FALSE
+
+/proc/not_has_flavor_text(mob/user)
+	if (config.require_flavor && (!user.client?.prefs?.flavor_texts["general"] || length(user.client.prefs.flavor_texts["general"]) < 30))
+		to_chat(user, "<span class='warning'>Please set your general flavor text to give a basic description of your character. Set it using the 'Set Flavor text' button on the 'General' tab in character setup, and choosing 'General' category.</span>")
+		return TRUE
+	return FALSE
+
+/proc/not_has_flavor_text_robot(mob/user)
+	if (config.require_flavor && (!user.client?.prefs?.flavour_texts_robot["Default"] || length(user.client.prefs.flavour_texts_robot["Default"]) < 30))
+		to_chat(user, "<span class='warning'>Please set your default robot flavor text to give a basic description of your character. Set it using the 'Set Robot Flavor text' button on the 'General' tab in character setup, and choosing 'Default' category.</span>")
+		return TRUE
+	return FALSE

--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -73,6 +73,10 @@
 		reset_ghostpod()
 		return
 
+	//No OOC notes
+	if (not_has_ooc_text(M))
+		return
+
 	while(finalized == "No" && M.client)
 		choice = tgui_input_list(M, "What type of predator do you want to play as?", "Maintpred Choice", possible_mobs)
 		if(!choice)	//We probably pushed the cancel button on the mob selection. Let's just put the ghost pod back in the list.
@@ -122,6 +126,11 @@
 
 /obj/structure/ghost_pod/ghost_activated/morphspawn/create_occupant(var/mob/M)
 	..()
+
+	//No OOC notes
+	if (not_has_ooc_text(M))
+		return
+
 	var/mob/living/simple_mob/vore/morph/newMorph = new /mob/living/simple_mob/vore/morph(get_turf(src))
 	if(M.mind)
 		M.mind.transfer_to(newMorph)

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -90,6 +90,11 @@
 	if(jobban_isbanned(user, "GhostRoles"))
 		to_chat(user, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 		return
+
+	//No OOC notes
+	if (not_has_ooc_text(user))
+		return
+
 	//VOREStation Add End
 	if(used)
 		to_chat(user, "<span class='warning'>Another spirit appears to have gotten to \the [src] before you.  Sorry.</span>")

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -15,6 +15,10 @@
 		to_chat(user, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 		return
 
+	//No OOC notes
+	if (not_has_ooc_text(user))
+		return
+
 	if(!remains_active || busy)
 		return
 

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -7,8 +7,13 @@
 		return TRUE
 
 	//No Flavor Text
-	if (config.require_flavor && !client?.prefs?.flavor_texts["general"] && !(J.mob_type & JOB_SILICON))
+	if (config.require_flavor && !(J.mob_type & JOB_SILICON) && (!client?.prefs?.flavor_texts["general"] || length(client.prefs.flavor_texts["general"]) < 30))
 		to_chat(src,"<span class='warning'>Please set your general flavor text to give a basic description of your character. Set it using the 'Set Flavor text' button on the 'General' tab in character setup, and choosing 'General' category.</span>")
+		pass = FALSE
+
+	//No Robot Flavor Text
+	if (config.require_flavor && (J.mob_type & JOB_SILICON) && (!client?.prefs?.flavour_texts_robot["Default"] || length(client.prefs.flavour_texts_robot["Default"]) < 30))
+		to_chat(src,"<span class='warning'>Please set your default robot flavor text to give a basic description of your character. Set it using the 'Set Robot Flavor text' button on the 'General' tab in character setup, and choosing 'Default' category.</span>")
 		pass = FALSE
 
 	//No OOC notes

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -11,11 +11,6 @@
 		to_chat(src,"<span class='warning'>Please set your general flavor text to give a basic description of your character. Set it using the 'Set Flavor text' button on the 'General' tab in character setup, and choosing 'General' category.</span>")
 		pass = FALSE
 
-	//No Robot Flavor Text
-	if (config.require_flavor && (J.mob_type & JOB_SILICON) && (!client?.prefs?.flavour_texts_robot["Default"] || length(client.prefs.flavour_texts_robot["Default"]) < 30))
-		to_chat(src,"<span class='warning'>Please set your default robot flavor text to give a basic description of your character. Set it using the 'Set Robot Flavor text' button on the 'General' tab in character setup, and choosing 'Default' category.</span>")
-		pass = FALSE
-
 	//No OOC notes
 	if (config.allow_Metadata && (!client?.prefs?.metadata || length(client.prefs.metadata) < 15))
 		to_chat(src,"<span class='warning'>Please set informative OOC notes related to RP/ERP preferences. Set them using the 'OOC Notes' button on the 'General' tab in character setup.</span>")


### PR DESCRIPTION
-> Flavour texts have now a minimum length. 30 characters should be doable by anyone. That's less than a sentence, but at least prevents the lazy single space joining.
Fixes  #15426

-> Added helpers for mob checks for OOC notes.

-> Added a check using the OOC helper for OOC notes texts for ghosts trying to activate a ghost pod or during ghost spawn events.

-> Mouses and drones have not been included for either as some players prefer to play them sneakily. Can be discussed further.

(Please review / test as I only could test a few of the ghost pods and haven't used the admin event panel before)