### PR TITLE
Robot dogborg melee weapons now use the melee subpath

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/dogborg/jaws/big
+/obj/item/weapon/melee/dogborg/jaws/big
 	name = "combat jaws"
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "jaws"
@@ -9,7 +9,7 @@
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
 	w_class = ITEMSIZE_NORMAL
 
-/obj/item/weapon/dogborg/jaws/small
+/obj/item/weapon/melee/dogborg/jaws/small
 	name = "puppy jaws"
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "smalljaws"
@@ -21,7 +21,7 @@
 	w_class = ITEMSIZE_NORMAL
 	var/emagged = 0
 
-/obj/item/weapon/dogborg/jaws/small/attack_self(mob/user)
+/obj/item/weapon/melee/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot/R = user
 	if(R.emagged || R.emag_items)
 		emagged = !emagged
@@ -48,7 +48,7 @@
 		update_icon()
 
 // Baton chompers
-/obj/item/weapon/borg_combat_shocker
+/obj/item/weapon/melee/borg_combat_shocker
 	name = "combat shocker"
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "combatshocker"
@@ -61,7 +61,7 @@
 	var/charge_cost = 15
 	var/dogborg = FALSE
 
-/obj/item/weapon/borg_combat_shocker/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
+/obj/item/weapon/melee/borg_combat_shocker/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	if(isrobot(target))
 		return ..()
 
@@ -348,7 +348,7 @@
 	recharge_time = 10 //Takes ten ticks to recharge a shot, so don't waste them all!
 	//cell_type = null //Same cell as a taser until edits are made.
 
-/obj/item/weapon/combat_borgblade
+/obj/item/weapon/melee/combat_borgblade
 	name = "energy blade"
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "swordtail"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -760,10 +760,10 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gun/energy/laser/mounted(src)
 	src.modules += new /obj/item/weapon/gun/energy/taser/mounted/cyborg/ertgun(src)
 	src.modules += new /obj/item/weapon/pickaxe/plasmacutter/borg(src)
-	src.modules += new /obj/item/weapon/combat_borgblade(src)
+	src.modules += new /obj/item/weapon/melee/combat_borgblade(src)
 	src.modules += new /obj/item/borg/combat/shield(src)
 	src.modules += new /obj/item/borg/combat/mobility(src)
-	src.modules += new /obj/item/weapon/borg_combat_shocker(src)
+	src.modules += new /obj/item/weapon/melee/borg_combat_shocker(src)
 	src.modules += new /obj/item/device/ticket_printer(src)
 	src.emag += new /obj/item/weapon/gun/energy/lasercannon/mounted(src)
 

--- a/code/modules/mob/living/silicon/robot/sprites/combat.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/combat.dm
@@ -101,11 +101,11 @@
 
 	..()
 
-	var/obj/item/weapon/combat_borgblade/CBB = locate() in module.modules
+	var/obj/item/weapon/melee/combat_borgblade/CBB = locate() in module.modules
 	if(CBB)
 		CBB.name = "sword tail"
 		CBB.desc = "A glowing dagger normally attached to the end of a cyborg's tail. It appears to be extremely sharp."
-	var/obj/item/weapon/borg_combat_shocker/BCS = locate() in module.modules
+	var/obj/item/weapon/melee/borg_combat_shocker/BCS = locate() in module.modules
 	if(BCS)
 		BCS.name = "combat jaws"
 		BCS.desc = "Shockingly chompy!"


### PR DESCRIPTION
None of the robot dogborg melee weapons had been subpathed to being a melee weapon.

change: the jaws are now a melee weapon
change: the combat borgblade is now a melee weapon
change: the combat shocker is now a melee weapon