### PR TITLE
right fixes...

### DIFF
--- a/code/modules/admin/verbs/modify_robot.dm
+++ b/code/modules/admin/verbs/modify_robot.dm
@@ -3,7 +3,7 @@
 	set name = "Modify Robot Module"
 	set desc = "Allows to add or remove modules to/from robots."
 	set category = "Admin"
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN, R_FUN, R_VAREDIT))
 		return
 
 	if(!istype(target) || !target.module)

--- a/code/modules/admin/verbs/resize.dm
+++ b/code/modules/admin/verbs/resize.dm
@@ -2,9 +2,9 @@
     set name = "Resize"
     set desc = "Resizes any living mob without any restrictions on size."
     set category = "Fun"
-    if(!check_rights(R_ADMIN, R_FUN))
+    if(!check_rights(R_ADMIN, R_FUN, R_VAREDIT))
         return
-    
+
     var/size_multiplier = tgui_input_number(usr, "Input size multiplier.", "Resize", 1)
     if(!size_multiplier)
         return //cancelled


### PR DESCRIPTION
whoever has varedit rights can easily set up the size as well, so why block the verb?
rip me... robot module handling was blocked from event managers and here as well, whomever can edit vars can do that as well.

🆑 Upstream
fix: added var_edit rights to resize
fix: added var_edit and fun rights to robot module handling
/🆑 