### PR TITLE
Url regex slightly adjusted

### DIFF
--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\[-a-zA-Z0-9@:%._+~#=]{1,256}\\b(?:\[-a-zA-Z0-9@:%_+.,~#?&//=]*\[^.,!?:; ()<>{}\\[]\n\"'´`]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\[-a-zA-Z0-9@:%._+~#=]{1,256}\\b(?:\[-a-zA-Z0-9@():%_+.,~#?&/=]*\[^.,!?:; ()<>{}\\[]\n\"'´`]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}]\n]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}\]\n]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.?]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}]\n]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}\]\n]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\[-a-zA-Z0-9@:%._+~#=]{1,256}\\b(?:\[-a-zA-Z0-9@:%_+.,~#?&//=]*\[^.,!?:; ()<>{}\\[]\n\"'´`]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}]\n]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://)\[-a-zA-Z0-9@:%._+~#=]{1,256}.\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,!?:; )>}]\n]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,?!]))", "gm"))

--- a/code/_global_vars/_regexes.dm
+++ b/code/_global_vars/_regexes.dm
@@ -1,4 +1,4 @@
 //These are a bunch of regex datums for use /((any|every|no|some|head|foot)where(wolf)?\sand\s)+(\.[\.\s]+\s?where\?)?/i
 GLOBAL_DATUM_INIT(is_http_protocol, /regex, regex("^https?://"))
 
-GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.,?!]))", "gm"))
+GLOBAL_DATUM_INIT(is_valid_url, /regex, regex("((?:https://.)\[-a-zA-Z0-9@:%._+~#=]{2,256}.\[a-z]{2,6}\\b(?:\[-a-zA-Z0-9@:%_+.~#?&//=]*\[^.?]))", "gm"))


### PR DESCRIPTION
It's more than likely that we might have some texts we close with a punctation mark after an url, so let's not parse them if they are standing alone.

Ok I got no clue why we are using , in our wiki links. But now that should work as well...

🆑 Upstream
qol: URL regex adjusted to ignore trailing punctation marks (:.?)
fix: , in vorestation wiki links not breaking the url parsing
/🆑 