### PR TITLE
improved robot HUD handling

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -217,13 +217,13 @@ var/obj/screen/robot_inventory
 	update_robot_modules_display()
 
 
-/datum/hud/proc/update_robot_modules_display()
+/datum/hud/proc/update_robot_modules_display(var/reset = FALSE)
 	if(!isrobot(mymob))
 		return
 
 	var/mob/living/silicon/robot/r = mymob
 
-	if(r.shown_robot_modules)
+	if(r.shown_robot_modules && !reset)
 		//Modules display is shown
 		//r.client.screen += robot_inventory	//"store" icon
 

--- a/code/modules/admin/verbs/modify_robot.dm
+++ b/code/modules/admin/verbs/modify_robot.dm
@@ -6,7 +6,7 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(!istype(target))
+	if(!istype(target) || !target.module)
 		return
 
 	if(!target.module.modules)
@@ -45,6 +45,7 @@
 					robot.module.contents.Remove(add_item)
 					target.module.modules.Add(add_item)
 					target.module.contents.Add(add_item)
+					target.hud_used.update_robot_modules_display()
 					to_chat(usr, "<span class='danger'>You added \"[add_item]\" to [target].</span>")
 					if(istype(add_item, /obj/item/stack/))
 						var/obj/item/stack/item_with_synth = add_item
@@ -94,6 +95,7 @@
 				if(!istype(selected_module_module, /obj/item/))
 					break
 				to_chat(usr, "<span class='danger'>You removed \"[selected_module_module]\" from [target]</span>")
+				target.hud_used.update_robot_modules_display(TRUE)
 				target.module.emag.Remove(selected_module_module)
 				target.module.modules.Remove(selected_module_module)
 				target.module.contents.Remove(selected_module_module)

--- a/code/modules/admin/verbs/modify_robot.dm
+++ b/code/modules/admin/verbs/modify_robot.dm
@@ -95,6 +95,7 @@
 				if(!istype(selected_module_module, /obj/item/))
 					break
 				to_chat(usr, "<span class='danger'>You removed \"[selected_module_module]\" from [target]</span>")
+				target.uneq_all()
 				target.hud_used.update_robot_modules_display(TRUE)
 				target.module.emag.Remove(selected_module_module)
 				target.module.modules.Remove(selected_module_module)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -341,6 +341,7 @@
 	hands.icon_state = get_hud_module_icon()
 	feedback_inc("cyborg_[lowertext(modtype)]",1)
 	updatename()
+	hud_used.update_robot_modules_display()
 	notify_ai(ROBOT_NOTIFICATION_NEW_MODULE, module.name)
 
 /mob/living/silicon/robot/proc/update_braintype()
@@ -767,6 +768,7 @@
 				to_chat(usr, "<span class='filter_notice'>You apply the upgrade to [src]!</span>")
 				usr.drop_item()
 				U.loc = src
+				hud_used.update_robot_modules_display()
 			else
 				to_chat(usr, "<span class='filter_notice'>Upgrade error!</span>")
 
@@ -804,12 +806,13 @@
 /mob/living/silicon/robot/proc/module_reset()
 	transform_with_anim() //VOREStation edit: sprite animation
 	uneq_all()
+	hud_used.update_robot_modules_display(TRUE)
 	modtype = initial(modtype)
 	hands.icon_state = get_hud_module_icon()
 
 	notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
 	module.Reset(src)
-	qdel(module)
+	module.Destroy()
 	module = null
 	updatename("Default")
 
@@ -1374,6 +1377,7 @@
 				laws.show_laws(src)
 				to_chat(src, "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and [TU.his] commands.</span>")
 				update_icon()
+				hud_used.update_robot_modules_display()
 		else
 			to_chat(user, "<span class='filter_warning'>You fail to hack [src]'s interface.</span>")
 			to_chat(src, "<span class='filter_warning'>Hack attempt detected.</span>")


### PR DESCRIPTION
fixes: robot UI modules not showing on change or robot reset
fixes: robot tools getting stuck on module reset or admin removal on screen
change: when new modules are added, the UI is refreshed
change: when modules are removed or the entire robot is reset, the hud is hidden beforehand
change: admin module removing unequips all active modules