### PR TITLE
Adds info button back in

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1429,6 +1429,19 @@ window "rpane"
 		is-checked = true
 		group = "rpanemode"
 		button-type = pushbox
+	elem "infob"
+		type = BUTTON
+		pos = 60,0
+		size = 60x16
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		background-color = none
+		is-visible = false
+		saved-params = "is-checked"
+		text = "Info"
+		command = ".winset \"rpanewindow.left=infowindow\""
+		group = "rpanemode"
+		button-type = pushbox
 	elem "mediapanel"
 		type = BROWSER
 		pos = 392,25


### PR DESCRIPTION
So. Back in #15518 the browser sidepanel got removed. And I don't think there were any uses of that so that's fine, and this doesn't return those elements.

The info button that was simultaneously removed on the other hand, serves a very important use. If you ever hit the Text button right next to it to hide the verbs/examine panel, the Info button is how you restored it. Without this button, you have to restart your client to get back your verbs panel. This brings the Info button back.

An alternative solution would be to remove the Text button as well, however I went for just returning the Info button as theoretically hiding the verbs panel completely with the Text button can reduce lag in some cases.