### PR TITLE
Vorebelly robot overlay fixes + VTEC toggle

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -86,9 +86,9 @@
 /obj/item/borg/upgrade/vtec/action(var/mob/living/silicon/robot/R)
 	if(..()) return 0
 
-	if(R.speed == -1)
+	if(R.speed == -1 || (/mob/living/silicon/robot/proc/toggle_vtec in R.verbs))
 		return 0
-
+	R.verbs += /mob/living/silicon/robot/proc/toggle_vtec
 	R.speed--
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -476,6 +476,16 @@
 	else
 		stat(null, text("No Cell Inserted!"))
 
+// function to toggle VTEC once installed
+/mob/living/silicon/robot/proc/toggle_vtec()
+    set name = "Toggle VTEC"
+    set category = "Abilities"
+    if(speed == -1)
+        to_chat(src, "<span class='filter_notice'>VTEC module disbaled.</span>")
+        speed = 0
+    else
+        to_chat(src, "<span class='filter_notice'>VTEC module enabled.</span>")
+        speed = -1
 
 // update the status screen display
 /mob/living/silicon/robot/Stat()
@@ -895,7 +905,7 @@
 				if(LAZYLEN(vore_selected.contents) > 0)
 					for(var/borgfood in vore_selected.contents) //"inspired" (kinda copied) from Chompstation's belly fullness system's procs
 						if(istype(borgfood, /mob/living))
-							if(vore_selected.belly_item_mult <= 0) //If mobs dont contribute, dont calculate further
+							if(vore_selected.belly_mob_mult <= 0) //If mobs dont contribute, dont calculate further
 								continue
 							var/mob/living/prey = borgfood //typecast to living
 							belly_size += (prey.size_multiplier / size_multiplier) / vore_selected.belly_mob_mult //Smaller prey are less filling to larger bellies

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -481,7 +481,7 @@
     set name = "Toggle VTEC"
     set category = "Abilities"
     if(speed == -1)
-        to_chat(src, "<span class='filter_notice'>VTEC module disbaled.</span>")
+        to_chat(src, "<span class='filter_notice'>VTEC module disabled.</span>")
         speed = 0
     else
         to_chat(src, "<span class='filter_notice'>VTEC module enabled.</span>")

--- a/tgui/packages/tgui/interfaces/VorePanel.js
+++ b/tgui/packages/tgui/interfaces/VorePanel.js
@@ -763,7 +763,7 @@ const VoreSelectedMobTypeBellyButtons = (props, context) => {
           <LabeledList.Item label="Item Vorebelly Size Mult">
             <Button
               onClick={() =>
-                act('set_attribute', { attribute: 'b_belly_item_multi' })
+                act('set_attribute', { attribute: 'b_belly_item_mult' })
               }
               content={belly_item_mult}
             />


### PR DESCRIPTION
fixed typo in the vorepanel tgui, resulting in "Item Vorebelly Size Mult" not being changeabale
fixed a wrong variable use which could lead to broken sprites in case the "Mob Vorebelly Size Mult" was set to 0.
added VTEC toggle. (This adds a Verb under Abilities once VTEC has been installed to allow robots to turn it off / on on a whim)