### PR TITLE
Fixes pixel shift breaking a few mob scaling issues

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -276,8 +276,8 @@ default behaviour is:
 		is_shifted = FALSE
 		pixel_x = default_pixel_x
 		pixel_y = default_pixel_y
-		layer = MOB_LAYER
-		plane = MOB_PLANE
+		layer = initial(layer)
+		plane = initial(plane)
 	// End VOREstation edit
 
 	if(pulling) // we were pulling a thing and didn't lose it during our move.


### PR DESCRIPTION
bigdragon mobs would sometimes be weirdly offset after pixel shifting, because the pixel shift would set their mob plane to the wrong plane for their mob.

Simple fix, make the pixel shift refer to the mob's initial plane/layer, instead of a fixed one.