### PR TITLE
we never want half or empty stacks

### DIFF
--- a/code/modules/materials/materials/_materials.dm
+++ b/code/modules/materials/materials/_materials.dm
@@ -326,7 +326,8 @@ var/list/name_to_material
 
 // Debris product. Used ALL THE TIME.
 /datum/material/proc/place_sheet(var/turf/target, amount)
-	if(stack_type)
+	amount = round(amount)
+	if(stack_type && amount > 0)
 		return new stack_type(target, amount)
 
 // As above.


### PR DESCRIPTION
We neither want half stacks as they can break things, nor do we want empty, unusable stacks, so let's just round and test if the stacks actually contain something before creation.

🆑  Upstream
fix: dropping empty stacks during protolathe / mech fab deconstruction
/🆑 