### PR TITLE
filter improvements and oldchat colours [Follow up for #15712]

### DIFF
--- a/code/modules/vore/chat_healthbars.dm
+++ b/code/modules/vore/chat_healthbars.dm
@@ -78,6 +78,8 @@
 		ourbar = "[ourbar] - [span_red("<b>DEAD</b>")]"
 	if(absorbed)
 		ourbar = span_purple("[ourbar] - ABSORBED")	//Absorb is a little funny, I didn't want it to say 'absorbing ABSORBED' so we did it different
+	else if(ourpercent > 99 && ourbelly.digest_mode == DM_HEAL)
+		ourbar = span_green("<b>[ourbar] - [ourbelly.digest_mode]ed</b>")
 	else if(ourpercent > 75)
 		ourbar = span_green("[ourbar] - [ourbelly.digest_mode]ing")
 	else if(ourpercent > 50)
@@ -87,7 +89,7 @@
 	else if(ourpercent > 0)
 		ourbar = span_red("[ourbar] - [ourbelly.digest_mode]ing")
 	else
-		ourbar = span_red("<b>[ourbar] - [ourbelly.digest_mode]ing</b>")
+		ourbar = span_red("<b>[ourbar] - [ourbelly.digest_mode]ed</b>")
 
 	if(onExamine)
 		to_chat(reciever,"<span class='notice'>[ourbar]</span>")

--- a/code/modules/vore/chat_healthbars.dm
+++ b/code/modules/vore/chat_healthbars.dm
@@ -1,6 +1,6 @@
 //Health bars in the game window would be pretty challenging and I don't know how to do that, so I thought this would be a good alternative
 
-/mob/living/proc/chat_healthbar(var/mob/living/reciever, override = FALSE)
+/mob/living/proc/chat_healthbar(var/mob/living/reciever, onExamine = FALSE, override = FALSE)
 	if(!reciever)	//No one to send it to, don't bother
 		return
 	if(!reciever.client)	//No one is home, don't bother
@@ -87,9 +87,12 @@
 	else if(ourpercent > 0)
 		ourbar = span_red("[ourbar] - [ourbelly.digest_mode]ing")
 	else
-		ourbar = "<span class='vdanger'>[ourbar] - [ourbelly.digest_mode]ing</span>"
+		ourbar = span_red("<b>[ourbar] - [ourbelly.digest_mode]ing</b>")
 
-	to_chat(reciever,"<span class='vnotice'>[ourbar]</span>")
+	if(onExamine)
+		to_chat(reciever,"<span class='notice'>[ourbar]</span>")
+	else
+		to_chat(reciever,"<span class='vnotice'>[ourbar]</span>")
 
 /mob/living/verb/print_healthbars()
 	set name = "Print Prey Healthbars"
@@ -104,10 +107,10 @@
 			if(!isliving(thing))
 				continue
 			if(!belly_announce)
-				to_chat(src, "<span class='vnotice'>[b.digest_mode] - Within [b.name]:</span>")	//We only want to announce the belly if we found something
+				to_chat(src, "<span class='notice'>[b.digest_mode] - Within [b.name]:</span>")	//We only want to announce the belly if we found something
 				belly_announce = TRUE
 			var/mob/living/ourmob = thing
-			ourmob.chat_healthbar(src, TRUE)
+			ourmob.chat_healthbar(src, TRUE, TRUE)
 			nuffin = FALSE
 	if(nuffin)
-		to_chat(src, "<span class='vwarning'>There are no mobs within any of your bellies to print health bars for.</span>")
+		to_chat(src, "<span class='warning'>There are no mobs within any of your bellies to print health bars for.</span>")

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -327,7 +327,9 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		new_percent = (L.health / L.maxHealth) * 100
 
 	var/lets_announce = FALSE
-	if(new_percent <= 75 && old_percent > 75)
+	if(new_percent <= 99 && old_percent > 99)
+		lets_announce = TRUE
+	else if(new_percent <= 75 && old_percent > 75)
 		lets_announce = TRUE
 	else if(new_percent <= 50 && old_percent > 50)
 		lets_announce = TRUE
@@ -356,7 +358,9 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		new_percent = (L.health / L.maxHealth) * 100
 
 	var/lets_announce = FALSE
-	if(new_percent >= 75 && old_percent < 75)
+	if(new_percent >= 100 && old_percent < 100)
+		lets_announce = TRUE
+	else if(new_percent >= 75 && old_percent < 75)
 		lets_announce = TRUE
 	else if(new_percent >= 50 && old_percent < 50)
 		lets_announce = TRUE
@@ -376,7 +380,9 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/old_percent = ((old_nutrition - 100) / 500) * 100
 	var/new_percent = ((L.nutrition - 100) / 500) * 100
 	var/lets_announce = FALSE
-	if(new_percent <= 75 && old_percent > 75)
+	if(new_percent <= 99 && old_percent > 99)
+		lets_announce = TRUE
+	else if(new_percent <= 75 && old_percent > 75)
 		lets_announce = TRUE
 	else if(new_percent <= 50 && old_percent > 50)
 		lets_announce = TRUE
@@ -398,7 +404,9 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/new_percent = ((L.nutrition - 100) / 500) * 100
 
 	var/lets_announce = FALSE
-	if(new_percent <= 75 && old_percent > 75)
+	if(new_percent <= 99 && old_percent > 99)
+		lets_announce = TRUE
+	else if(new_percent <= 75 && old_percent > 75)
 		lets_announce = TRUE
 	else if(new_percent <= 50 && old_percent > 50)
 		lets_announce = TRUE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -631,7 +631,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			to_chat(user, jointext(results, "<br>"))
 			if(isliving(target))
 				var/mob/living/ourtarget = target
-				ourtarget.chat_healthbar(user)
+				ourtarget.chat_healthbar(user, TRUE)
 			return TRUE
 
 		if("Use Hand")
@@ -744,7 +744,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			to_chat(user, jointext(results, "<br>"))
 			if(isliving(target))
 				var/mob/living/ourtarget = target
-				ourtarget.chat_healthbar(user)
+				ourtarget.chat_healthbar(user, TRUE)
 			return TRUE
 
 		if("Eject")

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -78,7 +78,7 @@ em						{font-style: normal;font-weight: bold;}
 /* Miscellaneous */
 .name					{font-weight: bold;}
 .say					{}
-.alert					{color: #ff0000;}
+.alert, .valert			{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}
 .ghostalert				{color: #5c00e6;	font-style: italic; font-weight: bold;}
 
@@ -96,11 +96,11 @@ h1.alert, h2.alert		{color: #000000;}
 .passive				{color: #660000;}
 
 .critical				{color: #ff0000; font-weight: bold; font-size: 150%;}
-.danger					{color: #ff0000; font-weight: bold;}
-.warning				{color: #ff0000; font-style: italic;}
+.danger, .vdanger		{color: #ff0000; font-weight: bold;}
+.warning, .vwarning		{color: #ff0000; font-style: italic;}
 .rose					{color: #ff5050;}
 .info					{color: #0000CC;}
-.notice					{color: #000099;}
+.notice, .vnotice		{color: #000099;}
 .alium					{color: #00ff00;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
 
@@ -116,7 +116,7 @@ h1.alert, h2.alert		{color: #000000;}
 .skrellfar				{color: #70FCFF;}
 .soghun					{color: #50BA6C;}
 .solcom					{color: #22228B;}
-.changeling				{color: #800080;font-style: italic;}
+.changeling, .psay, .pemote		{color: #800080;font-style: italic;}
 .sergal					{color: #0077FF;}
 .birdsongc				{color: #CC9900;}
 .vulpkanin				{color: #B97A57;}


### PR DESCRIPTION
Seems like I had forgotten the psay/pme and vorgan tags in the default chat theme during the filter updates and no one complained right away...

Furthermore, the healthbar now will only show the automatic notifications in the vorgan filter tab. Examines and the print verb remain in the info tag. Also a 4th auto level trigger was added so that preds know right away if prey is digesting/absorbing/draining or well fully healed.

auto notif:
100/99 (all modes)
76/75 (all modes)
51/50 (all modes)
26/25 (all modes)
1/0 (digest, drain, absorb)

🆑 Upstream
qol: added the during filter updates missed class tags to the old chat stylesheet
qol: reworked filtering on the healthbar and added a 5th auto notif step
/🆑 