### PR TITLE
Removing a to_world debug message

### DIFF
--- a/code/modules/mob/dead/corpse.dm
+++ b/code/modules/mob/dead/corpse.dm
@@ -107,7 +107,6 @@
 	M.real_name = generateCorpseName()
 	M.set_stat(DEAD) //Kills the new mob
 	if(corpsesynthtype > 0)
-		to_world("Synth")
 		if(!corpsesynthbrand)
 			corpsesynthbrand = "Unbranded"
 		for(var/obj/item/organ/external/O in M.organs)


### PR DESCRIPTION
No longer will there suddenly be
`Synth`
displayed to everyone when one of the synth simplemobs dies.