### PR TITLE
RD Console DesignDisk Fix

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -143,7 +143,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	if(!emagged)
 		playsound(src, 'sound/effects/sparks4.ogg', 75, 1)
 		emagged = 1
-		to_chat(user, "<span class='notice'>You you disable the security protocols.</span>")
+		to_chat(user, "<span class='notice'>You disable the security protocols.</span>")
 		return 1
 
 /obj/machinery/computer/rdconsole/proc/GetResearchLevelsInfo()

--- a/tgui/packages/tgui/interfaces/ResearchConsole.js
+++ b/tgui/packages/tgui/interfaces/ResearchConsole.js
@@ -196,7 +196,7 @@ const TechDisk = (props, context) => {
 const DataDisk = (props, context) => {
   const { act, data } = useBackend(context);
 
-  const { designs } = data.info;
+  const { designs } = data;
 
   const { disk } = props;
 
@@ -233,20 +233,22 @@ const DataDisk = (props, context) => {
           onInput={(e, v) => act('search', { search: v })}
           mb={1}
         />
-        <LabeledList>
-          {designs.map((item) => (
-            <LabeledList.Item label={item.name} key={item.name}>
-              <Button
-                icon="save"
-                onClick={() => {
-                  setSaveDialog(false);
-                  act('copy_design', { copy_design_ID: item.id });
-                }}>
-                Copy To Disk
-              </Button>
-            </LabeledList.Item>
-          ))}
-        </LabeledList>
+        {(designs && designs.length && (
+          <LabeledList>
+            {designs.map((item) => (
+              <LabeledList.Item label={item.name} key={item.name}>
+                <Button
+                  icon="save"
+                  onClick={() => {
+                    setSaveDialog(false);
+                    act('copy_design', { copy_design_ID: item.id });
+                  }}>
+                  Copy To Disk
+                </Button>
+              </LabeledList.Item>
+            ))}
+          </LabeledList>
+        )) || <Box color="warning">No designs found.</Box>}
       </Section>
     );
   }


### PR DESCRIPTION
-> Fixes the RD console crash and allows designs to be transferred from one console to another using the disks

!Please rebuild tgui before merging and add the built package. I would have to scrap some other things to do that right now.

Fixes #15263