### PR TITLE
borgjaw rebalance

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -1,32 +1,28 @@
+/obj/item/weapon/melee/dogborg/jaws
+	icon = 'icons/mob/dogborg_vr.dmi'
+	hitsound = 'sound/weapons/bite.ogg'
+	throwforce = 0
+	w_class = ITEMSIZE_NORMAL
+	pry = 1
+	tool_qualities = list(TOOL_CROWBAR)
+
 /obj/item/weapon/melee/dogborg/jaws/big
 	name = "combat jaws"
-	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "jaws"
 	desc = "The jaws of the law."
 	force = 25
 	armor_penetration = 25
 	defend_chance = 15
-	throwforce = 0
-	hitsound = 'sound/weapons/bite.ogg'
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
-	w_class = ITEMSIZE_NORMAL
-	pry = 1
-	tool_qualities = list(TOOL_CROWBAR)
 
 /obj/item/weapon/melee/dogborg/jaws/small
 	name = "puppy jaws"
-	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "smalljaws"
 	desc = "The jaws of a small dog."
 	force = 10
 	defend_chance = 5
-	throwforce = 0
-	hitsound = 'sound/weapons/bite.ogg'
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
-	w_class = ITEMSIZE_NORMAL
 	var/emagged = 0
-	pry = 1
-	tool_qualities = list(TOOL_CROWBAR)
 
 /obj/item/weapon/melee/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot/R = user

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -3,23 +3,30 @@
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "jaws"
 	desc = "The jaws of the law."
-	force = 10
+	force = 25
+	armor_penetration = 25
+	defend_chance = 15
 	throwforce = 0
 	hitsound = 'sound/weapons/bite.ogg'
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
 	w_class = ITEMSIZE_NORMAL
+	pry = 1
+	tool_qualities = list(TOOL_CROWBAR)
 
 /obj/item/weapon/melee/dogborg/jaws/small
 	name = "puppy jaws"
 	icon = 'icons/mob/dogborg_vr.dmi'
 	icon_state = "smalljaws"
 	desc = "The jaws of a small dog."
-	force = 5
+	force = 10
+	defend_chance = 5
 	throwforce = 0
 	hitsound = 'sound/weapons/bite.ogg'
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
 	w_class = ITEMSIZE_NORMAL
 	var/emagged = 0
+	pry = 1
+	tool_qualities = list(TOOL_CROWBAR)
 
 /obj/item/weapon/melee/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot/R = user
@@ -27,24 +34,20 @@
 		emagged = !emagged
 		if(emagged)
 			name = "combat jaws"
-			icon = 'icons/mob/dogborg_vr.dmi'
 			icon_state = "jaws"
 			desc = "The jaws of the law."
-			force = 10
-			throwforce = 0
-			hitsound = 'sound/weapons/bite.ogg'
+			force = 25
+			armor_penetration = 25
+			defend_chance = 15
 			attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
-			w_class = ITEMSIZE_NORMAL
 		else
 			name = "puppy jaws"
-			icon = 'icons/mob/dogborg_vr.dmi'
 			icon_state = "smalljaws"
 			desc = "The jaws of a small dog."
-			force = 5
-			throwforce = 0
-			hitsound = 'sound/weapons/bite.ogg'
+			force = 10
+			armor_penetration = 0
+			defend_chance = 5
 			attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
-			w_class = ITEMSIZE_NORMAL
 		update_icon()
 
 // Baton chompers


### PR DESCRIPTION
I know they are currently not in use, but just in case, let's get them setup to be used as crowbar replacement with some higher damage.

Going with the changes from https://github.com/CHOMPStation2/CHOMPStation2/pull/7676 , just having the tooling options added to actually allow replacement / swapping for the crowbar.

🆑 
balance: rebalance dogborg jaws and cleaning up the emagged section
/🆑 