### PR TITLE
@Runa-Dacino add(mentorhelp): Makes mhelps check for active mentors a…

### DIFF
--- a/code/modules/mentor/mentorhelp.dm
+++ b/code/modules/mentor/mentorhelp.dm
@@ -429,6 +429,25 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/mentor_help_tickets, new)
 	if(!msg)
 		return
 
+	// Making sure there's actually a mentor or admin who can respond.
+	var/list/admins = get_admin_counts()
+	var/list/activeAdmins = admins["present"]
+	var/list/mentors = GLOB.mentors
+	if(!mentors.len && !activeAdmins.len)
+		var/choice = tgui_alert(usr, "There are no active admins or mentors online. Would you like to make an ahelp instead, so that staff is notified of your issue? \
+		Alternatively, you may go to the discord yourself and repeat your question in #cadet-academy. Please note, if choosing the later, do not include current-round information.",
+		"Send to discord?", list("Admin-help!", "Still mentorhelp!", "Cancel"))
+		if(choice == "Admin-help!")
+			usr.client.adminhelp(msg)
+			src.verbs -= /client/verb/mentorhelp
+			spawn(1200)
+				src.verbs += /client/verb/mentorhelp // 2 minute cd to prevent abusing this to spam admins.
+			return
+		else if(choice == "Cancel")
+			return
+
+
+
 	//remove out adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/mentorhelp
 	spawn(600)


### PR DESCRIPTION
### What this does

Adds logic to mentorhelps to check the global mentorlist and the admin list (filtered for "Present" admins, as some admins like to leave their PC on when going to bed and they can't exactly answer either).

If nobody is available to answer, the player is prompted to make an admin help - choosing which immediately forwards/escalates their mhelp to an ahelp instead which then notifies discord so staff can step up and help.

Alternatively, they are suggested to go straight to discord themselves and ask in cadet academy. 

### Why we need this

There is nothing currently that informs players that there aren't any mentors online, and if they make an mhelp hoping to get help they'll likely not know to check staffwho in the first place and therefore, think mentors are ignoring them. Furthermore, even if they wouldn't think this - they still need that help and this will increase the probability of them receiving it.

### Commit details

@Runa-Dacino [add(mentorhelp): Makes mhelps check for active mentors a…](https://github.com/VOREStation/VOREStation/commit/3039750a9983a88cb712525d732604218d600a48) 

…nd admins

If no admin/mentor, it prompts sending ahelp instead or recommends going to discord personally.