### PR TITLE
remove static input background color in borghotkey mode

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,7 +1,7 @@
 macro "borghotkeymode"
 	elem
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5\""
+		command = ".winset \"mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true\""
 	elem
 		name = "Shift"
 		command = "KeyDown Shift"
@@ -790,7 +790,7 @@ macro "hotkeymode"
 macro "borgmacro"
 	elem
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
+		command = ".winset \"mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
 	elem
 		name = "Shift"
 		command = "KeyDown Shift"


### PR DESCRIPTION
Having the color defined static in the borg hotkey/macro mode causes the input toolbar to end up white with white text after use in darkmode. The static definition here is no longer compatible with the themes. As it's only used with borgs, normal players never had the issue. So removing it fully for now until finding (or if someone finds) a way to reintroduce it compatible with the themes.

🆑 
del: hotkey input background color for borghotkeymode / borgmarco
/🆑  