### PR TITLE
Smart Storage Tweaks

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -33,7 +33,7 @@
 /datum/persistent/storage/smartfridge/sheet_storage/lossy
 	name = "sheet storage lossy"
 	min_storage = 20	//if the amount is at or below this, don't cull
-	max_storage = 400	//if the amount is above this, cull it to this amount THEN do math
+	max_storage = 500	//if the amount is above this, cull it to this amount THEN do math
 	stacks_go_missing = TRUE
 	minimum_storage_reserve = TRUE
 

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -25,12 +25,17 @@
 	store_per_type = TRUE
 	target_type = /obj/machinery/smartfridge/sheets
 
+	var/min_retained = 75	//minimum percentage of current stock for retention
+	var/max_retained = 80	//maximum percentage of current stock for retention
 	var/stacks_go_missing = FALSE // Variable rate depletion of stacks inter-round
+	var/minimum_storage_reserve = FALSE	// ...but still try to maintain a minimum reserve?
 
 /datum/persistent/storage/smartfridge/sheet_storage/lossy
 	name = "sheet storage lossy"
-	max_storage = 250
+	min_storage = 20	//if the amount is at or below this, don't cull
+	max_storage = 400	//if the amount is above this, cull it to this amount THEN do math
 	stacks_go_missing = TRUE
+	minimum_storage_reserve = TRUE
 
 /datum/persistent/storage/smartfridge/sheet_storage/variable_max
 	name = "variable max storage"
@@ -65,8 +70,10 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(55,65)*0.01 // loss of 35-45% with rounding down
-			count = round(count*fuzzy)
+			var/fuzzy = rand(min_retained,max_retained)*0.01 // loss of 35-45% with rounding down
+			if(!minimum_storage_reserve || (count > min_storage && minimum_storage_reserve))
+				count = round(count*fuzzy)
+
 			if(count <= 0)
 				continue
 

--- a/code/modules/persistence/storage/storage.dm
+++ b/code/modules/persistence/storage/storage.dm
@@ -9,6 +9,7 @@
 	entry_decay_weight = 0
 	// // // //
 
+	var/min_storage = 0
 	var/max_storage = 0
 	var/store_per_type = FALSE // If true, will store up to max_storage for each type stored
 	var/target_type = null // Path of the thing that this expects to put stuff into


### PR DESCRIPTION
Some adjustments to Sheet Storage based on general feedback discussion. Implements the following;
- First, reduces the loss rate from 35\~45% to 20\~25%
- Second, increases the sheet maxcap from 250 to ~~400~~ 500
- Third, adds a minimum threshold of 20 to sheet culling

Numbers are of course up for debate, but as long as the storage is stocked *reasonably well* at some point in the prior 3~4 shifts, then even the deadest of deadshifts should have *some* materials to call upon with these numbers.

Tested locally, seems to work OK.

Input at end of test round was 800 steel, 300(?) silver, 100(?) gold, 15 graphite, 10 diamond. Stock at the start of the next round:
![image](https://github.com/VOREStation/VOREStation/assets/49700375/08316f27-fd99-4234-9cad-784a7f2b6c3a)