### PR TITLE
Fixes COMSIG_ATOM_ATTACK_HAND not being called in some instances

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -226,6 +226,7 @@
 
 /obj/item/attack_hand(mob/living/user as mob)
 	if (!user) return
+	..()
 	if(anchored)
 		to_chat(user, span("notice", "\The [src] won't budge, you can't pick it up!"))
 		return


### PR DESCRIPTION
/atom/proc/attack_hand just consists of a SEND_SIGNAL for that comsig.

/obj/item wasn't calling the parent proc on its attack_hand, meaning any registered signals for ATTACK_HAND were never being fired.