### PR TITLE
Adding Xenobio Bag to the Science Level Three Biohazard Locker.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -44,7 +44,8 @@
 
 	starts_with = list(
 		/obj/item/clothing/suit/bio_suit/scientist,
-		/obj/item/clothing/head/bio_hood/scientist)
+		/obj/item/clothing/head/bio_hood/scientist,
+		/obj/item/weapon/storage/bag/xeno = 1)
 
 /obj/structure/closet/l3closet/scientist/double
 	starts_with = list(


### PR DESCRIPTION
Added the Xenobiology Bag to the standard Level 3 Science locker, previously it was only in the double locker which some maps didn't have.