### PR TITLE
stop overcharge steal on borgs

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -72,9 +72,12 @@
 /obj/machinery/recharge_station/proc/process_occupant()
 	if(isrobot(occupant))
 		var/mob/living/silicon/robot/R = occupant
-		if(R.module)
+		var/overcharged = FALSE
+		if(R.cell.maxcharge < R.cell.charge)
+			overcharged = TRUE
+		if(R.module && !overcharged)
 			R.module.respawn_consumable(R, charging_power * CELLRATE / 250) //consumables are magical, apparently
-		if(R.cell && !R.cell.fully_charged())
+		if(R.cell && !R.cell.fully_charged() && !overcharged)
 			var/diff = min(R.cell.maxcharge - R.cell.charge, charging_power * CELLRATE) // Capped by charging_power / tick
 			var/charge_used = cell.use(diff)
 			R.cell.give(charge_used)


### PR DESCRIPTION
While other codebases do not really have that problem, we have the ability to get past the max charge threshold by ingesting power cells. Accidentally stepping into a charger removed all that charge. We will no longer lose our overcharge now. As we skip the charging process if the cell is part the maximum capacity. With the cell ingestion exploit fixed, that shouldn't pose an issue now.

🆑Upstream
balance: Robots no longer lose their overcharge when stepping into chargers.
 /🆑