### PR TITLE
further teleport pulling fixes

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -117,7 +117,7 @@
 			L.stop_pulling()
 			P.forceMove(T)
 			L.forceMove(T)
-			L.start_pulling(P)
+			L.continue_pulling(P)
 		else
 			L.forceMove(T)
 	else
@@ -285,4 +285,3 @@ var/global/list/tele_landmarks = list() // Terrible, but the alternative is loop
 
 /obj/effect/step_trigger/warning/train_edge
 	warningmessage = "The wind billowing alongside the train is extremely strong here! Any movement could easily pull you down beneath the carriages, return to the train immediately!"
-

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -220,7 +220,7 @@
 		if(L.pulling && !L.pulling.anchored)
 			var/atom/movable/P = L.pulling
 			P.forceMove(get_turf(top))
-			L.start_pulling(P)
+			L.continue_pulling(P)
 
 		for(var/obj/item/weapon/grab/G in list(L.l_hand, L.r_hand))
 			G.affecting.forceMove(get_turf(top))
@@ -479,7 +479,7 @@
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
 		if(P)
 			P.forceMove(get_turf(bottom))
-			L.start_pulling(P)
+			L.continue_pulling(P)
 
 		for(var/obj/item/weapon/grab/G in list(L.l_hand, L.r_hand))
 			G.affecting.forceMove(get_turf(bottom))


### PR DESCRIPTION
Seems I've forgotten some teleporters which still used start_pulling instead of the new continue_pulling.

🆑 Upstream
fix: teleporter pulling, like on tether mining will no longer interrupt pulling
fix: stairs use the continue pulling now was well
/🆑 