### PR TITLE
Fix datum components

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -297,12 +297,12 @@
   */
 /datum/component/proc/_GetInverseTypeList(our_type = type)
 	//we can do this one simple trick
+	. = list(our_type)
 	var/current_type = parent_type
-	. = list(our_type, current_type)
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
-		current_type = type2parent(current_type)
 		. += current_type
+		current_type = type2parent(current_type)
 
 /**
   * Internal proc to handle most all of the signaling procedure


### PR DESCRIPTION
You might want this too!

I noticed that datum_component vars in mobs were messed up (A list is in there and it shouldn't be) and tracked it down to this file being out of date.

It's fixed in TG here
https://github.com/tgstation/tgstation/blob/a655526113eb6f851cb69c84594d48bdd26086db/code/datums/components/_component.dm#L236