### PR TITLE
small typo

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -352,7 +352,7 @@
 			P.info += "<b>Time of scan:</b> [stationtime2text()]<br><br>"
 			P.info += "[generate_printing_text()]"
 			P.info += "<br><br><b>Notes:</b><br>"
-			P.name = "Body Scan - [name] ([stationtime2text()]"
+			P.name = "Body Scan - [name] ([stationtime2text()])"
 		else
 			return FALSE
 


### PR DESCRIPTION
xxx points to Body Scan - yyyy (10:57.

🆑 Upstream
spellcheck: Just a small typo (missing closing bracket) that annoyed me on the bodyscanner prints...
/🆑 