### PR TITLE
Adds syndi var to omni key

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -128,6 +128,7 @@
 
 /obj/item/device/encryptionkey/omni		//Literally only for the admin intercoms
 	channels = list("Mercenary" = 1, "Raider" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
+	syndie = 1//Signifies that it de-crypts Syndicate transmissions
 
 /obj/item/device/encryptionkey/ent
 	name = "entertainment encryption key"


### PR DESCRIPTION
We can't quite listen into those mercenary channels even though we have them without being allowed to decrypt them.

🆑Upstream 
fix: omni key allowing to listening in to merc channels
/🆑 