### PR TITLE
allows to hide important messages for admins in TG chat tabs

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -166,6 +166,7 @@ export const chatMiddleware = (store) => {
       settings.storedTypes,
       game.roundId,
       settings.prependTimestamps,
+      settings.hideImportantInAdminTab,
     );
     // Load the chat once settings are loaded
     if (!initialized && settings.initialized) {

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -16,6 +16,7 @@ export const typeIsImportant = (type) => {
   for (let typeDef of MESSAGE_TYPES) {
     if (typeDef.type === type && !!typeDef.important) {
       isImportant = true;
+      break;
     }
   }
   return isImportant;
@@ -30,6 +31,7 @@ export const adminPageOnly = (page) => {
       !(!!typeDef.important || !!typeDef.admin)
     ) {
       adminTab = false;
+      break;
     }
     if (page.acceptedTypes[typeDef.type] && !typeDef.important) {
       checked++;

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -11,6 +11,33 @@ import { MESSAGE_TYPE_INTERNAL, MESSAGE_TYPES } from './constants';
 export const canPageAcceptType = (page, type) =>
   type.startsWith(MESSAGE_TYPE_INTERNAL) || page.acceptedTypes[type];
 
+export const typeIsImportant = (type) => {
+  let isImportant = false;
+  for (let typeDef of MESSAGE_TYPES) {
+    if (typeDef.type === type && !!typeDef.important) {
+      isImportant = true;
+    }
+  }
+  return isImportant;
+};
+
+export const adminPageOnly = (page) => {
+  let adminTab = true;
+  let checked = 0;
+  for (let typeDef of MESSAGE_TYPES) {
+    if (
+      page.acceptedTypes[typeDef.type] &&
+      !(!!typeDef.important || !!typeDef.admin)
+    ) {
+      adminTab = false;
+    }
+    if (page.acceptedTypes[typeDef.type] && !typeDef.important) {
+      checked++;
+    }
+  }
+  return checked > 0 && adminTab;
+};
+
 export const canStoreType = (storedTypes, type) => storedTypes[type];
 
 export const createPage = (obj) => {

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
@@ -81,6 +81,7 @@ export const SettingsPanel = (props) => {
         {activeTab === 'export' && <ExportTab />}
         {activeTab === 'chatPage' && <ChatPageSettings />}
         {activeTab === 'textHighlight' && <TextHighlightSettings />}
+        {activeTab === 'adminSettings' && <AdminSettings />}
       </Stack.Item>
     </Stack>
   );
@@ -802,5 +803,31 @@ const TextHighlightSetting = (props) => {
         ''
       )}
     </Flex.Item>
+  );
+};
+
+export const AdminSettings = (props) => {
+  const dispatch = useDispatch();
+  const { hideImportantInAdminTab } = useSelector(selectSettings);
+  return (
+    <Section>
+      <LabeledList>
+        <LabeledList.Item label="Hide Important messages in admin only tabs">
+          <Button.Checkbox
+            checked={hideImportantInAdminTab}
+            content=""
+            tooltip="Enabling this will hide all important messages in admin filter exclusive tabs."
+            mr="5px"
+            onClick={() =>
+              dispatch(
+                updateSettings({
+                  hideImportantInAdminTab: !hideImportantInAdminTab,
+                }),
+              )
+            }
+          />
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
   );
 };

--- a/tgui/packages/tgui-panel/settings/constants.ts
+++ b/tgui/packages/tgui-panel/settings/constants.ts
@@ -10,6 +10,10 @@ export const SETTINGS_TABS = [
     name: 'General',
   },
   {
+    id: 'adminSettings',
+    name: 'Admin',
+  },
+  {
     id: 'limits',
     name: 'Visual Limits',
   },

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -58,6 +58,7 @@ const initialState = {
   lastId: null,
   initialized: false,
   storedTypes: {},
+  hideImportantInAdminTab: false,
 };
 
 export const settingsReducer = (state = initialState, action) => {


### PR DESCRIPTION
This allows to hide important messages in admin only tabs. Empty tabs, or tabs in which at least one non admin category is checked will still show them at any time if the setting to hide them in admin only tabs is enabled.

🆑 Upstream
admin: adds an option for admins to hide important messages (system, looc) within admin tabs to keep them out of e.g. Debug or Remote LOOC tabs
/🆑  
