### PR TITLE
fix division by 0 on fire effects

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -365,7 +365,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	var/total_combustables = (total_fuel + total_oxidizers)
 	var/active_combustables = (FIRE_REACTION_OXIDIZER_AMOUNT/FIRE_REACTION_FUEL_AMOUNT + 1)*reaction_limit
 
-	if(total_combustables > 0)
+	if(total_combustables > 0 && total_moles > 0)
 		//slows down the burning when the concentration of the reactants is low
 		var/damping_multiplier = min(1, active_combustables / (total_moles/group_multiplier))
 


### PR DESCRIPTION
🆑  Upstream
fix: fixed a division by zero in case special breath attacks are used in vacuumed rooms
/🆑 