### PR TITLE
Tweaks ahelps, mhelps and their respective pms to allow multiline entry into the text boxes

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -57,7 +57,7 @@
 
 	if(AH)
 		message_admins("<span class='pm'>[key_name_admin(src)] has started replying to [key_name(C, 0, 0)]'s admin help.</span>")
-	var/msg = tgui_input_text(src,"Message:", "Private message to [key_name(C, 0, 0)]")
+	var/msg = tgui_input_text(src,"Message:", "Private message to [key_name(C, 0, 0)]", multiline = TRUE)
 	if (!msg)
 		message_admins("<span class='pm'>[key_name_admin(src)] has cancelled their reply to [key_name(C, 0, 0)]'s admin help.</span>")
 		return
@@ -92,7 +92,7 @@
 		if(!ircreplyamount)	//to prevent people from spamming irc
 			return
 		if(!msg)
-			msg = tgui_input_text(src,"Message:", "Private message to Administrator")
+			msg = tgui_input_text(src,"Message:", "Private message to Administrator", multiline = TRUE)
 
 		if(!msg)
 			return
@@ -112,7 +112,7 @@
 
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
-			msg = tgui_input_text(src,"Message:", "Private message to [key_name(recipient, 0, 0)]")
+			msg = tgui_input_text(src,"Message:", "Private message to [key_name(recipient, 0, 0)]", multiline = TRUE)
 
 			if(!msg)
 				return
@@ -188,7 +188,7 @@
 					spawn()	//so we don't hold the caller proc up
 						var/sender = src
 						var/sendername = key
-						var/reply = tgui_input_text(recipient, msg,"Admin PM from-[sendername]", "")	//show message and await a reply
+						var/reply = tgui_input_text(recipient, msg,"Admin PM from-[sendername]", "", multiline = TRUE)	//show message and await a reply
 						if(recipient && reply)
 							if(sender)
 								recipient.cmd_admin_pm(sender,reply)										//sender is still about, let's reply to them

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -150,7 +150,7 @@ var/list/mentor_verbs_default = list(
 
 	if(MH)
 		message_mentors("<span class='mentor_channel'>[src] has started replying to [C]'s mentor help.</span>")
-	var/msg = tgui_input_text(src,"Message:", "Private message to [C]")
+	var/msg = tgui_input_text(src,"Message:", "Private message to [C]", multiline = TRUE)
 	if (!msg)
 		message_mentors("<span class='mentor_channel'>[src] has cancelled their reply to [C]'s mentor help.</span>")
 		return
@@ -168,7 +168,7 @@ var/list/mentor_verbs_default = list(
 	set hidden = 1
 
 	var/mhelp = tgui_alert(usr, "Select the help you need.","Request for Help",list("Adminhelp","Mentorhelp")) == "Mentorhelp"
-	var/msg = tgui_input_text(usr, "Input your request for help.", "Request for Help")
+	var/msg = tgui_input_text(usr, "Input your request for help.", "Request for Help", multiline = TRUE)
 
 	if (mhelp)
 		mentorhelp(msg)
@@ -202,7 +202,7 @@ var/list/mentor_verbs_default = list(
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		msg = tgui_input_text(src,"Message:", "Mentor-PM to [whom]")
+		msg = tgui_input_text(src,"Message:", "Mentor-PM to [whom]", multiline = TRUE)
 
 		if(!msg)
 			return


### PR DESCRIPTION
### What this does

Adds the "multiline = TRUE" flag to the relevant tgui_text_input() procedures to allow mentors and admins to better format their replies to players. Conversely, it also allows players to use multiple paragraphs to make their more complex questions and reports easier to read for staff.

**It works the same way as emotes:**
Pressing Enter sends the message as is.
Pressing Shift+Enter creates a newline.

### Why we need this

When we had the old multiline functionality reliant upon tgui-input-lock, you could reply to ahelps and mhelps using multiple lines allowing for more nuance and readability. You could also open them similarly.

You cannot do this anymore now that we use the shift enter method.

This restores the former functionality.

Any fears of people blanking out the chat by abusing multilines are assayed by the pre-existing sanitization in tgui_chat_input() limiting things to only 8 newlines or 4 paragraphs with whitespace separating them

### Commit details

[tweak: Modifies ahelps & mhelps and pms to allow multiline entry](https://github.com/VOREStation/VOREStation/pull/15828/commits/9f65ca23e8a69c3d01137b9adadc992a21034524)