### PR TITLE
Follow UP fixes for #15454 + silicon set_flavor is now multiline

### DIFF
--- a/code/__defines/span_vr.dm
+++ b/code/__defines/span_vr.dm
@@ -29,7 +29,7 @@
 
 
 #define span_emote(str) ("<span class='emote'>" + str + "</span>")
-#define span_emote_subtle(str) ("<span class='emote_subtle'>" + str + "</span>")
+#define span_emote_subtle(str) ("<span class='emotesubtle'>" + str + "</span>")
 
 #define span_attack(str) ("<span class='attack'>" + str + "</span>")
 #define span_moderate(str) ("<span class='moderate'>" + str + "</span>")

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -266,7 +266,7 @@
 	set desc = "Sets an extended description of your character's features."
 	set category = "IC"
 
-	var/new_flavortext = strip_html_simple(tgui_input_text(usr, "Please enter your new flavour text.", "Flavour text", null))
+	var/new_flavortext = strip_html_simple(tgui_input_text(usr, "Please enter your new flavour text.", "Flavour text", null, multiline = TRUE))
 	if(new_flavortext)
 		flavor_text = new_flavortext
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -266,7 +266,7 @@
 	set desc = "Sets an extended description of your character's features."
 	set category = "IC"
 
-	var/new_flavortext = strip_html_simple(tgui_input_text(usr, "Please enter your new flavour text.", "Flavour text", null, multiline = TRUE))
+	var/new_flavortext = strip_html_simple(tgui_input_text(usr, "Please enter your new flavour text.", "Flavour text", flavor_text, multiline = TRUE))
 	if(new_flavortext)
 		flavor_text = new_flavortext
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
@@ -489,7 +489,7 @@
 	var/mob/living/simple_mob/vore/overmap/stardog/m = s.parent
 
 	log_subtle(message,L)
-	message = "<span class='emote_subtle'><B>[L]</B> <I>[message]</I></span>"
+	message = "<span class='emotesubtle'><B>[L]</B> <I>[message]</I></span>"
 	message = "<B>(From the back of \the [m]) </B>" + message
 	message = encode_html_emphasis(message)
 
@@ -1161,7 +1161,7 @@
 		return
 
 	log_subtle(message,L)
-	message = "<span class='emote_subtle'><B>[L]</B> <I>[message]</I></span>"
+	message = "<span class='emotesubtle'><B>[L]</B> <I>[message]</I></span>"
 	message = "<B>(From within \the [s]) </B>" + message
 	message = encode_html_emphasis(message)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -70,7 +70,7 @@
 		to_chat(src, "<span class='filter_notice'><I>... You can almost hear someone talking ...</I></span>")
 	else
 		if(client && client.prefs.chat_timestamp)
-			msg = replacetext(msg, new/regex("^(<span(?: \[^>]*)?>)(.*</span>)", ""), "$1[time] $2")
+			msg = replacetext(msg, new/regex("^(<span(?: \[^>]*)?>)((?:.|\\n)*</span>)", ""), "$1[time] $2") 
 			to_chat(src,msg)
 		else if(teleop)
 			to_chat(teleop, create_text_tag("body", "BODY:", teleop.client) + "[msg]")

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -73,7 +73,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 /* VOREStation Edit Start */
 .emote					{}
-.emote_subtle			{font-style: italic;}
+.emotesubtle			{font-style: italic;}
 /* VOREStation Edit End */
 
 /* Game Messages */


### PR DESCRIPTION
-> removed the last _ in emote_subtle
-> changed the timestamp insert regex as it was causing issues with multiline subtle / emote to also include matches on \n
-> small change to the flavor input verb for robots to allow multiline flavor texts to be added or edited for the round directly