### PR TITLE
Adjusts a few SD things

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
@@ -97,7 +97,8 @@
 
 /mob/living/simple_mob/vore/alienanimals/space_ghost/apply_melee_effects(var/atom/A)
 	var/mob/living/L = A
-	L.hallucination += 50
+	if(L.hallucination <= 100)
+		L.hallucination += rand(1,10)
 
 /mob/living/simple_mob/vore/alienanimals/space_ghost/shoot(atom/A) //We're shooting ghosts at people and need them to have the same faction as their parent, okay?
 	if(!projectiletype)
@@ -209,7 +210,8 @@
 /mob/living/simple_mob/vore/alienanimals/spooky_ghost/apply_melee_effects(var/atom/A)
 	var/mob/living/L = A
 	if(L && istype(L))
-		L.hallucination += rand(1,50)
+		if(L.hallucination <= 100)
+			L.hallucination += rand(1,10)
 
 /mob/living/simple_mob/vore/alienanimals/spooky_ghost/Life()
 	. = ..()

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -1751,7 +1751,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/quantumpad,
+/turf/simulated/floor,
 /area/stellardelight/deck1/aft)
 "do" = (
 /obj/machinery/conveyor{
@@ -5548,6 +5552,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/mining)
 "lf" = (
@@ -7087,16 +7094,9 @@
 /turf/simulated/floor/tiled/eris/steel/gray_platform,
 /area/stellardelight/deck1/exploshuttle)
 "on" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/eris/steel/cargo,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/smartfridge/sheets/persistent,
+/turf/simulated/floor,
 /area/stellardelight/deck1/mining)
 "oo" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -18404,17 +18404,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
-"Nm" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/angled{
-	dir = 1;
-	name = "night shift APC";
-	nightshift_setting = 2
-	},
-/turf/simulated/floor/tiled/eris/steel/cargo,
-/area/stellardelight/deck1/mining)
 "No" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -22428,6 +22417,14 @@
 /obj/structure/table/standard,
 /obj/machinery/recharger{
 	pixel_y = 5
+	},
+/obj/machinery/power/apc/angled{
+	dir = 1;
+	name = "night shift APC";
+	nightshift_setting = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/mining)
@@ -33963,9 +33960,9 @@ ip
 CG
 cA
 hg
-dl
-Nm
 on
+wp
+pV
 pR
 rI
 SS

--- a/maps/submaps/space_rocks/space_rocks_stuff.dm
+++ b/maps/submaps/space_rocks/space_rocks_stuff.dm
@@ -15,16 +15,14 @@
 	name = "Asteroid Mob Spawner"
 	faction = "space_rock"
 	atmos_comp = TRUE
-	prob_spawn = 100
-	prob_fall = 40
+	prob_spawn = 25
+	prob_fall = 25
 	//guard = 20
 	mobs_to_pick_from = list(
-		/mob/living/simple_mob/animal/space/bats = 10, 
-		/mob/living/simple_mob/vore/alienanimals/space_jellyfish = 15, 
-		/mob/living/simple_mob/vore/alienanimals/startreader = 15,
-		/mob/living/simple_mob/vore/alienanimals/space_ghost = 6,
+		/mob/living/simple_mob/animal/space/ray = 50,
+		/mob/living/simple_mob/animal/space/gnat = 25,
+		/mob/living/simple_mob/animal/space/bats = 10,
+		/mob/living/simple_mob/vore/alienanimals/space_jellyfish = 1,
 		/mob/living/simple_mob/vore/oregrub = 1,
-		/mob/living/simple_mob/animal/space/carp = 3,
-		/mob/living/simple_mob/animal/space/carp/large = 1,
-		/mob/living/simple_mob/animal/space/carp/large/huge = 1
+		/mob/living/simple_mob/animal/space/carp = 3
 	)


### PR DESCRIPTION
Stuff people have been asking for over the years:

removes star treaders and space ghosts from space rocks spawn pool, as well as the more dangerous carp variants. In exchange adds space rays and space gnats, and readjusts the spawn rates taking these things into account. This should make things more forgiving for miners.

Mining also now has an additional material fridge. This one is exposed to the hallway though, where science can get at it. This should be useful for allowing science to return materials, or for cargo to make materials available, if they want to.

Additionally, the SD starts with a Qpad in front of science. (Science still needs to set it)

Oh also, caps the hallucination damage that space ghosts can do if you stand around and let them hit you
