### PR TITLE
Makes it so when "handle"-ing an ahelp as staff, a message is sent to discord

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -424,13 +424,14 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin(msg)
 	AddInteraction("[key_name_admin(usr)] is now handling this ticket.")
-	SSwebhooks.send(
-		WEBHOOK_AHELP_SENT,
-		list(
-			"name" = "Ticket ([id]) (Game ID: [game_id]) being handled.",
-			"body" = "[key_name(usr)] is now handling the ticket."
-		)
-	)
+	var/query_string = "type=admintake"
+	query_string += "&key=[url_encode(config.chat_webhook_key)]"
+	query_string += "&admin=[url_encode(key_name_admin(usr))]"
+	query_string += "&user=[url_encode(key_name(initiator))]"
+	world.Export("[config.chat_webhook_url]?[query_string]")
+
+
+
 
 //Show the ticket panel
 /datum/admin_help/proc/TicketPanel()


### PR DESCRIPTION
### What this does

When a player makes an ahelp, one of the options for responding is the "handle" button. Presently, it only informs other staff that is online. This was meant to also notify the discord chat as well.

Using the world.Export() logic that was proven to work for fax "take" button, pressing "handle" will notify the discord chat of an issue being handled from now on.

### Why we need this

Logging in to assist with an ahelp if it's already being taken care of can be frustrating, and NOT logging in because you think the staff online are taking care of it is very frustrating for the player.

While we already have an informal habit to check mark or otherwise note we're handling an ahelp, making it easier by just pressing a button in-game without having to tab out to discord will make it much more convenient for the staff member handling it.

### How this will look like

Basically same as it does for fax messages, except with the ahelp preview rather than the fax preview

![image](https://github.com/VOREStation/VOREStation/assets/20523270/53b88801-471b-493a-8100-229015a522ac)


the censored sections for the handling message being
admin ckey/character name
sender ckey/character name

### IMPORTANT NOTES

As it works using webhook, I could not test it beyond log_debug checking the query string to make sure it works.

It SHOULD work however given it's the same code as fax machine take_question uses already.

**FURTHERMORE:**

We should check why SSWebhook approach is NOT working. See the staff discussion thread on the issue I opened https://discord.com/channels/173831852602294272/1165998242400571402

### Commits

[fix(ahelp): Makes pressing "handle" actually use webhook](https://github.com/VOREStation/VOREStation/pull/15472/commits/cc6c813f6dad30d9d21652d76a01cd840e9db998)

Changes webhook set-up for ahelp "handleissue" from https://github.com/VOREStation/VOREStation/blame/f61f90b9e7596019705abf96ad1bac8a127c936f/code/modules/admin/verbs/adminhelp.dm#L413 to https://github.com/VOREStation/VOREStation/blame/f61f90b9e7596019705abf96ad1bac8a127c936f/code/modules/admin/topic.dm#L1348

This was done as it was discovered the fax machine "take_question" actually sends to discord.

TODO: Standardizing whether we use world.Export() or SSwebhooks, if later fix SSWebhooks