### PR TITLE
Fix forgotten check in movement

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -58,9 +58,14 @@
 				to_chat(src, "<span class='warning'>You stopped swimming downwards.</span>")
 				return 0
 
-		else if(!destination.CanZPass(src, direction))
+		else if(!destination.CanZPass(src, direction)) // one for the down and non-special case
 			to_chat(src, "<span class='warning'>\The [destination] blocks your way.</span>")
 			return 0
+
+	else if(!destination.CanZPass(src, direction)) // and one for up
+		to_chat(src, "<span class='warning'>\The [destination] blocks your way.</span>")
+		return 0
+
 
 	var/area/area = get_area(src)
 	if(area.has_gravity() && !can_overcome_gravity())


### PR DESCRIPTION
In PR #15328 

Specifically here: https://github.com/VOREStation/VOREStation/pull/15328/files#diff-284f84b4d2e4bef4fe808771c2a07749f5f1513a292ea10f225435fa0d983e16L49

The check that makes sure you can pass to your target turf was accidently made to only work on DOWNWARDS when the special case was added. It previously ran irrespective of direction

This fixes that. 