### PR TITLE
radstorm changes and borg module fixes

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -34,6 +34,8 @@
 		SSradiation.z_radiate(locate(1, 1, z), radiation_level, 1)
 
 	for(var/mob/living/carbon/C in living_mob_list)
+		if(!(C.z in using_map.station_levels) || C.isSynthetic() || isbelly(C.loc))
+			continue
 		var/area/A = get_area(C)
 		if(!A)
 			continue
@@ -41,7 +43,9 @@
 			continue
 		if(istype(C,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C
-			if(prob(5))
+			var/chance = 5.0
+			chance -= (chance / 100) * C.getarmor(null, "rad")
+			if(prob(chance))
 				if (prob(75))
 					randmutb(H) // Applies bad mutation
 					domutcheck(H,null,MUTCHK_FORCED)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -237,6 +237,7 @@
 	icon_state = "synthtongue"
 	hitsound = 'sound/effects/attackblob.ogg'
 	var/emagged = 0
+	var/busy = 0 	//prevents abuse and runtimes
 
 /obj/item/device/robot_tongue/New()
 	..()
@@ -263,21 +264,27 @@
 		return
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if(busy)
+		to_chat(user, "<span class='warning'>You are already licking something else.</span>")
+		return
 	if(user.client && (target in user.client.screen))
 		to_chat(user, "<span class='warning'>You need to take \the [target.name] off before cleaning it!</span>")
 		return
 	else if(istype(target,/obj/item))
 		if(istype(target,/obj/item/trash))
 			user.visible_message("<span class='filter_notice'>[user] nibbles away at \the [target.name].</span>", "<span class='notice'>You begin to nibble away at \the [target.name]...</span>")
+			busy = 1
 			if(do_after (user, 50))
 				user.visible_message("<span class='filter_notice'>[user] finishes eating \the [target.name].</span>", "<span class='notice'>You finish eating \the [target.name].</span>")
 				to_chat(user, "<span class='notice'>You finish off \the [target.name].</span>")
 				qdel(target)
 				var/mob/living/silicon/robot/R = user
 				R.cell.charge += 250
+			busy = 0
 			return
 		if(istype(target,/obj/item/weapon/cell))
 			user.visible_message("<span class='filter_notice'>[user] begins cramming \the [target.name] down its throat.</span>", "<span class='notice'>You begin cramming \the [target.name] down your throat...</span>")
+			busy = 1
 			if(do_after (user, 50))
 				user.visible_message("<span class='filter_notice'>[user] finishes gulping down \the [target.name].</span>", "<span class='notice'>You finish swallowing \the [target.name].</span>")
 				to_chat(user, "<span class='notice'>You finish off \the [target.name], and gain some charge!</span>")
@@ -285,6 +292,7 @@
 				var/obj/item/weapon/cell/C = target
 				R.cell.charge += C.charge / 3
 				qdel(target)
+			busy = 0
 			return
 	else if(ishuman(target))
 		if(src.emagged)
@@ -345,7 +353,8 @@
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "swordtail"
 	desc = "A glowing dagger. It appears to be extremely sharp."
-	force = 20 //Takes 5 hits to 100-0
+	force = 35 //Takes 3 hits to 100-0
+	armor_penetration = 70
 	sharp = TRUE
 	edge = TRUE
 	throwforce = 0 //This shouldn't be thrown in the first place.


### PR DESCRIPTION
change: the mutation chance of radiation storms will now only affect livings on station level
change: the mutation chance of radiation storm will no longer affect synthetics
change: the mutation chance of radiation storms will respect raidation suits
balance: ERT robot energy sword tail has been buffed to 35 damage, 70 armour pen to be more in line with other energy weapons
fix: synthtongue lick exploit has been fixed, prevents surreal charge gains from a single cell