### PR TITLE
Makes instant digestion properly apply vore death flag all the time

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -855,6 +855,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 							var/mob/living/carbon/human/h = l
 							thismuch = thismuch * h.species.digestion_nutrition_modifier
 						l.adjust_nutrition(thismuch)
+					ourtarget.mind?.vore_death = TRUE
 					ourtarget.death()		// To make sure all on-death procs get properly called
 					if(ourtarget)
 						if(ourtarget.is_preference_enabled(/datum/client_preference/digestion_noises))


### PR DESCRIPTION
Fixes #15765 

Turns out the issue showed up when instant digesting someone when your belly wasn't on digest or selective mode, as the vore death flag is only applied to prey that die in belly while they're in those modes. Fixes that, now instant digestion manually applies the flag beforehand.