### PR TITLE
Adds a preference to NOT see subtles/whispers even if sender is OK with it or if admin

### DIFF
--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -113,6 +113,13 @@ var/list/_client_preferences_by_type
 	enabled_description = "Visible"
 	disabled_description = "Hidden"
 	enabled_by_default = FALSE
+
+/datum/client_preference/ghost_see_whisubtle
+	description = "See subtles/whispers as ghost"
+	key = "GHOST_SEE_WHISUBTLE"
+	enabled_description = "Visible"
+	disabled_description = "Hidden"
+	enabled_by_default = TRUE
 //VOREStation Add End
 /datum/client_preference/weather_sounds
 	description ="Weather sounds"
@@ -373,7 +380,7 @@ var/list/_client_preferences_by_type
 	key = "RECEIVE_TIPS"
 	enabled_description = "Enabled"
 	disabled_description = "Disabled"
- 
+
 /datum/client_preference/pain_frequency
 	description = "Pain Messages Cooldown"
 	key = "PAIN_FREQUENCY"

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -88,6 +88,21 @@
 
 	feedback_add_details("admin_verb","TWhisubtleVis") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/verb/toggle_ghost_privacyvision()
+	set name = "Toggle Ghost Private Eyes/ears"
+	set category = "Preferences"
+	set desc = "Toggles your ability to see subtles/whispers. Overrides admin status. Respects Ghost Privacy"
+
+	var/pref_path = /datum/client_preference/ghost_see_whisubtle
+
+	toggle_preference(pref_path)
+
+	to_chat(src, "As a ghost, you will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] hear subtles/whispers made by players.")
+
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	feedback_add_details("admin_verb","TGhostSeeWhisSubtle") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/verb/toggle_capture_crystal()
 	set name = "Toggle Catchable"
 	set category = "Preferences"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -363,7 +363,8 @@ var/list/channel_to_radio_key = new
 
 			if(M && src) //If we still exist, when the spawn processes
 				//VOREStation Add - Ghosts don't hear whispers
-				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !M.client?.holder)
+				if(whispering && isobserver(M) && (!M.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle) || \
+				(!is_preference_enabled(/datum/client_preference/whisubtle_vis)  && !M.client?.holder)))
 					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
 					return
 				//VOREStation Add End

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -513,7 +513,8 @@
 		if (istype(G, /mob/new_player))
 			continue
 		else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears))
-			if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder)
+			if((is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder) && \
+			G.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle))
 				to_chat(G, "<span class='filter_say cult'>[src.name]'s screen prints, \"[message]\"</span>")
 
 /mob/living/silicon/pai/proc/touch_window(soft_name)	//This lets us touch TGUI procs and windows that may be nested behind other TGUI procs and windows

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
@@ -500,7 +500,8 @@
 	for(var/mob/M as anything in vis_mobs)
 		if(isnewplayer(M))
 			continue
-		if(isobserver(M) && !L.is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
+		if(isobserver(M) && (!M.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle) || \
+		!L.is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder))
 			spawn(0)
 				M.show_message(undisplayed_message, 2)
 		else
@@ -1171,7 +1172,8 @@
 	for(var/mob/M as anything in vis_mobs)
 		if(isnewplayer(M))
 			continue
-		if(isobserver(M) && !L.is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
+		if(isobserver(M) && (!M.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle) || \
+		!L.is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder))
 			spawn(0)
 				M.show_message(undisplayed_message, 2)
 		else

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -200,7 +200,8 @@
 		for(var/mob/M as anything in vis_mobs)
 			if(isnewplayer(M))
 				continue
-			if(isobserver(M) && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
+			if(isobserver(M) && (!M.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle) || \
+			!is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder))
 				spawn(0)
 					M.show_message(undisplayed_message, 2)
 			else
@@ -341,7 +342,8 @@
 		for (var/mob/G in player_list)
 			if (istype(G, /mob/new_player))
 				continue
-			else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears))
+			else if(isobserver(G) &&  G.is_preference_enabled(/datum/client_preference/ghost_ears && \
+			G.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle)))
 				if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder)
 					to_chat(G, "<span class='psay'>\The [M] thinks, \"[message]\"</span>")
 		log_say(message,M)
@@ -438,7 +440,8 @@
 		for (var/mob/G in player_list)
 			if (istype(G, /mob/new_player))
 				continue
-			else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears))
+			else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears && \
+			G.is_preference_enabled(/datum/client_preference/ghost_see_whisubtle)))
 				if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder)
 					to_chat(G, "<span class='pemote'>\The [M] [message]</span>")
 		log_say(message,M)


### PR DESCRIPTION
### What this does

Creates a new preference toggle, default TRUE, that determines whether you see other people's subtles/whispers while ghosting.

The following cases exist now:

**SEE**
Sender is PUBLIC AND receiver is SEE AND receiver is ADMIN: Receiver see subtles/whispers
Sender is PUBLIC AND receiver is SEE AND receiver is NOT ADMIN: Receiver sees subtles/whispers
Sender is PRIVATE AND receiver is SEE AND receiver is ADMIN: Receiver see subtles/whispers

**NOT SEE**
Sender is PUBLIC AND receiver is  NOT SEE AND receiver is ADMIN: Received DOES NOT see subtles/whispers
Sender is PUBLIC AND receiver is  NOT SEE AND receiver is NOT ADMIN: Received DOES NOT see subtles/whispers
Sender is PRIVATE  AND receiver is SEE AND receiver is NOT ADMIN: Receiver DOES NOT subtles/whispers
Sender is PRIVATE AND receiver is  NOT SEE AND receiver is ADMIN: Received DOES NOT see subtles/whispers
Sender is PRIVATE AND receiver is  NOT SEE AND receiver is NOT ADMIN: Received DOES NOT see subtles/whispers

### Why We Need This

Originally, it was going to be a purely staff preference but I found it both easier to implement as a global one, and saw no reason not to.

The original intent was that if you are a GM running an event, you want to see what players participating might be trying to do/what they're saying so you can react. However, enabling ghost ears/ghost eyes means you see people's scenes as admin.

This makes it much harder to track an already fast chat, so being able to turn it off I think would be a godsend based on my first event's headaches.

For players, this should give them an extra layer of protection from accidentally seeing something as a ghost they don't want.

### Testing

Tested all the listed cases above on local server, however I'm getting tired so I probably missed something.

I will try and re-test it again tomorrow with a clear mind and if possible, request others to test it for me as well.

### Commit Details

[add(preference): Toggle seeing subtles/whispers](https://github.com/VOREStation/VOREStation/commit/6af3b172c169a41bfd6b619fda43484524300882)
Adds a toggle that overrides being an admin for seeing people's subtles/whispers. Meaning, even if you are an admin you won't see them. This is overriden by the sender's preference, IF they prefer privacy.