### PR TITLE
Add /data back into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ vchat.db*
 *.pid
 cfg/
 
+#Ignore the data folder/symlink itself.  This is very important if you are using VGS
+/data
+
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*


### PR DESCRIPTION
This will fix the `data` symlink being deleted whenever the server is updated using VGS.