### PR TITLE
Temp disable textlimit warnings

### DIFF
--- a/code/modules/vore/eating/mob_vr.dm
+++ b/code/modules/vore/eating/mob_vr.dm
@@ -24,7 +24,8 @@
 	var/allow_spontaneous_tf = FALSE	// Obviously.
 	var/show_vore_fx = TRUE				// Show belly fullscreens
 	var/selective_preference = DM_DEFAULT	// Preference for selective bellymode
-	var/eating_privacy_global = FALSE //Makes eating attempt/success messages only reach for subtle range if true, overwritten by belly-specific var
+	var/text_warnings = TRUE 			// Allows us to dismiss the text limit warning messages after viewing it once per round
+	var/eating_privacy_global = FALSE 	// Makes eating attempt/success messages only reach for subtle range if true, overwritten by belly-specific var
 	var/nutrition_message_visible = TRUE
 	var/list/nutrition_messages = list(
 							"They are starving! You can hear their stomach snarling from across the room!",

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1009,7 +1009,9 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 				host.vore_selected.absorbed_desc = new_desc
 				. = TRUE
 		if("b_msgs")
-			tgui_alert(user,"Setting abusive or deceptive messages will result in a ban. Consider this your warning. Max 150 characters per message (250 for examines, 500 for idle messages), max 10 messages per topic.","Really, don't.") // Should remain tgui_alert() (blocking)
+			if(host.text_warnings)
+				if(tgui_alert(user,"Setting abusive or deceptive messages will result in a ban. Consider this your warning. Max 150 characters per message (250 for examines, 500 for idle messages), max 10 messages per topic.","Really, don't.",list("OK", "Disable Warnings")) == "Disable Warnings") // Should remain tgui_alert() (blocking)
+					host.text_warnings = FALSE
 			var/help = " Press enter twice to separate messages. '%pred' will be replaced with your name. '%prey' will be replaced with the prey's name. '%belly' will be replaced with your belly's name. '%count' will be replaced with the number of anything in your belly. '%countprey' will be replaced with the number of living prey in your belly."
 			switch(params["msgtype"])
 				if("dmp")

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1009,9 +1009,9 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 				host.vore_selected.absorbed_desc = new_desc
 				. = TRUE
 		if("b_msgs")
-			if(host.text_warnings)
+			if(user.text_warnings)
 				if(tgui_alert(user,"Setting abusive or deceptive messages will result in a ban. Consider this your warning. Max 150 characters per message (250 for examines, 500 for idle messages), max 10 messages per topic.","Really, don't.",list("OK", "Disable Warnings")) == "Disable Warnings") // Should remain tgui_alert() (blocking)
-					host.text_warnings = FALSE
+					user.text_warnings = FALSE
 			var/help = " Press enter twice to separate messages. '%pred' will be replaced with your name. '%prey' will be replaced with the prey's name. '%belly' will be replaced with your belly's name. '%count' will be replaced with the number of anything in your belly. '%countprey' will be replaced with the number of living prey in your belly."
 			switch(params["msgtype"])
 				if("dmp")

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -249,6 +249,7 @@
 	new_mob.nutrition_message_visible = nutrition_message_visible
 	new_mob.allow_spontaneous_tf = allow_spontaneous_tf
 	new_mob.eating_privacy_global = eating_privacy_global
+	new_mob.text_warnings = text_warnings
 
 /////SUBTYPES/////
 

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -154,10 +154,6 @@
 	set name = "Adjust Mass"
 	set category = "Abilities" //Seeing as prometheans have an IC reason to be changing mass.
 
-	if(!resizable)
-		to_chat(src, "<span class='warning'>You are immune to resizing!</span>")
-		return
-
 	var/nagmessage = "Adjust your mass to be a size between 25 to 200% (or 1% to 600% in dormitories). (DO NOT ABUSE)"
 	var/default = size_multiplier * 100
 	var/new_size = tgui_input_number(usr, nagmessage, "Pick a Size", default, 600, 1)


### PR DESCRIPTION
The textlimit warnings of the vorepanel can now be disabled for the round / in the menu after viewing them once by clicking "Disable Warnings" on the popup.
For some reason the self-resize verb had been blocked by the vorepanel pref even though self resizing should've been excluded from the blocking.

🆑 Upstream
qol: Allows to temporarily disable textlimit warnings for the vorepanel belly texts
fix: the self resize verb now can be used even if resizing through others is disabled
/🆑 