### PR TITLE
fixes unusable grill recipes

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/container.dm
+++ b/code/modules/food/kitchen/cooking_machines/container.dm
@@ -193,7 +193,6 @@
 
 	// We add to the insertable list specifically for the oven trays, to allow specialty cakes.
 	insertable += list(
-		/obj/item/clothing/head/cakehat, // This is because we want to allow birthday cakes to be makeable.
 		/obj/item/organ/internal/brain // As before, needed for braincake
 	)
 
@@ -217,10 +216,6 @@
 		/obj/item/organ/internal/brain,
 		/obj/item/robot_parts/head,
 		/obj/item/weapon/ectoplasm,
-		/obj/item/clothing/mask/gas/clown_hat,
-		/obj/item/clothing/head/beret,
 		/obj/item/weapon/holder/mouse,
-		/obj/item/stack/rods,
-		/obj/item/clothing/head/wizard/fake,
-		/obj/item/clothing/head/wizard
+		/obj/item/stack/rods
 	)

--- a/code/modules/food/kitchen/cooking_machines/container.dm
+++ b/code/modules/food/kitchen/cooking_machines/container.dm
@@ -208,3 +208,19 @@
 	shortname = "rack"
 	desc = "Put ingredients 'in'/on this; designed for use with a grill. Warranty void if used incorrectly. Alt click to remove contents."
 	icon_state = "grillrack"
+
+/obj/item/weapon/reagent_containers/cooking_container/grill/Initialize()
+	. = ..()
+
+	// Needed for the special recipes of the grill
+	insertable += list(
+		/obj/item/organ/internal/brain,
+		/obj/item/robot_parts/head,
+		/obj/item/weapon/ectoplasm,
+		/obj/item/clothing/mask/gas/clown_hat,
+		/obj/item/clothing/head/beret,
+		/obj/item/weapon/holder/mouse,
+		/obj/item/stack/rods,
+		/obj/item/clothing/head/wizard/fake,
+		/obj/item/clothing/head/wizard
+	)


### PR DESCRIPTION
adds the special ingredients to the grill and cleans up duplications which are already on the default list.

🆑 Upstream
fix: Fixes the unusable grill recipes by adding the special ingredients to the insertable list
/🆑  