### PR TITLE
Graphite Table Material

### DIFF
--- a/code/modules/materials/materials/metals/metals.dm
+++ b/code/modules/materials/materials/metals/metals.dm
@@ -151,6 +151,7 @@
 	stack_type = /obj/item/stack/material/graphite
 	flags = MATERIAL_BRITTLE
 	icon_base = "solid"
+	table_icon_base = "stone"
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#333333"
 	hardness = 75


### PR DESCRIPTION
Changes graphite to use stone table appearance when used to build tables.