### PR TITLE
porting healthbars from roguestar + disassemble mat fixes

### DIFF
--- a/code/datums/observation/stat_set.dm
+++ b/code/datums/observation/stat_set.dm
@@ -22,3 +22,12 @@ GLOBAL_DATUM_INIT(stat_set_event, /decl/observ/stat_set, new)
 	. = ..()
 	if(stat != old_stat)
 		GLOB.stat_set_event.raise_event(src, old_stat, new_stat)
+
+		if(isbelly(src.loc))
+			var/obj/belly/ourbelly = src.loc
+			if(!ourbelly.owner.client)
+				return
+			if(stat == CONSCIOUS)
+				to_chat(ourbelly.owner, "<span class='notice'>\The [src.name] is awake.</span>")
+			else if(stat == UNCONSCIOUS)
+				to_chat(ourbelly.owner, "<span class='red'>\The [src.name] has fallen unconscious!</span>")

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -50,7 +50,7 @@
 	if(W.has_tool_quality(TOOL_WELDER) && material.shard_can_repair)
 		var/obj/item/weapon/weldingtool/WT = W.get_welder()
 		if(WT.remove_fuel(0, user))
-			material.place_sheet(loc)
+			material.place_sheet(loc, 1)
 			qdel(src)
 			return
 	return ..()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -155,7 +155,7 @@
 
 /obj/structure/bed/proc/remove_padding()
 	if(padding_material)
-		padding_material.place_sheet(get_turf(src))
+		padding_material.place_sheet(get_turf(src), 1)
 		padding_material = null
 	update_icon()
 
@@ -164,9 +164,9 @@
 	update_icon()
 
 /obj/structure/bed/proc/dismantle()
-	material.place_sheet(get_turf(src))
+	material.place_sheet(get_turf(src), 1)
 	if(padding_material)
-		padding_material.place_sheet(get_turf(src))
+		padding_material.place_sheet(get_turf(src), 1)
 
 /obj/structure/bed/psych
 	name = "psychiatrist's couch"

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -67,7 +67,7 @@ var/global/list/stool_cache = list() //haha stool
 
 /obj/item/weapon/stool/proc/remove_padding()
 	if(padding_material)
-		padding_material.place_sheet(get_turf(src))
+		padding_material.place_sheet(get_turf(src), 1)
 		padding_material = null
 	update_icon()
 
@@ -104,9 +104,9 @@ var/global/list/stool_cache = list() //haha stool
 
 /obj/item/weapon/stool/proc/dismantle()
 	if(material)
-		material.place_sheet(get_turf(src))
+		material.place_sheet(get_turf(src), 1)
 	if(padding_material)
-		padding_material.place_sheet(get_turf(src))
+		padding_material.place_sheet(get_turf(src), 1)
 	qdel(src)
 
 /obj/item/weapon/stool/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -330,6 +330,12 @@ var/list/_client_preferences_by_type
 	enabled_description = "On"
 	disabled_description = "Off"
 
+/datum/client_preference/vore_health_bars
+	description = "Vore Health Bars"
+	key = "VORE_HEALTH_BARS"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+
 /datum/client_preference/runechat_mob
 	description = "Runechat (Mobs)"
 	key = "RUNECHAT_MOB"

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -489,6 +489,19 @@
 
 	feedback_add_details("admin_verb","TSubtleSounds")
 
+/client/verb/toggle_vore_health_bars()
+	set name = "Toggle Vore Health Bars"
+	set category = "Preferences"
+	set desc = "Toggle the display of vore related health bars"
+
+	var/pref_path = /datum/client_preference/vore_health_bars
+	toggle_preference(pref_path)
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	to_chat(src, "Vore related health bars - [(is_preference_enabled(/datum/client_preference/vore_health_bars)) ? "Enabled" : "Disabled"]")
+
+	feedback_add_details("admin_verb","TVoreHealthBars")
+
 // Not attached to a pref datum because those are strict binary toggles
 /client/verb/toggle_examine_mode()
 	set name = "Toggle Examine Mode"

--- a/code/modules/materials/materials/_materials.dm
+++ b/code/modules/materials/materials/_materials.dm
@@ -322,7 +322,7 @@ var/list/name_to_material
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
 /datum/material/proc/place_dismantled_product(var/turf/target)
-	place_sheet(target)
+	place_sheet(target, 1)
 
 // Debris product. Used ALL THE TIME.
 /datum/material/proc/place_sheet(var/turf/target, amount)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -693,6 +693,7 @@
 				stat("Keys Held", keys2text(client.move_keys_held | client.mod_keys_held))
 				stat("Next Move ADD", dirs2text(client.next_move_dir_add))
 				stat("Next Move SUB", dirs2text(client.next_move_dir_sub))
+				stat("Current size:", size_multiplier * 100)
 
 			if(statpanel("MC"))
 				stat("Location:", "([x], [y], [z]) [loc]")

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -305,13 +305,13 @@ var/list/table_icon_cache = list()
 	var/obj/item/weapon/material/shard/S = null
 	if(reinforced)
 		if(reinforced.stack_type && (full_return || prob(20)))
-			reinforced.place_sheet(loc)
+			reinforced.place_sheet(loc, 1)
 		else
 			S = reinforced.place_shard(loc)
 			if(S) shards += S
 	if(material)
 		if(material.stack_type && (full_return || prob(20)))
-			material.place_sheet(loc)
+			material.place_sheet(loc, 1)
 		else
 			S = material.place_shard(loc)
 			if(S) shards += S

--- a/code/modules/vore/chat_healthbars.dm
+++ b/code/modules/vore/chat_healthbars.dm
@@ -87,9 +87,9 @@
 	else if(ourpercent > 0)
 		ourbar = span_red("[ourbar] - [ourbelly.digest_mode]ing")
 	else
-		ourbar = "<span class = 'vdanger'>[ourbar] - [ourbelly.digest_mode]ing</span>"
+		ourbar = "<span class='vdanger'>[ourbar] - [ourbelly.digest_mode]ing</span>"
 
-	to_chat(reciever,ourbar)
+	to_chat(reciever,"<span class='vnotice'>[ourbar]</span>")
 
 /mob/living/verb/print_healthbars()
 	set name = "Print Prey Healthbars"

--- a/code/modules/vore/chat_healthbars.dm
+++ b/code/modules/vore/chat_healthbars.dm
@@ -1,0 +1,113 @@
+//Health bars in the game window would be pretty challenging and I don't know how to do that, so I thought this would be a good alternative
+
+/mob/living/proc/chat_healthbar(var/mob/living/reciever, override = FALSE)
+	if(!reciever)	//No one to send it to, don't bother
+		return
+	if(!reciever.client)	//No one is home, don't bother
+		return
+	if(!override)	//Did the person push the verb? Ignore the pref
+		if(!reciever.client.is_preference_enabled(/datum/client_preference/vore_health_bars))
+			return
+	var/ourpercent = 0
+
+	if(ishuman(src))	//humans don't die or become unconcious at 0%, it's actually like -50% or something, so, let's pretend they have 50 more health than they do
+		ourpercent = ((health + 50) / (maxHealth + 50)) * 100
+	else
+		ourpercent = (health / maxHealth) * 100
+
+	var/ourbar = ""
+	var/obj/belly/ourbelly = src.loc
+	var/which_var = "Health"
+	if(ourbelly.digest_mode == "Absorb" || ourbelly.digest_mode == "Drain")
+		ourpercent = round(((nutrition - 100) / 500) * 100)
+		which_var = "Nutrition"	//It's secretly also a nutrition bar depending on your digest mode
+
+	ourpercent = round(ourpercent)
+
+	switch(ourpercent)	//I thought about trying to do this in a more automated way but my brain isn't very large so enjoy my stupid switch statement
+		if(100)
+			ourbar = "|▓▓▓▓▓▓▓▓▓▓|"
+		if(95 to 99)
+			ourbar = "|▓▓▓▓▓▓▓▓▓▒|"
+		if(90 to 94)
+			ourbar = "|▓▓▓▓▓▓▓▓▓░|"
+		if(85 to 89)
+			ourbar = "|▓▓▓▓▓▓▓▓▒░|"
+		if(80 to 84)
+			ourbar = "|▓▓▓▓▓▓▓▓░░|"
+		if(75 to 79)
+			ourbar = "|▓▓▓▓▓▓▓▒░░|"
+		if(70 to 74)
+			ourbar = "|▓▓▓▓▓▓▓░░░|"
+		if(65 to 69)
+			ourbar = "|▓▓▓▓▓▓▒░░░|"
+		if(60 to 64)
+			ourbar = "|▓▓▓▓▓▓░░░░|"
+		if(55 to 59)
+			ourbar = "|▓▓▓▓▓▒░░░░|"
+		if(50 to 54)
+			ourbar = "|▓▓▓▓▓░░░░░|"
+		if(45 to 49)
+			ourbar = "|▓▓▓▓▒░░░░░|"
+		if(40 to 44)
+			ourbar = "|▓▓▓▓░░░░░░|"
+		if(35 to 39)
+			ourbar = "|▓▓▓▒░░░░░░|"
+		if(30 to 34)
+			ourbar = "|▓▓▓░░░░░░░|"
+		if(25 to 29)
+			ourbar = "|▓▓▒░░░░░░░|"
+		if(20 to 24)
+			ourbar = "|▓▓░░░░░░░░|"
+		if(15 to 19)
+			ourbar = "|▓▒░░░░░░░░|"
+		if(10 to 14)
+			ourbar = "|▓░░░░░░░░░|"
+		if(5 to 9)
+			ourbar = "|▒░░░░░░░░░|"
+		if(0)
+			ourbar = "|░░░░░░░░░░|"
+		else
+			ourbar = "!░░░░░░░░░░!"
+
+	ourbar = "[ourbar] [which_var] - [src.name]"
+
+	if(stat == UNCONSCIOUS)
+		ourbar = "[ourbar] - [span_orange("<b>UNCONSCIOUS</b>")]"
+	else if(stat == DEAD)
+		ourbar = "[ourbar] - [span_red("<b>DEAD</b>")]"
+	if(absorbed)
+		ourbar = span_purple("[ourbar] - ABSORBED")	//Absorb is a little funny, I didn't want it to say 'absorbing ABSORBED' so we did it different
+	else if(ourpercent > 75)
+		ourbar = span_green("[ourbar] - [ourbelly.digest_mode]ing")
+	else if(ourpercent > 50)
+		ourbar = span_yellow("[ourbar] - [ourbelly.digest_mode]ing")
+	else if(ourpercent > 25)
+		ourbar = span_orange("[ourbar] - [ourbelly.digest_mode]ing")
+	else if(ourpercent > 0)
+		ourbar = span_red("[ourbar] - [ourbelly.digest_mode]ing")
+	else
+		ourbar = "<span class = 'vdanger'>[ourbar] - [ourbelly.digest_mode]ing</span>"
+
+	to_chat(reciever,ourbar)
+
+/mob/living/verb/print_healthbars()
+	set name = "Print Prey Healthbars"
+	set category = "Abilities"
+
+	var/nuffin = TRUE
+	for(var/obj/belly/b in vore_organs)
+		if(!b.contents.len)
+			continue
+		var/belly_announce = FALSE	//We only want to announce the belly once
+		for(var/thing as anything in b.contents)
+			if(!isliving(thing))
+				continue
+			if(!belly_announce)
+				to_chat(src, "<span class='vnotice'>[b.digest_mode] - Within [b.name]:</span>")	//We only want to announce the belly if we found something
+				belly_announce = TRUE
+			var/mob/living/ourmob = thing
+			ourmob.chat_healthbar(src, TRUE)
+			nuffin = FALSE
+	if(nuffin)
+		to_chat(src, "<span class='vwarning'>There are no mobs within any of your bellies to print health bars for.</span>")

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -629,6 +629,9 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			if(!results || !results.len)
 				results = list("You were unable to examine that. Tell a developer!")
 			to_chat(user, jointext(results, "<br>"))
+			if(isliving(target))
+				var/mob/living/ourtarget = target
+				ourtarget.chat_healthbar(user)
 			return TRUE
 
 		if("Use Hand")
@@ -739,6 +742,9 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			if(!results || !results.len)
 				results = list("You were unable to examine that. Tell a developer!")
 			to_chat(user, jointext(results, "<br>"))
+			if(isliving(target))
+				var/mob/living/ourtarget = target
+				ourtarget.chat_healthbar(user)
 			return TRUE
 
 		if("Eject")

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-vchatdark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-vchatdark.scss
@@ -662,6 +662,7 @@ img.icon.bigicon {
 .red {
   color: #ff0000;
 }
+
 .crimson {
   color: #dc143c;
 }

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4113,6 +4113,7 @@
 #include "code\modules\virus2\helpers.dm"
 #include "code\modules\virus2\isolator.dm"
 #include "code\modules\virus2\items_devices.dm"
+#include "code\modules\vore\chat_healthbars.dm"
 #include "code\modules\vore\hook-defs_vr.dm"
 #include "code\modules\vore\mouseray.dm"
 #include "code\modules\vore\trycatch_vr.dm"


### PR DESCRIPTION
Porting the vore healthbars from [roguestar](https://github.com/TS-Rogue-Star/Rogue-Star/pull/126/files), but we are using 4 colour codings,

```
0-25: red
>25-50: orange
>50-75: yellow
>75-100: green
```
Also fixed that you can in belly examine prey and get the healthbar shown as well

🆑 Upstream
add: Porting the vore healthbar chatprint from roguestar with a few slight changes
fix: disassembling of multiple objects dropping 0 material stacks
/🆑 