### PR TITLE
Emags syndiborgs by default, borg petting pref

### DIFF
--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -304,3 +304,7 @@
 		if(PREF_FBP_SOFTWARE)
 			return 150
 	return S.max_age // welp
+
+#undef PREF_FBP_CYBORG
+#undef PREF_FBP_POSI
+#undef PREF_FBP_SOFTWARE

--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -5,20 +5,22 @@
 /datum/category_item/player_setup_item/vore/misc/load_character(var/savefile/S)
 	S["show_in_directory"]		>> pref.show_in_directory
 	S["directory_tag"]			>> pref.directory_tag
-	S["directory_erptag"]			>> pref.directory_erptag
+	S["directory_erptag"]		>> pref.directory_erptag
 	S["directory_ad"]			>> pref.directory_ad
 	S["sensorpref"]				>> pref.sensorpref
 	S["capture_crystal"]		>> pref.capture_crystal
 	S["auto_backup_implant"]	>> pref.auto_backup_implant
+	S["borg_petting"]			>> pref.borg_petting
 
 /datum/category_item/player_setup_item/vore/misc/save_character(var/savefile/S)
 	S["show_in_directory"]		<< pref.show_in_directory
 	S["directory_tag"]			<< pref.directory_tag
-	S["directory_erptag"]			<< pref.directory_erptag
+	S["directory_erptag"]		<< pref.directory_erptag
 	S["directory_ad"]			<< pref.directory_ad
 	S["sensorpref"]				<< pref.sensorpref
 	S["capture_crystal"]		<< pref.capture_crystal
 	S["auto_backup_implant"]	<< pref.auto_backup_implant
+	S["borg_petting"]			<< pref.borg_petting
 
 /datum/category_item/player_setup_item/vore/misc/copy_to_mob(var/mob/living/carbon/human/character)
 	if(pref.sensorpref > 5 || pref.sensorpref < 1)
@@ -29,10 +31,11 @@
 /datum/category_item/player_setup_item/vore/misc/sanitize_character()
 	pref.show_in_directory		= sanitize_integer(pref.show_in_directory, 0, 1, initial(pref.show_in_directory))
 	pref.directory_tag			= sanitize_inlist(pref.directory_tag, GLOB.char_directory_tags, initial(pref.directory_tag))
-	pref.directory_erptag			= sanitize_inlist(pref.directory_erptag, GLOB.char_directory_erptags, initial(pref.directory_erptag))
+	pref.directory_erptag		= sanitize_inlist(pref.directory_erptag, GLOB.char_directory_erptags, initial(pref.directory_erptag))
 	pref.sensorpref				= sanitize_integer(pref.sensorpref, 1, sensorpreflist.len, initial(pref.sensorpref))
 	pref.capture_crystal		= sanitize_integer(pref.capture_crystal, 0, 1, initial(pref.capture_crystal))
-	pref.auto_backup_implant		= sanitize_integer(pref.auto_backup_implant, 0, 1, initial(pref.auto_backup_implant))
+	pref.auto_backup_implant	= sanitize_integer(pref.auto_backup_implant, 0, 1, initial(pref.auto_backup_implant))
+	pref.borg_petting			= sanitize_integer(pref.borg_petting, 0, 1, initial(pref.borg_petting))
 
 /datum/category_item/player_setup_item/vore/misc/content(var/mob/user)
 	. += "<br>"
@@ -43,6 +46,7 @@
 	. += "<b>Suit Sensors Preference:</b> <a [pref.sensorpref ? "" : ""] href='?src=\ref[src];toggle_sensor_setting=1'><b>[sensorpreflist[pref.sensorpref]]</b></a><br>"
 	. += "<b>Capture Crystal Preference:</b> <a [pref.capture_crystal ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_capture_crystal=1'><b>[pref.capture_crystal ? "Yes" : "No"]</b></a><br>"
 	. += "<b>Spawn With Backup Implant:</b> <a [pref.auto_backup_implant ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_implant=1'><b>[pref.auto_backup_implant ? "Yes" : "No"]</b></a><br>"
+	. += "<b>Allow petting as robot:</b> <a [pref.borg_petting ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_borg_petting=1'><b>[pref.borg_petting ? "Yes" : "No"]</b></a><br>"
 
 /datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["toggle_show_in_directory"])
@@ -76,5 +80,8 @@
 		return TOPIC_REFRESH
 	else if(href_list["toggle_implant"])
 		pref.auto_backup_implant = pref.auto_backup_implant ? 0 : 1;
+		return TOPIC_REFRESH
+	else if(href_list["toggle_borg_petting"])
+		pref.borg_petting = pref.borg_petting ? 0 : 1;
 		return TOPIC_REFRESH
 	return ..();

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -6,6 +6,7 @@
 	var/sensorpref = 5			//Set character's suit sensor level
 	var/capture_crystal = 1	//Whether or not someone is able to be caught with capture crystals
 	var/auto_backup_implant = FALSE //Whether someone starts with a backup implant or not.
+	var/borg_petting = TRUE //Whether someone can be petted as a borg or not.
 
 	var/job_talon_high = 0
 	var/job_talon_med = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -813,7 +813,7 @@
 	modtype = initial(modtype)
 	hands.icon_state = get_hud_module_icon()
 	if(notify)
-	notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
+		notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
 	module.Reset(src)
 	module.Destroy()
 	module = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -96,7 +96,7 @@
 	var/lockcharge //Used when looking to see if a borg is locked down.
 	var/lockdown = 0 //Controls whether or not the borg is actually locked down.
 	var/speed = 0 //Cause sec borgs gotta go fast //No they dont!
-	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
+	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console. Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
 	var/braintype = "Cyborg"
 
@@ -164,15 +164,15 @@
 
 	add_robot_verbs()
 
-	hud_list[HEALTH_HUD]      = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_HEALTH)
-	hud_list[STATUS_HUD]      = gen_hud_image('icons/mob/hud.dmi', src, "hudhealth100", plane = PLANE_CH_STATUS)
-	hud_list[LIFE_HUD]        = gen_hud_image('icons/mob/hud.dmi', src, "hudhealth100", plane = PLANE_CH_LIFE)
-	hud_list[ID_HUD]          = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_ID)
-	hud_list[WANTED_HUD]      = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_WANTED)
-	hud_list[IMPLOYAL_HUD]    = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPLOYAL)
-	hud_list[IMPCHEM_HUD]     = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPCHEM)
-	hud_list[IMPTRACK_HUD]    = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPTRACK)
-	hud_list[SPECIALROLE_HUD] = gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_SPECIAL)
+	hud_list[HEALTH_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_HEALTH)
+	hud_list[STATUS_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudhealth100", plane = PLANE_CH_STATUS)
+	hud_list[LIFE_HUD]			= gen_hud_image('icons/mob/hud.dmi', src, "hudhealth100", plane = PLANE_CH_LIFE)
+	hud_list[ID_HUD]			= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_ID)
+	hud_list[WANTED_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_WANTED)
+	hud_list[IMPLOYAL_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPLOYAL)
+	hud_list[IMPCHEM_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPCHEM)
+	hud_list[IMPTRACK_HUD]		= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_IMPTRACK)
+	hud_list[SPECIALROLE_HUD]	= gen_hud_image('icons/mob/hud.dmi', src, "hudblank", plane = PLANE_CH_SPECIAL)
 
 /mob/living/silicon/robot/LateInitialize()
 	. = ..()
@@ -518,14 +518,14 @@
 
 // function to toggle VTEC once installed
 /mob/living/silicon/robot/proc/toggle_vtec()
-    set name = "Toggle VTEC"
-    set category = "Abilities"
-    if(speed == -1)
-        to_chat(src, "<span class='filter_notice'>VTEC module disabled.</span>")
-        speed = 0
-    else
-        to_chat(src, "<span class='filter_notice'>VTEC module enabled.</span>")
-        speed = -1
+	set name = "Toggle VTEC"
+	set category = "Abilities"
+	if(speed == -1)
+		to_chat(src, "<span class='filter_notice'>VTEC module disabled.</span>")
+		speed = 0
+	else
+		to_chat(src, "<span class='filter_notice'>VTEC module enabled.</span>")
+		speed = -1
 
 // update the status screen display
 /mob/living/silicon/robot/Stat()
@@ -813,7 +813,7 @@
 	modtype = initial(modtype)
 	hands.icon_state = get_hud_module_icon()
 	if(notify)
-		notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
+	notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, module.name)
 	module.Reset(src)
 	module.Destroy()
 	module = null
@@ -842,11 +842,15 @@
 
 	if(istype(user,/mob/living/carbon/human) && !opened)
 		var/mob/living/carbon/human/H = user
-		//Adding borg petting.  Help intent pets, Disarm intent taps and Harm is punching(no damage)
+		//Adding borg petting. Help intent pets if preferences allow, Disarm intent taps and Harm is punching(no damage)
 		switch(H.a_intent)
 			if(I_HELP)
-				visible_message("<span class='notice'>[H] pets [src].</span>")
-				return
+				if(client && !client.prefs.borg_petting)
+					visible_message("<span class='notice'>[H] reaches out for [src], but quickly refrains from petting.</span>")
+					return
+				else
+					visible_message("<span class='notice'>[H] pets [src].</span>")
+					return
 			if(I_HURT)
 				H.do_attack_animation(src)
 				if(H.species.can_shred(H))
@@ -1146,7 +1150,7 @@
 /mob/living/silicon/robot/proc/ResetSecurityCodes()
 	set category = "Robot Commands"
 	set name = "Reset Identity Codes"
-	set desc = "Scrambles your security and identification codes and resets your current buffers.  Unlocks you and but permenantly severs you from your AI and the robotics console and will deactivate your camera system."
+	set desc = "Scrambles your security and identification codes and resets your current buffers. Unlocks you and permenantly severs you from your AI and the robotics console and will deactivate your camera system."
 
 	var/mob/living/silicon/robot/R = src
 
@@ -1331,11 +1335,22 @@
 		return
 
 	if(opened)//Cover is open
-		if(emagged)	return//Prevents the X has hit Y with Z message also you cant emag them twice
+		if(emagged)
+			if (!has_zeroth_law())
+				to_chat(user, "<span class='filter_notice'>You assigned yourself as [src]'s operator.</span>")
+				message_admins("[key_name_admin(user)] assigned as operator on cyborg [key_name_admin(src)]. Syndicate Operator change.")
+				log_game("[key_name(user)] assigned as operator on cyborg [key_name(src)]. Syndicate Operator change.")
+				var/datum/gender/TU = gender_datums[user.get_visible_gender()]
+				set_zeroth_law("Only [user.real_name] and people [TU.he] designate[TU.s] as being such are operatives.")
+				to_chat(src, "<b>Obey these laws:</b>")
+				laws.show_laws(src)
+				to_chat(src, "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and [TU.his] commands.</span>")
+			else
+				to_chat(user, "<span class='filter_notice'>[src] already has an operator assigned.</span>")
+			return//Prevents the X has hit Y with Z message also you cant emag them twice
 		if(wiresexposed)
 			to_chat(user, "<span class='filter_notice'>You must close the panel first.</span>")
 			return
-
 
 		// The block of code below is from TG. Feel free to replace with a better result if desired.
 		if(shell) // AI shells cannot be emagged, so we try to make it look like a standard reset. Smart players may see through this, however.
@@ -1350,8 +1365,8 @@
 			lawupdate = 0
 			disconnect_from_ai()
 			to_chat(user, "<span class='filter_notice'>You emag [src]'s interface.</span>")
-			message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)].  Laws overridden.")
-			log_game("[key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
+			message_admins("[key_name_admin(user)] emagged cyborg [key_name_admin(src)]. Laws overridden.")
+			log_game("[key_name(user)] emagged cyborg [key_name(src)]. Laws overridden.")
 			clear_supplied_laws()
 			clear_inherent_laws()
 			laws = new /datum/ai_laws/syndicate_override

--- a/code/modules/mob/living/silicon/robot/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon/robot/syndicate
 	lawupdate = 0
 	scrambledcodes = 1
+	emagged = 1
 	icon_state = "securityrobot"
 	modtype = "Security"
 	lawchannel = "State"

--- a/code/modules/news/newspaper.dm
+++ b/code/modules/news/newspaper.dm
@@ -27,7 +27,7 @@
 		switch(screen)
 			if(0) //Cover
 				dat+="<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>"
-				dat+="<DIV ALIGN='center'><FONT SIZE=2>[using_map.company_name]-standard newspaper, for use on [using_map.company_name]� Space Facilities</FONT></div><HR>"
+				dat+="<DIV ALIGN='center'><FONT SIZE=2>[using_map.company_name]-standard newspaper, for use on [using_map.company_name] Space Facilities</FONT></div><HR>"
 				if(isemptylist(news_content))
 					if(important_message)
 						dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [pages+2]\]</FONT><BR></ul>"


### PR DESCRIPTION
🆑
add: setting to allow borg players to disable petting
fix: syndicate borgs spawn emagged to have scrambled access, their ai wire unpulseable and can be assigned a single operator as long they have no zeroth law (scrambled module still shows as uninstalled on analyser to hide emagged state)
code: undefined some local defines in preference_setup
/🆑