### PR TITLE
nif duplication prevention

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -52,7 +52,7 @@
 /datum/species/create_organs(var/mob/living/carbon/human/H)
 	..()
 	var/has_nif = FALSE
-	for(var/C in H.contents["head"].implants)
+	for(var/C in H.contents["head"].contents)
 		if(istype(C, /obj/item/device/nif))
 			has_nif = TRUE
 	if(H.nif && !has_nif)

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -50,17 +50,20 @@
 		unarmed_attacks += new u_type()
 
 /datum/species/create_organs(var/mob/living/carbon/human/H)
-	if(H.nif)
+	..()
+	var/has_nif = FALSE
+	for(var/C in H.contents["head"].implants)
+		if(istype(C, /obj/item/device/nif))
+			has_nif = TRUE
+	if(H.nif && !has_nif)
 		var/type = H.nif.type
 		var/durability = H.nif.durability
 		var/list/nifsofts = H.nif.nifsofts
 		var/list/nif_savedata = H.nif.save_data.Copy()
-		..()
 
 		var/obj/item/device/nif/nif = new type(H,durability,nif_savedata)
 		nif.nifsofts = nifsofts
-	else
-		..()
+
 /datum/species/proc/produceCopy(var/list/traits, var/mob/living/carbon/human/H, var/custom_base)
 	ASSERT(src)
 	ASSERT(istype(H))


### PR DESCRIPTION
When we are creating organs through the create_organ call, we should first do the organ part, then check if there is already a nif installed and in case there is, we do not want to add another one.

If someone rather wants to have the old one deleted, it's just to remove it from both lists in case it exists and qdel it. Then continue with adding a new one.

H.contents["head"].implants
H.contents["head"].contents

Someone with more experience with NIFs should test this as well. I mostly did a few quick tests.