### PR TITLE
unicode chat handling

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -255,6 +255,10 @@
 /proc/capitalize(var/t as text)
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
+//Returns a unicode string with the first element of the string capitalized.
+/proc/capitalize_utf(var/t as text)
+	return uppertext(copytext_char(t, 1, 2)) + copytext_char(t, 2)
+
 //This proc strips html properly, remove < > and all text between
 //for complete text sanitizing should be used sanitize()
 /proc/strip_html_properly(var/input)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -22,7 +22,7 @@
 				return
 
 		if(iteration_count == 1)
-			piece = capitalize(piece)
+			piece = capitalize_utf(piece)
 
 		if(always_stars)
 			piece = stars(piece)


### PR DESCRIPTION
According to the references, the unicode handling is more performance heavy than the byte handling, so we only use it for the chat right now.

🆑Upstream
fix: Unicode characters won't break any longer during Say / Whisper
/🆑 