### PR TITLE
Ports TGStation fix to text input trimming 

### DIFF
--- a/code/__defines/text.dm
+++ b/code/__defines/text.dm
@@ -1,0 +1,10 @@
+/**
+ * Holds global defines for use in text input procedures
+ */
+
+
+/**
+ * stuff like `copytext(input, length(input))` will trim the last character of the input,
+ * because DM does it so it copies until the char BEFORE the `end` arg, so we need to bump `end` by 1 in these cases.
+ */
+#define PREVENT_CHARACTER_TRIM_LOSS(integer) (integer + 1)

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -32,9 +32,9 @@
 	if(!user.client.prefs.tgui_input_mode)
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length)
+				return stripped_multiline_input(user, message, title, default, PREVENT_CHARACTER_TRIM_LOSS(max_length))
 			else
-				return stripped_input(user, message, title, default, max_length)
+				return stripped_input(user, message, title, default, PREVENT_CHARACTER_TRIM_LOSS(max_length))
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -159,4 +159,4 @@
 /datum/tgui_input_text/proc/set_entry(entry)
 	if(!isnull(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
-		src.entry = trim(converted_entry, max_length)
+		src.entry = trim(converted_entry, PREVENT_CHARACTER_TRIM_LOSS(max_length))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -96,6 +96,7 @@
 #include "code\__defines\subsystems.dm"
 #include "code\__defines\supply.dm"
 #include "code\__defines\targeting.dm"
+#include "code\__defines\text.dm"
 #include "code\__defines\tgs.config.dm"
 #include "code\__defines\tgs.dm"
 #include "code\__defines\tgui.dm"


### PR DESCRIPTION
### What this does

Ports the following commit: https://github.com/tgstation/tgstation/commit/df4397565fe6204985bb2b844ee37b5180cee508

Simply put: changes text input to add +1 to user defined max_length as normally it would remove the last character. (123456 would become 12345 at 6 character trim).

### Why we need this

Bug fix/parity with TG text input for TGUI

### Commit details

[fix(text_input): ports TG fix to length trim](https://github.com/VOREStation/VOREStation/commit/ca155337a9246714951dd26971489a2e9bd3f999) 

original commit: https://github.com/tgstation/tgstation/commit/df4397565fe6204985bb2b844ee37b5180cee508

local changes: adds new _defines file text.dm to start collecting text specific defines for better code readability