### PR TITLE
Makes absorbs escapable (and other tweaks)

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
@@ -81,7 +81,7 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	vore_ignores_undigestable = 0 // they absorb rather than digest, you're going in either way
 	vore_default_mode = DM_HOLD
 	vore_digest_chance = 0			// Chance to switch to digest mode if resisted
-	vore_absorb_chance = 20			// BECOME A PART OF ME.
+	vore_absorb_chance = 100		// Will always start to absorb if the prey fails its generous escape chance
 	vore_pounce_chance = 5 // Small chance to punish people who abuse their nomming behaviour to try and kite them forever with repeated melee attacks.
 	vore_stomach_name = "internal chamber"
 	vore_stomach_flavor	= "You are squeezed into the tight embrace of the alien creature's warm and cozy insides."
@@ -92,7 +92,8 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	var/obj/belly/B = vore_selected
 	B.name = "internal chamber"
 	B.desc = "Having been too slow to disentangle yourself from the gaslamp's tentacles, the alien creature eventually winds enough of them around your body to lift you up off of the ground. Struggle as you might now, it is too late to deny the jellyfish-esque scavenger its lucky catch; inch by inch, the gaslamp tugs you upwards into its equivalent of a stomach, the transition between the cool-to-frigid atmosphere on the outside to its surprising internal heat something you can feel through any outer wear you possess. Minutes pass, soon resulting in the gentle creature's body sporting a rounded, bulging swell, an indistinct shadow shifting and twitching inside it as you squirm about. Be it to escape or simply to get settled, you might want to take care, however. The gaslamp's internal chamber is slick and squishy instead of overly oppressive, yet, each wave of warmth that pulses over you leaves you feeling weaker than the last..."
-
+	B.escapechance = 40 //easy to squirm out of...
+	B.escapechance_absorbed = 5 //...but EXTREMELY clingy if you fail
 	B.emote_lists[DM_HOLD] = list(
 		"The gaslamp gently bobs up and down as it lazily drifts elsewhere, the movement hardly enough to disturb the shadowy, indistinct figure curled up within it: you.",
 		"The fungal creature’s inner walls tenderly ripple and squeeze about your form for a few moments, squelching softly... until another wave of warmth pulses through the chamber.",

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -563,7 +563,7 @@ I think I covered everything.
 	autotransferwait = 150
 	escapable = 1
 	escapechance = 100
-	escapetime = 30
+	escapetime = 15
 	fancy_vore = 1
 	contamination_color = "grey"
 	contamination_flavor = "Wet"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
@@ -319,7 +319,7 @@
 	B.digestchance = 0
 	B.absorbchance = 0
 	B.escapechance = 10
-	B.escapetime = 10 SECONDS
+	B.escapetime = 5 SECONDS
 	B.selective_preference = DM_DIGEST
 	B.escape_stun = 3
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -27,10 +27,11 @@
 	var/digest_clone = 0					// Clone damage per tick in digestion mode
 	var/immutable = FALSE					// Prevents this belly from being deleted
 	var/escapable = FALSE					// Belly can be resisted out of at any time
-	var/escapetime = 20 SECONDS				// Deciseconds, how long to escape this belly
+	var/escapetime = 10 SECONDS				// Deciseconds, how long to escape this belly
 	var/digestchance = 0					// % Chance of stomach beginning to digest if prey struggles
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.
+	var/escapechance_absorbed = 20			// % Chance of absorbed prey finishing an escape. Requires a successful escape roll against the above as well.
 	var/escape_stun = 0						// AI controlled mobs with a number here will be weakened by the provided var when someone escapes, to prevent endless nom loops
 	var/transferchance = 0 					// % Chance of prey being trasnsfered, goes from 0-100%
 	var/transferchance_secondary = 0 		// % Chance of prey being transfered to transferchance_secondary, also goes 0-100%
@@ -1012,7 +1013,6 @@
 
 	for(var/mob/M in hearers(4, owner))
 		M.show_message(struggle_outer_message, 2) // hearable
-	to_chat(R, struggle_user_message)
 
 	var/sound/struggle_snuggle
 	var/sound/struggle_rustle = sound(get_sfx("rustle"))
@@ -1107,10 +1107,10 @@
 			return
 
 		else //Nothing interesting happened.
-			to_chat(R, "<span class='warning'>You make no progress in escaping [owner]'s [lowertext(name)].</span>")
+			to_chat(R, struggle_user_message)
 			to_chat(owner, "<span class='warning'>Your prey appears to be unable to make any progress in escaping your [lowertext(name)].</span>")
 			return
-
+	to_chat(R, struggle_user_message)
 
 /obj/belly/proc/relay_absorbed_resist(mob/living/R)
 	if (!(R in contents) || !R.absorbed)
@@ -1141,7 +1141,6 @@
 
 	for(var/mob/M in hearers(4, owner))
 		M.show_message(struggle_outer_message, 2) // hearable
-	to_chat(R, struggle_user_message)
 
 	var/sound/struggle_snuggle
 	var/sound/struggle_rustle = sound(get_sfx("rustle"))
@@ -1154,6 +1153,27 @@
 		playsound(src, struggle_snuggle, vary = 1, vol = 75, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/digestion_noises, volume_channel = VOLUME_CHANNEL_VORE)
 	else
 		playsound(src, struggle_rustle, vary = 1, vol = 75, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/digestion_noises, volume_channel = VOLUME_CHANNEL_VORE)
+
+	//absorb resists
+	if(escapable || owner.stat) //If the stomach has escapable enabled or the owner is dead/unconscious
+		if(prob(escapechance) || owner.stat) //Let's have it check to see if the prey's escape attempt starts.
+			to_chat(R, "<span class='warning'>You try to force yourself out of \the [lowertext(name)].</span>")
+			to_chat(owner, "<span class='warning'>Someone is attempting to free themselves from your [lowertext(name)]!</span>")
+			if(do_after(R, escapetime))
+				if((escapable || owner.stat) && (R.loc == src) && prob(escapechance_absorbed)) //Does the escape attempt succeed?
+					release_specific_contents(R)
+					to_chat(R,"<span class='warning'>You manage to free yourself from \the [lowertext(name)].</span>")
+					to_chat(owner,"<span class='warning'>[R] forces themselves free of your [lowertext(name)]!</span>")
+					for(var/mob/M in hearers(4, owner))
+						M.show_message("<span class='warning'>[R] climbs out of [owner]'s [lowertext(name)]!</span>", 2)
+					return
+				else if(!(R.loc == src)) //Aren't even in the belly. Quietly fail.
+					return
+				else //Belly became inescapable or you failed your roll.
+					to_chat(R,"<span class='warning'>Before you manage to reach freedom, you feel yourself getting dragged back into \the [lowertext(name)]!</span>")
+					to_chat(owner,"<span class='notice'>The attempt to escape from your [lowertext(name)] has failed!</span>")
+					return
+	to_chat(R, struggle_user_message)
 
 /obj/belly/proc/get_mobs_and_objs_in_belly()
 	var/list/see = list()


### PR DESCRIPTION
Firstly, escape timers have been cut in half across the board so you don't have to wait for ages after a successful escape roll.

Secondly, adds a chance of escaping if absorbed into a belly that is possible to escape from.
By default this chance is 25% but it is checked *after* waiting out an otherwise successful escape attempt - in effect, this changes absorption from "game over" to "75% chance of the predator dragging you back in on the spot when you'd otherwise escape" - still means that if you get pudged you've got a good chance of being stuck there for a while.

Thirdly, a minor tweak to the messages when resisting in a belly - it now only gives you the fail message if you actually fail, rather than showing the struggle message (most of which imply failure) *then* the escape message on a successful roll.

Fourthly, messes about with gaslamps to give them some somewhat different probabilities since they're the only dedicated absorby mob we actually have.