### PR TITLE
Up-port: Various runtimes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -473,70 +473,74 @@
 		SStranscore.leave_round(to_despawn)
 	//VOREStation Edit End - Resleeving.
 
-	//Handle job slot/tater cleanup.
-	var/job = to_despawn.mind.assigned_role
-	job_master.FreeRole(job)
-	to_despawn.mind.assigned_role = null
+		// Everything below should only be applicable to a cliented living/carbon/human.
+		// All living/carbon/humans should have minds.
 
-	if(to_despawn.mind.objectives.len)
-		qdel(to_despawn.mind.objectives)
-		to_despawn.mind.special_role = null
+		//Handle job slot/tater cleanup.
+		var/job = to_despawn.mind.assigned_role
+		job_master.FreeRole(job)
+		to_despawn.mind.assigned_role = null
 
-	//else
-		//if(ticker.mode.name == "AutoTraitor")
-			//var/datum/game_mode/traitor/autotraitor/current_mode = ticker.mode
-			//current_mode.possible_traitors.Remove(to_despawn)
+		if(to_despawn.mind.objectives.len)
+			qdel(to_despawn.mind.objectives)
+			to_despawn.mind.special_role = null
 
-	// Delete them from datacore.
+		//else
+			//if(ticker.mode.name == "AutoTraitor")
+				//var/datum/game_mode/traitor/autotraitor/current_mode = ticker.mode
+				//current_mode.possible_traitors.Remove(to_despawn)
 
-	if(PDA_Manifest.len)
-		PDA_Manifest.Cut()
-	for(var/datum/data/record/R in data_core.medical)
-		if((R.fields["name"] == to_despawn.real_name))
-			qdel(R)
-	for(var/datum/data/record/T in data_core.security)
-		if((T.fields["name"] == to_despawn.real_name))
-			qdel(T)
-	for(var/datum/data/record/G in data_core.general)
-		if((G.fields["name"] == to_despawn.real_name))
-			qdel(G)
+		// Delete them from datacore.
 
-	// Also check the hidden version of each datacore, if they're an offmap role.
-	var/datum/job/J = SSjob.get_job(job)
-	if(J?.offmap_spawn)
-		for(var/datum/data/record/R in data_core.hidden_general)
+		if(PDA_Manifest.len)
+			PDA_Manifest.Cut()
+		for(var/datum/data/record/R in data_core.medical)
 			if((R.fields["name"] == to_despawn.real_name))
 				qdel(R)
-		for(var/datum/data/record/T in data_core.hidden_security)
+		for(var/datum/data/record/T in data_core.security)
 			if((T.fields["name"] == to_despawn.real_name))
 				qdel(T)
-		for(var/datum/data/record/G in data_core.hidden_medical)
+		for(var/datum/data/record/G in data_core.general)
 			if((G.fields["name"] == to_despawn.real_name))
 				qdel(G)
 
-	icon_state = base_icon_state
+		// Also check the hidden version of each datacore, if they're an offmap role.
+		var/datum/job/J = SSjob.get_job(job)
+		if(J?.offmap_spawn)
+			for(var/datum/data/record/R in data_core.hidden_general)
+				if((R.fields["name"] == to_despawn.real_name))
+					qdel(R)
+			for(var/datum/data/record/T in data_core.hidden_security)
+				if((T.fields["name"] == to_despawn.real_name))
+					qdel(T)
+			for(var/datum/data/record/G in data_core.hidden_medical)
+				if((G.fields["name"] == to_despawn.real_name))
+					qdel(G)
 
-	//TODO: Check objectives/mode, update new targets if this mob is the target, spawn new antags?
+		icon_state = base_icon_state
+
+		//TODO: Check objectives/mode, update new targets if this mob is the target, spawn new antags?
 
 
-	//Make an announcement and log the person entering storage.
-	control_computer.frozen_crew += "[to_despawn.real_name], [to_despawn.mind.role_alt_title] - [stationtime2text()]"
-	control_computer._admin_logs += "[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) at [stationtime2text()]"
-	log_and_message_admins("[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) entered cryostorage.")
+		//Make an announcement and log the person entering storage.
+		control_computer.frozen_crew += "[to_despawn.real_name], [to_despawn.mind.role_alt_title] - [stationtime2text()]"
+		control_computer._admin_logs += "[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) at [stationtime2text()]"
+		log_and_message_admins("[key_name(to_despawn)] ([to_despawn.mind.role_alt_title]) entered cryostorage.")
 
-	//VOREStation Edit Start
-	var/depart_announce = TRUE
-	var/departing_job = to_despawn.mind.role_alt_title
+		//VOREStation Edit Start
+		var/depart_announce = TRUE
+		var/departing_job = to_despawn.mind.role_alt_title
 
 
-	if(istype(to_despawn, /mob/living/dominated_brain))
-		depart_announce = FALSE
+		if(istype(to_despawn, /mob/living/dominated_brain))
+			depart_announce = FALSE
 
-	if(depart_announce)
-		announce.autosay("[to_despawn.real_name][departing_job ? ", [departing_job], " : " "][on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
-		visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2]</span>", 3)
+		if(depart_announce)
+			announce.autosay("[to_despawn.real_name][departing_job ? ", [departing_job], " : " "][on_store_message]", "[on_store_name]", announce_channel, using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
+			visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2]</span>", 3)
 
-	//VOREStation Edit End
+
+		//VOREStation Edit End
 
 	//VOREStation Edit begin: Dont delete mobs-in-mobs
 	if(to_despawn.client && to_despawn.stat<2)

--- a/code/game/objects/items/devices/text_to_speech.dm
+++ b/code/game/objects/items/devices/text_to_speech.dm
@@ -26,7 +26,7 @@
 	if(message)
 		audible_message("\icon[src][bicon(src)] \The [src.name] states, \"[message]\"", runemessage = "synthesized speech")
 		if(ismob(loc))
-			loc.audible_message("", runemessage = "\[TTS Voice\] [message]")
+			loc.runechat_message("\[TTS Voice\] [message]")
 
 /obj/item/device/text_to_speech/AltClick(mob/user) // QOL Change
 	attack_self(user)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -271,19 +271,30 @@
 	//DISCONNECT//
 	//////////////
 /client/Del()
+	if(!gc_destroyed)
+		gc_destroyed = world.time
+		if (!QDELING(src))
+			stack_trace("Client does not purport to be QDELING, this is going to cause bugs in other places!")
+
+		GLOB.ahelp_tickets.ClientLogout(src)
+		GLOB.mhelp_tickets.ClientLogout(src)
+
+		// Yes this is the same as what's found in qdel(). Yes it does need to be here
+		// Get off my back
+		SEND_SIGNAL(src, COMSIG_PARENT_QDELETING, TRUE)
+		Destroy() //Clean up signals and timers.
+	return ..()
+
+/client/Destroy()
 	if(holder)
 		holder.owner = null
 		GLOB.admins -= src
 	if (mentorholder)
 		mentorholder.owner = null
 		GLOB.mentors -= src
-	GLOB.ahelp_tickets.ClientLogout(src)
-	GLOB.mhelp_tickets.ClientLogout(src)
 	GLOB.directory -= ckey
 	GLOB.clients -= src
-	return ..()
 
-/client/Destroy()
 	..()
 	return QDEL_HINT_HARDDEL_NOW
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -418,7 +418,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		for(var/BP in mark_datum.body_parts)
 			var/obj/item/organ/external/O = character.organs_by_name[BP]
-			if(O && islist(O.markings) && islist(pref.body_markings[M]))
+			if(O && islist(O.markings) && O.markings[M] && islist(pref.body_markings[M]))
 				O.markings[M] = list("color" = pref.body_markings[M][BP]["color"], "datum" = mark_datum, "priority" = priority, "on" = pref.body_markings[M][BP]["on"])
 	character.markings_len = priority
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -418,7 +418,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		for(var/BP in mark_datum.body_parts)
 			var/obj/item/organ/external/O = character.organs_by_name[BP]
-			if(O && islist(O.markings) && O.markings[M] && islist(pref.body_markings[M]))
+			if(O && islist(O.markings) && islist(pref.body_markings[M]) && islist(pref.body_markings[M][BP]))
 				O.markings[M] = list("color" = pref.body_markings[M][BP]["color"], "datum" = mark_datum, "priority" = priority, "on" = pref.body_markings[M][BP]["on"])
 	character.markings_len = priority
 

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -418,7 +418,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 		for(var/BP in mark_datum.body_parts)
 			var/obj/item/organ/external/O = character.organs_by_name[BP]
-			if(O)
+			if(O && islist(O.markings) && islist(pref.body_markings[M]))
 				O.markings[M] = list("color" = pref.body_markings[M][BP]["color"], "datum" = mark_datum, "priority" = priority, "on" = pref.body_markings[M][BP]["on"])
 	character.markings_len = priority
 

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -91,7 +91,7 @@
 		preference = list(preference)
 	for(var/p in preference)
 		var/datum/client_preference/cp = get_client_preference(p)
-		if(!prefs || !cp || !(cp.key in prefs.preferences_enabled))
+		if(!prefs || !cp || !istype(cp, /datum/client_preference) || !(cp.key in prefs.preferences_enabled))
 			return FALSE
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1197,12 +1197,24 @@
 	return 0
 
 //Exploitable Info Update
+/obj
+	var/datum/weakref/exploit_for //if this obj is an exploit for somebody, this points to them
 
 /mob/proc/amend_exploitable(var/obj/item/I)
 	if(istype(I))
 		exploit_addons |= I
 		var/exploitmsg = html_decode("\n" + "Has " + I.name + ".")
 		exploit_record += exploitmsg
+		I.exploit_for = WEAKREF(src)
+
+
+/obj/Destroy()
+	if(exploit_for)
+		var/mob/exploited = exploit_for.resolve()
+		exploited?.exploit_addons -= src
+		exploit_for = null
+	. = ..()
+
 
 /client/proc/check_has_body_select()
 	return mob && mob.hud_used && istype(mob.zone_sel, /obj/screen/zone_sel)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -89,7 +89,7 @@
  * return bool - TRUE if a new pooled window is opened, FALSE in all other situations including if a new pooled window didn't open because one already exists.
  */
 /datum/tgui/proc/open()
-	if(!user.client)
+	if(!user?.client)
 		return FALSE
 	if(window)
 		return FALSE
@@ -206,7 +206,7 @@
  * optional force bool Send an update even if UI is not interactive.
  */
 /datum/tgui/proc/send_full_update(custom_data, force)
-	if(!user.client || !initialized || closing)
+	if(!user?.client || !initialized || closing)
 		return
 	//if(!COOLDOWN_FINISHED(src, refresh_cooldown))
 		//refreshing = TRUE


### PR DESCRIPTION
More stuff from chomp that you might like

- runechat runtime
- Cryopod runtimes. Moved a whole bunch of stuff dependant on a datum mind up one indenation behind the if(to_despawn.mind) check
- TTS speech runtime
- Client procs tweak. Make Del() (Disconnection proc) call Destroy, plus some signal stuff
- runtime in pref setup with a bad bdy_markings
- bigdragon runtimes. Also his charge-up attacks (fire, charge) now cancel on tame or death.
- exploitable object hard del
- tgui runtimes in open and send_full_update

source: https://github.com/CHOMPStation2/CHOMPStation2/pull/7873

EDIT: also adds this to this PR
- 03_body i think this happens when people have invalid markings saved in their character saves?
- 02_settings, if a pref doesn't have an associated datum
https://github.com/CHOMPStation2/CHOMPStation2/pull/7884