### PR TITLE
Metamorphosis Ray design for RnD

### DIFF
--- a/code/modules/research/designs/weapons_vr.dm
+++ b/code/modules/research/designs/weapons_vr.dm
@@ -33,6 +33,14 @@
 	build_path = /obj/item/weapon/gun/energy/netgun
 	sort_string = "MAAVC"
 
+/datum/design/item/weapon/energy/metamorphosisray
+	name = "metamorphosis ray"
+	id = "metamorphosisray"
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 4, TECH_BIO = 5, TECH_BLUESPACE = 4, TECH_ILLEGAL = 5)
+	materials = list(MAT_STEEL = 1000, MAT_GLASS = 2000, MAT_URANIUM = 500, MAT_PHORON = 1500)
+	build_path = /obj/item/weapon/gun/energy/mouseray/metamorphosis
+	sort_string = "MAAVD"
+
 // Misc weapons
 
 /datum/design/item/weapon/pummeler


### PR DESCRIPTION
A fun scene tool now more available, similar to how RnD can print others like the Body Snatcher. Tech and Material costs based off the Recombobulation Ray design which is effectively the same gun but only reverts. Added requirement for Illegal level 5 and placed under the energy weapon category.