### PR TITLE
Hardwood Parquet

### DIFF
--- a/code/modules/materials/materials/organic/wood.dm
+++ b/code/modules/materials/materials/organic/wood.dm
@@ -79,6 +79,7 @@
 
 /datum/material/wood/hardwood/generate_recipes()
 	..()
+	recipes += new /datum/stack_recipe("parquet wood floor tile", /obj/item/stack/tile/wood/parquet, 1, 4, 20, pass_stack_color = FALSE)
 	for(var/datum/stack_recipe/r_recipe in recipes)
 		if(r_recipe.title == "wood floor tile")
 			recipes -= r_recipe


### PR DESCRIPTION
You can now use hardwood planks to make parquet wood flooring, as an alternative to regular wooden flooring. I'd been meaning to look into something like this for a while, and only realized there was actual parquet when looking around the fantasy village map again.

Parquet style;
![image](https://github.com/VOREStation/VOREStation/assets/49700375/8b4042e8-05a8-4eab-abae-973e779998b4)

Might mess around with it some more and try to tweak the colours to better match the hardwood planks, but not a huge priority.