### PR TITLE
porting the notification hiding from TG

### DIFF
--- a/tgui/packages/tgui-panel/chat/ChatPageSettings.jsx
+++ b/tgui/packages/tgui-panel/chat/ChatPageSettings.jsx
@@ -44,6 +44,22 @@ export const ChatPageSettings = (props) => {
             }
           />
         </Stack.Item>
+        <Stack.Item>
+          <Button.Checkbox
+            content="Mute"
+            checked={page.hideUnreadCount}
+            icon={page.hideUnreadCount ? 'bell-slash' : 'bell'}
+            tooltip="Disables unread counter"
+            onClick={() =>
+              dispatch(
+                updateChatPage({
+                  pageId: page.id,
+                  hideUnreadCount: !page.hideUnreadCount,
+                }),
+              )
+            }
+          />
+        </Stack.Item>
         {!page.isMain ? (
           <Stack.Item>
             <Button

--- a/tgui/packages/tgui-panel/chat/ChatTabs.jsx
+++ b/tgui/packages/tgui-panel/chat/ChatTabs.jsx
@@ -39,6 +39,7 @@ export const ChatTabs = (props) => {
               key={page.id}
               selected={page === currentPage}
               rightSlot={
+                !page.hideUnreadCount &&
                 page.unreadCount > 0 && (
                   <UnreadCountWidget value={page.unreadCount} />
                 )

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -26,6 +26,7 @@ export const createPage = (obj) => {
     name: 'New Tab',
     acceptedTypes: acceptedTypes,
     unreadCount: 0,
+    hideUnreadCount: false,
     createdAt: Date.now(),
     ...obj,
   };


### PR DESCRIPTION
Seemingly TG-Chat had a small update to hide the unread notifications (message count) on a TAB, this is quite nice for admin tabs, so porting it over from https://github.com/tgstation/tgstation

🆑 Upstream
qol: allows to hide the red message count from the chat tabs
/🆑 