### PR TITLE
prevent pickup of items we are inside of

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -191,6 +191,10 @@
 	if(stat)
 		return 0
 
+	// prevent picking up items while being in them
+	if(istype(A, /obj/item) && A == loc)
+		return 0
+
 	return 1
 
 /*


### PR DESCRIPTION
Due to possible recursive runtimes when throwing ourselves and the silliness of self pickup. Even though amusing when possessing an item. It might be best we prevent the ability to pick up an item whilst being inside of. Possessing allows moving. Someone could add a way to kick the item around without having to pick it up.

For food stuff, well, no need at all to be able to pick the item up while being inside of.

fixes #15779

🆑 
remove: the ability to self-pickup possessed items or items one is inside of
/🆑 