### PR TITLE
Fixes sensor console (and other overmap consoles) not accepting decimal input when appropriate

### DIFF
--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -62,7 +62,7 @@
 			. = TRUE
 
 		if("set_global_limit")
-			var/newlim = tgui_input_number(usr, "Input new thrust limit (0..100%)", "Thrust limit", linked.thrust_limit*100, 100, 0)
+			var/newlim = tgui_input_number(usr, "Input new thrust limit (0..100%)", "Thrust limit", linked.thrust_limit*100, 100, 0, round_value = FALSE)
 			if(tgui_status(usr, state) != STATUS_INTERACTIVE)
 				return FALSE
 			linked.thrust_limit = clamp(newlim/100, 0, 1)
@@ -78,7 +78,7 @@
 
 		if("set_limit")
 			var/datum/ship_engine/E = locate(params["engine"])
-			var/newlim = tgui_input_number(usr, "Input new thrust limit (0..100)", "Thrust limit", E.get_thrust_limit(), 100, 0)
+			var/newlim = tgui_input_number(usr, "Input new thrust limit (0..100)", "Thrust limit", E.get_thrust_limit(), 100, 0, round_value = FALSE)
 			if(tgui_status(usr, state) != STATUS_INTERACTIVE)
 				return FALSE
 			var/limit = clamp(newlim/100, 0, 1)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -217,13 +217,13 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 			. = TRUE
 
 		if("speedlimit")
-			var/newlimit = tgui_input_number(usr, "Input new speed limit for autopilot (0 to brake)", "Autopilot speed limit", speedlimit*1000, 100000)
+			var/newlimit = tgui_input_number(usr, "Input new speed limit for autopilot (0 to brake)", "Autopilot speed limit", speedlimit*1000, 100000, round_value = FALSE)
 			if(newlimit)
 				speedlimit = CLAMP(newlimit/1000, 0, 100)
 			. = TRUE
 
 		if("accellimit")
-			var/newlimit = tgui_input_number(usr, "Input new acceleration limit", "Acceleration limit", accellimit*1000)
+			var/newlimit = tgui_input_number(usr, "Input new acceleration limit", "Acceleration limit", accellimit*1000, round_value = FALSE)
 			if(newlimit)
 				accellimit = max(newlimit/1000, 0)
 			. = TRUE

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -106,7 +106,7 @@
 	if(sensors)
 		switch(action)
 			if("range")
-				var/nrange = tgui_input_number(usr, "Set new sensors range", "Sensor range", sensors.range, world.view)
+				var/nrange = tgui_input_number(usr, "Set new sensors range", "Sensor range", sensors.range, world.view, round_value = FALSE )
 				if(tgui_status(usr, state) != STATUS_INTERACTIVE)
 					return FALSE
 				if(nrange)


### PR DESCRIPTION
### What this does:
Fixes informally reported bug when piloting overmap shuttles preventing setting the sensor range to decimal values, causing them to be rounded to nearest integer.

While at it, also allows decimal input for the following functionalities:

- Helm Console -> Acceleration Limiter (caps max velocity change/thrust to exact value, but wastes fuel)
- Hem Console -> Speed Limit (caps max speed autopilot tries to achieve)
- Engine Console -> Global Volume Limiter (Changes velocity change/thrust based on ejection mass, non-exact but saves fuel.)
- Engine Console -> Per-Thruster Volume Limiter (Changes velocity change/thrust based on ejection mass, non-exact but saves fuel.)

### Why we need this

This is a bugfix to restore former functionality before TGUI 5.0.

### Commit Details

[fix(overmap machines): Fixes number inputs not allowing decimals](https://github.com/VOREStation/VOREStation/commit/1c410e10d2f1162aaa65de4495de7cce6bb3958b) 

* Adds flag of round_value = FALSE to  sensor range on sensor console
* Adds flag of round_value = FALSE to acceleration limiter on helm console
* Adds flag of round_value = FALSE to global volume limiter on engine console
* Adds flag of round_value = FALSE on per-engine volume limiter on engine console

:cl: Upstream
fix: Fixed a few number inputs to allow floats on the sensor-, helm- and engine console.
/:cl: