### PR TITLE
small qol (naming fixes)

### DIFF
--- a/code/modules/research/designs/locator_devices.dm
+++ b/code/modules/research/designs/locator_devices.dm
@@ -6,7 +6,7 @@
 
 /datum/design/item/gps/AssembleDesignName()
 	..()
-	name = "Triangulating device design ([name])"
+	name = "Triangulating device design (GPS - [name])"
 
 /datum/design/item/gps/generic
 	name = "GEN"

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -117,7 +117,7 @@
 //Robo internal organ fix. For when an organic has robotic limbs.
 /datum/surgery_step/fix_organic_organ_robotic //For artificial organs
 	surgery_name = "Mend Organ"
-	
+
 	allowed_tools = list(
 	/obj/item/stack/nanopaste = 100,
 	/obj/item/stack/cable_coil = 75,

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -20,7 +20,7 @@
 //				CHEST INTERNAL ORGAN SURGERY					//
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/internal/fix_organ
-	surgery_name = "Dress Organ"
+	surgery_name = "Treat Organ"
 
 	allowed_tools = list(
 	/obj/item/stack/medical/advanced/bruise_pack= 100,		\
@@ -117,7 +117,7 @@
 //Robo internal organ fix. For when an organic has robotic limbs.
 /datum/surgery_step/fix_organic_organ_robotic //For artificial organs
 	surgery_name = "Mend Organ"
-
+	
 	allowed_tools = list(
 	/obj/item/stack/nanopaste = 100,
 	/obj/item/stack/cable_coil = 75,
@@ -191,7 +191,7 @@
 ///////////////////////////////////////////////////////////////
 
 /datum/surgery_step/internal/detatch_organ/
-	surgery_name = "Detatch Organ"
+	surgery_name = "Detach Organ"
 
 	allowed_tools = list(
 	/obj/item/weapon/surgical/scalpel = 100,		\


### PR DESCRIPTION
🆑 Upstream
qol: added GPS into Triangulating device design names, so that people find it when only searching for GPS
qol: changed the wording on the organ treatment, from dress to treat. Fixed a typo in Detach.
/🆑 

Downstream: Needs manual changes as we somehow never took over the naming on those steps. DO NOT MERGE right away!