### PR TITLE
Paralysis Refactor

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -4,7 +4,7 @@ Contains helper procs for airflow, handled in /connection_group.
 
 /mob/var/tmp/last_airflow_stun = 0
 /mob/proc/airflow_stun()
-	if(stat == 2)
+	if(stat == DEAD)
 		return 0
 	if(last_airflow_stun > world.time - vsc.airflow_stun_cooldown)	return 0
 

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -1,7 +1,8 @@
 // /mob/var/stat things.
 #define CONSCIOUS   0
-#define UNCONSCIOUS 1
-#define DEAD        2
+#define PARALYZED	1
+#define UNCONSCIOUS 2
+#define DEAD        3
 
 // Bitflags defining which status effects could be or are inflicted on a mob.
 #define CANSTUN     0x1

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -386,7 +386,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/select = null
 	var/list/borgs = list()
 	for (var/mob/living/silicon/robot/A in player_list)
-		if (A.stat == 2 || A.connected_ai || A.scrambledcodes || istype(A,/mob/living/silicon/robot/drone))
+		if (A.stat == DEAD || A.connected_ai || A.scrambledcodes || istype(A,/mob/living/silicon/robot/drone))
 			continue
 		var/name = "[A.real_name] ([A.modtype] [A.braintype])"
 		borgs[name] = A

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -41,7 +41,7 @@
 	throw_range = 20
 	var/randomize = TRUE
 	var/square_chance = 10
-	
+
 /obj/item/weapon/soap/Initialize()
 	if(randomize && prob(square_chance))
 		icon_state = "[icon_state]-alt"
@@ -346,7 +346,7 @@
 		if (C.c_tag == target)
 			target = C
 			break
-	if (usr.stat == 2) return
+	if (usr.stat == DEAD) return
 
 	usr.client.eye = target
 

--- a/code/game/antagonist/station/highlander.dm
+++ b/code/game/antagonist/station/highlander.dm
@@ -60,7 +60,7 @@ var/datum/antagonist/highlander/highlanders
 		return
 
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.stat == 2 || !(H.client)) continue
+		if(H.stat == DEAD || !(H.client)) continue
 		if(is_special_character(H)) continue
 		highlanders.add_antagonist(H.mind)
 

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -101,6 +101,6 @@ var/datum/antagonist/renegade/renegades
 	to_chat(usr, "<B>You summoned guns!</B>")
 	message_admins("[key_name_admin(usr, 1)] summoned guns!")
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.stat == 2 || !(H.client)) continue
+		if(H.stat == DEAD || !(H.client)) continue
 		if(is_special_character(H)) continue
 		renegades.add_antagonist(H.mind)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -369,11 +369,11 @@ var/global/list/additional_antag_types = list()
 
 	send2mainirc("A round of [src.name] has ended - [surviving_total] survivors, [ghosts] ghosts.")
 	SSwebhooks.send(
-		WEBHOOK_ROUNDEND, 
+		WEBHOOK_ROUNDEND,
 		list(
-			"survivors" = surviving_total, 
-			"escaped" = escaped_total, 
-			"ghosts" = ghosts, 
+			"survivors" = surviving_total,
+			"escaped" = escaped_total,
+			"ghosts" = ghosts,
 			"clients" = clients
 		)
 	)
@@ -490,8 +490,11 @@ var/global/list/additional_antag_types = list()
 				if(L.suiciding)	//Suicider
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='red'><b>Suicide</b></font>)\n"
 					continue //Disconnected client
+				if(L.stat == PARALYZED)
+					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Paralyzed)\n"
+					continue //Paralyzed
 				if(L.stat == UNCONSCIOUS)
-					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dying)\n"
+					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Unconscious)\n"
 					continue //Unconscious
 				if(L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -269,7 +269,7 @@ datum
 			check_completion()
 				if(!emergency_shuttle.returned())
 					return 0
-				if(target.current.stat == 2)
+				if(target.current.stat == DEAD)
 					return 0
 				var/turf/location = get_turf(target.current.loc)
 				if(!location)
@@ -316,7 +316,7 @@ datum
 				if(!emergency_shuttle.returned())
 					return 0
 
-				if(target.current.stat == 2)
+				if(target.current.stat == DEAD)
 					return 0
 
 				var/turf/location = get_turf(target.current.loc)
@@ -358,7 +358,7 @@ datum
 
 			check_completion()
 				if(target && target.current)
-					if(target.current.stat == 2 || istype(get_area(target.current), /area/tdome) || issilicon(target.current) || isbrain(target.current))
+					if(target.current.stat == DEAD || istype(get_area(target.current), /area/tdome) || issilicon(target.current) || isbrain(target.current))
 						return 1
 					else
 						return 0
@@ -429,7 +429,7 @@ datum
 
 			check_completion()
 				if(target && target.current)
-					if(target.current.stat == 2)
+					if(target.current.stat == DEAD)
 						if(config.require_heads_alive) return 0
 					else
 						if(!target.current.handcuffed)
@@ -480,7 +480,7 @@ datum
 				if(!emergency_shuttle.returned())
 					return 0
 
-				if(!owner.current || owner.current.stat == 2)
+				if(!owner.current || owner.current.stat == DEAD)
 					return 0
 				var/turf/location = get_turf(owner.current.loc)
 
@@ -515,7 +515,7 @@ datum
 				if(!emergency_shuttle.returned())
 					return 0
 
-				if(!owner.current || owner.current.stat ==2)
+				if(!owner.current || owner.current.stat == DEAD)
 					return 0
 
 				var/turf/location = get_turf(owner.current.loc)
@@ -540,7 +540,7 @@ datum
 			explanation_text = "Stay alive."
 
 			check_completion()
-				if(!owner.current || owner.current.stat == 2)
+				if(!owner.current || owner.current.stat == DEAD)
 					return 0
 
 				return 1
@@ -1331,7 +1331,7 @@ datum
 			check_completion()
 				if(!ishuman(owner.current))
 					return 0
-				if(!owner.current || owner.current.stat == 2)
+				if(!owner.current || owner.current.stat == DEAD)
 					return 0
 
 				var/current_amount
@@ -1406,7 +1406,7 @@ datum
 			check_completion()
 				if(target && target.current)
 					var/turf/T = get_turf(target.current)
-					if(target.current.stat == 2)
+					if(target.current.stat == DEAD)
 						return 1
 					else if((T) && (isNotStationLevel(T.z)))//If they leave the station they count as dead for this
 						return 2

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -290,7 +290,7 @@ var/global/list/all_objectives = list()
 		return 0
 	if(!emergency_shuttle.returned())
 		return 0
-	if(!owner.current || owner.current.stat ==2)
+	if(!owner.current || owner.current.stat == DEAD)
 		return 0
 	var/turf/location = get_turf(owner.current.loc)
 	if(!location)
@@ -553,7 +553,7 @@ var/global/list/all_objectives = list()
 /datum/objective/download/check_completion()
 	if(!ishuman(owner.current))
 		return 0
-	if(!owner.current || owner.current.stat == 2)
+	if(!owner.current || owner.current.stat == DEAD)
 		return 0
 
 	var/current_amount
@@ -663,7 +663,7 @@ var/global/list/all_objectives = list()
 
 /datum/objective/heist/kidnap/check_completion()
 	if(target && target.current)
-		if (target.current.stat == 2)
+		if (target.current.stat == DEAD)
 			return 0 // They're dead. Fail.
 		//if (!target.current.restrained())
 		//	return 0 // They're loose. Close but no cigar.

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -16,7 +16,7 @@
 			triggerAlarm()
 	else if (detectTime == -1)
 		for (var/mob/target in motionTargets)
-			if (target.stat == 2) lostTarget(target)
+			if (target.stat == DEAD) lostTarget(target)
 			// If not detecting with motion camera...
 			if (!area_motion)
 				// See if the camera is still in range

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -9,7 +9,7 @@
 	return !(T?.z in using_map.player_levels)
 
 /mob/living/silicon/ai/proc/get_camera_list()
-	if(src.stat == 2)
+	if(src.stat == DEAD)
 		return
 
 	cameranet.process_sort()
@@ -102,7 +102,7 @@
 	var/list/cameras = list()
 
 /mob/living/silicon/ai/proc/trackable_mobs()
-	if(usr.stat == 2)
+	if(usr.stat == DEAD)
 		return list()
 
 	var/datum/trackable/TB = new()
@@ -133,7 +133,7 @@
 	set name = "Follow With Camera"
 	set desc = "Select who you would like to track."
 
-	if(src.stat == 2)
+	if(src.stat == DEAD)
 		to_chat(src, "You can't follow [target_name] with cameras because you are dead!")
 		return
 	if(!target_name)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -128,7 +128,7 @@
 				if(!M.brainmob)
 					to_chat(user, "<span class='warning'>Sticking an empty [P] into the frame would sort of defeat the purpose.</span>")
 					return
-				if(M.brainmob.stat == 2)
+				if(M.brainmob.stat == DEAD)
 					to_chat(user, "<span class='warning'>Sticking a dead [P] into the frame would sort of defeat the purpose.</span>")
 					return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -213,7 +213,7 @@
 			return
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise
-		occupant.set_stat(UNCONSCIOUS)
+		occupant.set_stat(PARALYZED)
 		occupant.dir = SOUTH
 		if(occupant.bodytemperature < T0C)
 			occupant.Sleeping(max(5, (1/occupant.bodytemperature)*2000))
@@ -320,7 +320,7 @@
 	set category = "Object"
 	set src in oview(1)
 	if(usr == occupant)//If the user is inside the tube...
-		if(usr.stat == 2)//and he's not dead....
+		if(usr.stat == DEAD)//and he's not dead....
 			return
 		to_chat(usr, "<span class='notice'>Release sequence activated. This will take two minutes.</span>")
 		sleep(1200)

--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -40,17 +40,17 @@
 
 		var/brain_activity = "none"
 		var/breathing = "none"
-		
+
 		if(victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 			var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[O_BRAIN]
 			if(istype(brain))
 				if(victim.getBrainLoss())
 					brain_activity = "anomalous"
-				else if(victim.stat == UNCONSCIOUS)
+				else if(victim.stat == UNCONSCIOUS || victim.stat == PARALYZED)
 					brain_activity = "weak"
 				else
 					brain_activity = "normal"
-			
+
 			var/obj/item/organ/internal/lungs/lungs = victim.internal_organs_by_name[O_LUNGS]
 			if(istype(lungs))
 				var/oxyloss = victim.getOxyLoss()
@@ -60,7 +60,7 @@
 					breathing = "shallow"
 				else
 					breathing = "normal"
-		
+
 		. += "<span class='notice'>Brain activity: [brain_activity]</span>"
 		. += "<span class='notice'>Breathing: [breathing]</span>"
 
@@ -115,10 +115,10 @@
 		if(victim.getBrainLoss())
 			add_overlay("brain_verybad")
 			add_overlay("brain_warning")
-		else if(victim.stat == UNCONSCIOUS)
+		else if(victim.stat == UNCONSCIOUS || victim.stat == PARALYZED)
 			add_overlay("brain_bad")
 		else
-			add_overlay("brain_ok")				
+			add_overlay("brain_ok")
 	else
 		add_overlay("brain_warning")
 

--- a/code/game/mecha/equipment/tools/sleeper.dm
+++ b/code/game/mecha/equipment/tools/sleeper.dm
@@ -202,7 +202,7 @@
 	set category = "Exosuit Interface"
 	set src = usr.loc
 	set popup_menu = 0
-	if(usr!=src.occupant || usr.stat == 2)
+	if(usr!=src.occupant || usr.stat == DEAD)
 		return
 	to_chat(usr,"<span class='notice'>Release sequence activated. This will take one minute.</span>")
 	sleep(600)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -195,7 +195,7 @@
 		return
 	if(!chassis.selected)
 		chassis.selected = available_equipment[1]
-		chassis.occupant_message("You select [chassis.selected]") 
+		chassis.occupant_message("You select [chassis.selected]")
 		send_byjax(chassis.occupant,"exosuit.browser","eq_list",chassis.get_equipment_list())
 		button_icon_state = "mech_cycle_equip_on"
 		button.UpdateIcon()
@@ -294,7 +294,7 @@
 	overload()
 
 /obj/mecha/proc/overload()
-	if(usr.stat == 1)//No manipulating things while unconcious.
+	if(usr.stat == PARALYZED)//No manipulating things while unconcious or unable to act
 		return
 	if(usr!=src.occupant)
 		return

--- a/code/game/objects/items/devices/communicator/integrated.dm
+++ b/code/game/objects/items/devices/communicator/integrated.dm
@@ -25,7 +25,7 @@
 	set desc = "Utilizes your built-in communicator."
 	set src in usr
 
-	if(usr.stat == 2)
+	if(usr.stat == DEAD)
 		to_chat(usr, "You can't do that because you are dead!")
 		return
 

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -119,6 +119,8 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 	switch(H.stat)
 		if(CONSCIOUS)
 			output += "Alive<br>"
+		if(PARALYZED)
+			output += "Paralyzed<br>"
 		if(UNCONSCIOUS)
 			output += "Unconscious<br>"
 		if(DEAD)

--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -280,7 +280,7 @@
 	//Basically! Mobs over 1000 max health will be unable to be caught without using status effects.
 	//Thanks Aronai!
 	var/effect_count = 0	//This will give you a smol chance to capture if you have applied status effects, even if the chance would ordinarily be <0
-	if(M.stat == UNCONSCIOUS)
+	if(M.stat == PARALYZED || M.stat == UNCONSCIOUS)
 		capture_chance += 0.1
 		effect_count += 1
 	else if(M.stat == CONSCIOUS)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -522,7 +522,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	if(isnull(M)) // If the mob got gibbed
 		activate()
-	else if(M.stat == 2)
+	else if(M.stat == DEAD)
 		activate("death")
 
 /obj/item/weapon/implant/death_alarm/activate(var/cause)

--- a/code/game/objects/structures/props/nest.dm
+++ b/code/game/objects/structures/props/nest.dm
@@ -63,5 +63,5 @@
 
 /obj/structure/prop/nest/proc/update_creatures()
 	for(var/mob/living/L in den_mobs)
-		if(L.stat == 2)
+		if(L.stat == DEAD)
 			remove_creature(L)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -70,7 +70,7 @@ var/silent_ert = 0
 	var/deadcount = 0
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.client) // Monkeys and mice don't have a client, amirite?
-			if(H.stat == 2) deadcount++
+			if(H.stat == DEAD) deadcount++
 			total++
 
 	if(total == 0) return 0

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -598,7 +598,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!input)
 		return
 	for(var/mob/living/silicon/ai/M in mob_list)
-		if (M.stat == 2)
+		if (M.stat == DEAD)
 			to_chat(usr, "Upload failed. No signal is being detected from the AI.")
 		else if (M.see_in_dark == 0)
 			to_chat(usr, "Upload failed. Only a faint signal is being detected from the AI, and it is not responding to our requests. It may be low on power.")

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -135,7 +135,7 @@
 		if(L.stat)
 			if(L.stat == DEAD && !handle_corpse) // Leave dead things alone
 				return FALSE
-			if(L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
+			if(L.stat == PARALYZED || L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
 				if(mauling)
 					return TRUE
 				//VOREStation Add Start

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -10,14 +10,14 @@
 	if (!ticker)
 		to_chat(src, "You can't commit suicide before the game starts!")
 		return
-	
+
 	to_chat(src, "<span class='warning'>No. Adminhelp if there is a legitimate reason, and please review our server rules.</span>")
 	message_admins("[ckey] has tried to trigger the suicide verb as human, but it is currently disabled.")
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1
 
-	if (stat == 2)
+	if (stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return
 
@@ -41,7 +41,7 @@
 /mob/living/silicon/ai/verb/suicide()
 	set hidden = 1
 
-	if (stat == 2)
+	if (stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return
 
@@ -61,7 +61,7 @@
 /mob/living/silicon/robot/verb/suicide()
 	set hidden = 1
 
-	if (stat == 2)
+	if (stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return
 

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -205,7 +205,7 @@
 		return 0
 
 	//OH SHIT.
-	if(holder.wearer.stat == 2)
+	if(holder.wearer.stat == DEAD)
 		engage(1)
 
 /obj/item/rig_module/self_destruct/engage(var/skip_check)

--- a/code/modules/clothing/spacesuits/rig/modules/specific/self_destruct.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/specific/self_destruct.dm
@@ -37,7 +37,7 @@
 		return 0
 
 	//OH SHIT.
-	if(holder.wearer.stat == 2)
+	if(holder.wearer.stat == DEAD)
 		engage(1)
 
 /obj/item/rig_module/self_destruct/engage(var/skip_check)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -50,8 +50,7 @@
 			return 1
 
 		if(paralysis && paralysis > 0)
-			blinded = 1
-			set_stat(UNCONSCIOUS)
+			set_stat(PARALYZED)
 			if(halloss > 0)
 				adjustHalLoss(-3)
 
@@ -88,13 +87,13 @@
 
 /mob/living/carbon/alien/handle_regular_hud_updates()
 
-	if (stat == 2 || (XRAY in src.mutations))
+	if (stat == DEAD || (XRAY in src.mutations))
 		sight |= SEE_TURFS
 		sight |= SEE_MOBS
 		sight |= SEE_OBJS
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	else if (stat != 2)
+	else if (stat != DEAD)
 		sight &= ~SEE_TURFS
 		sight &= ~SEE_MOBS
 		sight &= ~SEE_OBJS
@@ -102,7 +101,7 @@
 		see_invisible = SEE_INVISIBLE_LIVING
 
 	if (healths)
-		if (stat != 2)
+		if (stat != DEAD)
 			switch(health)
 				if(100 to INFINITY)
 					healths.icon_state = "health0"
@@ -124,7 +123,7 @@
 	if (client)
 		client.screen.Remove(global_hud.blurry,global_hud.druggy,global_hud.vimpaired)
 
-	if ( stat != 2)
+	if (stat != DEAD)
 		if ((blinded))
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		else

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -204,7 +204,7 @@
 			if(CONSCIOUS)
 				if(!src.brainmob.client)
 					. += "<span class='warning'>It appears to be in stand-by mode.</span>" //afk
-			if(UNCONSCIOUS)
+			if(UNCONSCIOUS || PARALYZED)
 				. += "<span class='warning'>It doesn't seem to be responsive.</span>"
 			if(DEAD)
 				. += "<span class='deadsay'>It appears to be completely inactive.</span>"

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -47,7 +47,7 @@
 
 		handle_temperature_damage(HEAD, environment.temperature, environment_heat_capacity*transfer_coefficient)
 
-	if(stat==2)
+	if(stat == DEAD)
 		bodytemperature += 0.1*(environment.temperature - bodytemperature)*environment_heat_capacity/(environment_heat_capacity + 270000)
 
 	//Account for massive pressure differences
@@ -155,13 +155,13 @@
 	return 1
 
 /mob/living/carbon/brain/handle_regular_hud_updates()
-	if (stat == 2 || (XRAY in src.mutations))
+	if (stat == DEAD || (XRAY in src.mutations))
 		sight |= SEE_TURFS
 		sight |= SEE_MOBS
 		sight |= SEE_OBJS
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	else if (stat != 2)
+	else if (stat != DEAD)
 		sight &= ~SEE_TURFS
 		sight &= ~SEE_MOBS
 		sight &= ~SEE_OBJS
@@ -169,7 +169,7 @@
 		see_invisible = SEE_INVISIBLE_LIVING
 
 	if (healths)
-		if (stat != 2)
+		if (stat != DEAD)
 			switch(health)
 				if(100 to INFINITY)
 					healths.icon_state = "health0"
@@ -188,13 +188,13 @@
 		else
 			healths.icon_state = "health7"
 
-		if (stat == 2 || (XRAY in src.mutations))
+		if (stat == DEAD || (XRAY in src.mutations))
 			sight |= SEE_TURFS
 			sight |= SEE_MOBS
 			sight |= SEE_OBJS
 			see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_LEVEL_TWO
-		else if (stat != 2)
+		else if (stat != DEAD)
 			sight &= ~SEE_TURFS
 			sight &= ~SEE_MOBS
 			sight &= ~SEE_OBJS
@@ -203,7 +203,7 @@
 	if (client)
 		client.screen.Remove(global_hud.blurry,global_hud.druggy,global_hud.vimpaired)
 
-	if (stat != 2)
+	if (stat != DEAD)
 		if ((blinded))
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -287,7 +287,7 @@
 
 	if (src.stat)
 		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>"
-		if((stat == 2 || src.losebreath) && get_dist(user, src) <= 3)
+		if((stat == DEAD || src.losebreath) && get_dist(user, src) <= 3)
 			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>"
 		if(istype(user, /mob/living/carbon/human) && !user.stat && Adjacent(user))
 			user.visible_message("<b>[usr]</b> checks [src]'s pulse.", "You check [src]'s pulse.")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -217,7 +217,7 @@
 	if(HULK in mutations)	return
 	// Notify our AI if they can now control the suit.
 	if(wearing_rig && !stat && paralysis < amount) //We are passing out right this second.
-		wearing_rig.notify_ai("<span class='danger'>Warning: user consciousness failure. Mobility control passed to integrated intelligence system.</span>")
+		wearing_rig.notify_ai("<span class='danger'>Warning: user incapacitation detected. Mobility control passed to integrated intelligence system.</span>")
 	..()
 
 /mob/living/carbon/human/proc/Stasis(amount)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -338,7 +338,7 @@ emp_act
 				if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
 					if(prob(effective_force))
 						apply_effect(20, PARALYZE, blocked, soaked)
-						visible_message("<span class='danger'>\The [src] has been knocked unconscious!</span>")
+						visible_message("<span class='danger'>\The [src] has been stunned!</span>")
 					if(bloody)//Apply blood
 						if(wear_mask)
 							wear_mask.add_blood(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1245,22 +1245,24 @@
 			Paralyse(10)
 			setHalLoss(species.total_health - 1)
 
-		if(paralysis || sleeping)
+		if(paralysis)
+			set_stat(PARALYZED)
+			animate_tail_reset()
+
+		if(sleeping)
+			adjustHalLoss(-3)
 			blinded = 1
 			set_stat(UNCONSCIOUS)
 			animate_tail_reset()
-			adjustHalLoss(-3)
-
-			if(sleeping)
-				handle_dreams()
-				if (mind)
-					//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of stoxin or similar.
-					if(client || sleeping > 3)
-						AdjustSleeping(-1)
-						throw_alert("asleep", /obj/screen/alert/asleep)
-				if( prob(2) && health && !hal_crit && client )
-					spawn(0)
-						emote("snore")
+			handle_dreams()
+			if (mind)
+				//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of stoxin or similar.
+				if(client || sleeping > 3)
+					AdjustSleeping(-1)
+					throw_alert("asleep", /obj/screen/alert/asleep)
+			if( prob(2) && health && !hal_crit && client )
+				spawn(0)
+					emote("snore")
 		//CONSCIOUS
 		else
 			set_stat(CONSCIOUS)
@@ -1723,7 +1725,7 @@
 				stomach_contents.Remove(M)
 				continue
 			if(istype(M, /mob/living/carbon) && stat != 2)
-				if(M.stat == 2)
+				if(M.stat == DEAD)
 					M.death(1)
 					stomach_contents.Remove(M)
 					qdel(M)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -371,12 +371,12 @@
 	if(istype(G.affecting,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = G.affecting
 		H.apply_damage(50,BRUTE)
-		if(H.stat == 2)
+		if(H.stat == DEAD)
 			H.gib()
 
 	else
 		var/mob/living/M = G.affecting
 		if(!istype(M)) return //wut
 		M.apply_damage(50,BRUTE)
-		if(M.stat == 2)
+		if(M.stat == DEAD)
 			M.gib()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -112,6 +112,8 @@
 	updatehealth()
 	if(stat != DEAD)
 		if(paralysis)
+			set_stat(PARALYZED)
+		else if (sleeping)
 			set_stat(UNCONSCIOUS)
 		else if (status_flags & FAKEDEATH)
 			set_stat(UNCONSCIOUS)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -22,17 +22,17 @@
 			else
 				. += "<span class='warning'>It seems to be running on backup power.</span>"
 
-		if (src.stat == UNCONSCIOUS)
+		if (src.stat == UNCONSCIOUS || src.stat == PARALYZED)
 			. += "<span class='warning'>It is non-responsive and displaying the text: \"RUNTIME: Sensory Overload, stack 26/3\".</span>"
 
 		if(deployed_shell)
 			. += "The wireless networking light is blinking."
 
 	. += "*---------*"
-	
+
 	if(hardware && (hardware.owner == src))
 		. += hardware.get_examine_desc()
-	
+
 	user.showLaws(src)
 
 /mob/proc/showLaws(var/mob/living/silicon/S)

--- a/code/modules/mob/living/silicon/decoy/life.dm
+++ b/code/modules/mob/living/silicon/decoy/life.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/decoy/Life()
-	if (src.stat == 2)
+	if (src.stat == DEAD)
 		return
 	else
 		if (src.health <= config.health_threshold_dead && src.stat != 2)

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -4,9 +4,9 @@
 	switch(src.stat)
 		if(CONSCIOUS)
 			if(!src.client)	. += "It appears to be in stand-by mode." //afk
-		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
+		if(UNCONSCIOUS || PARALYZED)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
-	
+
 	// VOREStation Edit: Start
 	. += attempt_vr(src,"examine_bellies",args) //VOREStation Edit
 	if(print_flavor_text()) . += "\n[print_flavor_text()]\n"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -216,7 +216,7 @@
 		src.unset_machine()
 		src.reset_view(null)
 		return 0
-	if (stat == 2 || !C.status || !(src.network in C.network)) return 0
+	if (stat == DEAD || !C.status || !(src.network in C.network)) return 0
 
 	// ok, we're alive, camera is good and in our network...
 
@@ -422,7 +422,7 @@
 	else
 		visible_message("<span class='warning'>[user.name] bonks [src] harmlessly with [W].</span>")
 	spawn(1)
-		if(stat != 2) close_up()
+		if(stat != DEAD) close_up()
 	return
 
 /mob/living/silicon/pai/attack_hand(mob/user as mob)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -237,7 +237,7 @@ var/list/mob_hat_cache = list()
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 		var/datum/gender/TU = gender_datums[user.get_visible_gender()]
-		if(stat == 2)
+		if(stat == DEAD)
 
 			if(!config.allow_drone_spawn || emagged || health < -35) //It's dead, Dave.
 				to_chat(user, "<span class='danger'>The interface is fried, and a distressing burned smell wafts from the robot's interior. You're not rebooting this one.</span>")
@@ -271,7 +271,7 @@ var/list/mob_hat_cache = list()
 	..()
 
 /mob/living/silicon/robot/drone/emag_act(var/remaining_charges, var/mob/user)
-	if(!client || stat == 2)
+	if(!client || stat == DEAD)
 		to_chat(user, "<span class='danger'>There's not much point subverting this heap of junk.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -27,7 +27,7 @@
 				. += "It appears to be an [deployed ? "active" : "empty"] AI shell."
 			else if(!src.client)
 				. += "It appears to be in stand-by mode." //afk
-		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
+		if(UNCONSCIOUS || PARALYZED)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
 
 	// VOREStation Edit: Start

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -69,7 +69,7 @@
 /mob/living/silicon/robot/handle_regular_status_updates()
 
 	if(src.camera && !scrambledcodes)
-		if(src.stat == 2 || wires.is_cut(WIRE_BORG_CAMERA))
+		if(src.stat == DEAD || wires.is_cut(WIRE_BORG_CAMERA))
 			src.camera.set_status(0)
 		else
 			src.camera.set_status(1)
@@ -89,7 +89,7 @@
 	if (src.stat != 2) //Alive.
 		if (src.weakened > 0)	// Do not fullstun on weaken
 			AdjustWeakened(-1)
-		if (src.paralysis || src.stunned || !src.has_power) //Stunned etc.
+		if (src.stunned || !src.has_power) //Stunned etc.
 			src.set_stat(UNCONSCIOUS)
 			if (src.stunned > 0)
 				AdjustStunned(-1)

--- a/code/modules/mob/living/simple_mob/appearance.dm
+++ b/code/modules/mob/living/simple_mob/appearance.dm
@@ -19,7 +19,7 @@
 		icon_state = icon_dead
 
 	//Resting or KO'd
-	else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest)
+	else if(((stat == UNCONSCIOUS) || (stat == PARALYZED) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest)
 		icon_state = icon_rest
 
 	//Backup

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -94,7 +94,7 @@
 			icon_state = "[icon_living]-[vore_fullness]"
 		else if(stat >= DEAD && (vore_icons & SA_ICON_DEAD))
 			icon_state = "[icon_dead]-[vore_fullness]"
-		else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
+		else if(((stat == UNCONSCIOUS) || (stat == PARALYZED) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
 			icon_state = "[icon_rest]-[vore_fullness]"
 		if(vore_eyes && voremob_awake) //Update eye layer if applicable.
 			remove_eyes()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_captive.dm
@@ -18,7 +18,7 @@
 		if (!message)
 			return
 		log_say(message,src)
-		if (stat == 2)
+		if (stat == DEAD)
 			return say_dead(message)
 
 		var/mob/living/simple_mob/animal/borer/B = src.loc

--- a/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_powers.dm
@@ -164,7 +164,7 @@
 
 	H.add_language("Cortical Link")
 
-	if(host.stat == 2)
+	if(host.stat == DEAD)
 		H.verbs |= /mob/living/carbon/human/proc/jumpstart
 
 	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -70,7 +70,7 @@
 		to_chat(src, "<span class='filter_notice'><I>... You can almost hear someone talking ...</I></span>")
 	else
 		if(client && client.prefs.chat_timestamp)
-			msg = replacetext(msg, new/regex("^(<span(?: \[^>]*)?>)((?:.|\\n)*</span>)", ""), "$1[time] $2") 
+			msg = replacetext(msg, new/regex("^(<span(?: \[^>]*)?>)((?:.|\\n)*</span>)", ""), "$1[time] $2")
 			to_chat(src,msg)
 		else if(teleop)
 			to_chat(teleop, create_text_tag("body", "BODY:", teleop.client) + "[msg]")
@@ -170,10 +170,10 @@
 	if ((incapacitation_flags & INCAPACITATION_STUNNED) && stunned)
 		return 1
 
-	if ((incapacitation_flags & INCAPACITATION_FORCELYING) && (weakened || resting))
+	if ((incapacitation_flags & INCAPACITATION_FORCELYING) && (weakened || resting || paralysis))
 		return 1
 
-	if ((incapacitation_flags & INCAPACITATION_KNOCKOUT) && (stat || paralysis || sleeping || (status_flags & FAKEDEATH)))
+	if ((incapacitation_flags & INCAPACITATION_KNOCKOUT) && (stat || sleeping || (status_flags & FAKEDEATH)))
 		return 1
 
 	if((incapacitation_flags & INCAPACITATION_RESTRAINED) && restrained())
@@ -919,8 +919,8 @@
 		return
 	usr.setClickCooldown(20)
 
-	if(usr.stat == 1)
-		to_chat(usr, "<span class='filter_notice'>You are unconcious and cannot do that!</span>")
+	if(usr.stat >= 1)
+		to_chat(usr, "<span class='filter_notice'>You are cannot do that right now!</span>")
 		return
 
 	if(usr.restrained())

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -13,7 +13,7 @@
 	invisibility = 101
 
 	density = FALSE
-	stat = 2
+	stat = DEAD
 	canmove = 0
 
 	anchored = TRUE	//  don't get pushed around

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -5,6 +5,9 @@
 	set name = "Whisper"
 	set category = "IC"
 	//VOREStation Addition Start
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't speak whilst paralyzed!</span>")
+		return
 	if(forced_psay)
 		psay(message)
 		return
@@ -16,6 +19,9 @@
 	set name = "Say"
 	set category = "IC"
 	//VOREStation Addition Start
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't speak whilst paralyzed!</span>")
+		return
 	if(forced_psay)
 		psay(message)
 		return
@@ -30,6 +36,9 @@
 
 	if(say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<font color='red'>Speech is currently admin-disabled.</font>")
+		return
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't act whilst paralyzed!</span>")
 		return
 	//VOREStation Addition Start
 	if(forced_psay)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -10,6 +10,9 @@
 	if(say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "Speech is currently admin-disabled.")
 		return
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't act whilst paralyzed!</span>")
+		return
 	if(forced_psay)
 		pme(message)
 		return
@@ -32,6 +35,9 @@
 	if(say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "Speech is currently admin-disabled.")
 		return
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't act whilst paralyzed!</span>")
+		return
 	if(forced_psay)
 		pme(message)
 		return
@@ -52,6 +58,9 @@
 		return
 
 	//VOREStation Addition Start
+	if(paralysis)
+		to_chat(usr, "<span class='danger'>You can't act whilst paralyzed!</span>")
+		return
 	if(forced_psay)
 		pme(message)
 		return

--- a/code/modules/reagents/reactions/instant/instant.dm
+++ b/code/modules/reagents/reactions/instant/instant.dm
@@ -370,6 +370,13 @@
 	required_reagents = list("ethanol" = 1, "chlorine" = 3, "water" = 1)
 	result_amount = 1
 
+/decl/chemical_reaction/instant/paralyzant
+	name = "Paralyzant"
+	id = "paralyzant"
+	result = "paralyzant"
+	required_reagents = list("ethanol" = 1, "hydrogen" = 2, "chlorine" = 2)
+	result_amount = 1
+
 /decl/chemical_reaction/instant/potassium_chloride
 	name = "Potassium Chloride"
 	id = "potassium_chloride"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -779,14 +779,10 @@
 	if(effective_dose == metabolism)
 		M.AdjustParalysis(1)
 	else if(effective_dose < 2 * threshold)
-		M.AdjustParalysis(5)
-		M.eye_blurry = max(M.eye_blurry, 10)
+		M.AdjustParalysis(2.5)
 	else
 		if(alien == IS_SLIME)
-			if(prob(30))
-				M.ear_deaf = max(M.ear_deaf, 4)
-			M.eye_blurry = max(M.eye_blurry, 60)
-			M.AdjustParalysis(5)
+			M.AdjustParalysis(2.5)
 
 	if(effective_dose > 1 * threshold)
 		M.adjustToxLoss(removed)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -749,6 +749,54 @@
 	M.SetLosebreath(10)
 	M.adjustOxyLoss(removed * overdose_mod)
 
+/datum/reagent/paralyzant
+	name = "Paralyzant"
+	id = "paralyzant"
+	description = "A potent muscle relaxant. Disables subjects without knocking them completely unconscious."
+	taste_description = "bitterness"
+	reagent_state = SOLID
+	color = "#000067"
+	metabolism = REM * 0.5
+	ingest_met = REM * 1.5
+	overdose = REAGENTS_OVERDOSE / 3	//use INCREDIBLY carefully!
+	overdose_mod = 3
+
+/datum/reagent/paralyzant/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+
+	var/threshold = 1 * M.species.chem_strength_tox
+	if(alien == IS_SKRELL)
+		threshold = 1.2
+
+	if(alien == IS_SLIME)
+		threshold = 6	//Evens to 3 due to the fact they are considered 'small' for flaps.
+
+	var/effective_dose = dose
+	if(issmall(M))
+		effective_dose *= 2
+
+	if(effective_dose == metabolism)
+		M.AdjustParalysis(1)
+	else if(effective_dose < 2 * threshold)
+		M.AdjustParalysis(5)
+		M.eye_blurry = max(M.eye_blurry, 10)
+	else
+		if(alien == IS_SLIME)
+			if(prob(30))
+				M.ear_deaf = max(M.ear_deaf, 4)
+			M.eye_blurry = max(M.eye_blurry, 60)
+			M.AdjustParalysis(5)
+
+	if(effective_dose > 1 * threshold)
+		M.adjustToxLoss(removed)
+
+/datum/reagent/paralyzant/overdose(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	//As it turns out having your muscles stop working makes it hard to breathe
+	M.SetLosebreath(10)
+	M.adjustOxyLoss(removed * overdose_mod)
+
 /datum/reagent/chloralhydrate/beer2 //disguised as normal beer for use by emagged brobots
 	name = "Beer"
 	id = "beer2"

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -68,7 +68,7 @@
 		cure(mob)
 		return
 
-	if(mob.stat == 2)
+	if(mob.stat == DEAD)
 		return
 	if(stage <= 1 && clicks == 0) 	// with a certain chance, the mob may become immune to the disease before it starts properly
 		if(prob(5))


### PR DESCRIPTION
This started as a "hey, there's no drugs that *just* apply paralyze, I should change that" and became "wait, why the fuck is Paralyze just Sleeping 2". So I set out on a QUEST to refactor paralysis into a more unique condition; being paralyzed means you can't move or do anything, but you can still see and hear the world around you! So this could be used either for simplemobs (esp. if they have some 'drag back to nest' AI), maintpreds, or whatever else!

A fairly extensive work in progress as there are still a few things I need to iron out and test to be sure there's no weird interactions.

- [x] Make paralysis, well, paralyze you. No movement or say/emote allowed.
- [ ] Make sure you can still hear/see messages. Partially done; hearing works, but visible_messages are being parsed as if blind for some reason.
- [ ] Make sure paralysis properly stops buckling and most item usage.
- [ ] Fix any other lingering oddities.

Would greatly appreciate a couple more sets of eyes on this to help me track down and fix some of the leftover issues.