### PR TITLE
Makes it possible to edit the scaling of /obj subtypes in strongDMM and have it apply on initialization

### DIFF
--- a/code/__defines/atoms_movable.dm
+++ b/code/__defines/atoms_movable.dm
@@ -1,0 +1,7 @@
+/*
+** Holds defines for code\game\atoms_movable.dm to avoid magic numbers and potential unexpected overwrites down the line
+*/
+
+#define DEFAULT_ICON_SCALE_X 1
+#define DEFAULT_ICON_SCALE_Y 1
+#define DEFAULT_ICON_ROTATION 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -16,9 +16,9 @@
 	var/moved_recently = 0
 	var/mob/pulledby = null
 	var/item_state = null // Used to specify the item state for the on-mob overlays.
-	var/icon_scale_x = 1 // Used to scale icons up or down horizonally in update_transform().
-	var/icon_scale_y = 1 // Used to scale icons up or down vertically in update_transform().
-	var/icon_rotation = 0 // Used to rotate icons in update_transform()
+	var/icon_scale_x = DEFAULT_ICON_SCALE_X // Used to scale icons up or down horizonally in update_transform().
+	var/icon_scale_y = DEFAULT_ICON_SCALE_Y // Used to scale icons up or down vertically in update_transform().
+	var/icon_rotation = DEFAULT_ICON_ROTATION // Used to rotate icons in update_transform()
 	var/icon_expected_height = 32
 	var/icon_expected_width = 32
 	var/old_x = 0
@@ -45,6 +45,8 @@
 			add_overlay(list(em_block), TRUE)
 	if(opacity)
 		AddElement(/datum/element/light_blocking)
+	if(icon_scale_x != DEFAULT_ICON_SCALE_X || icon_scale_y != DEFAULT_ICON_SCALE_Y || icon_rotation != DEFAULT_ICON_ROTATION)
+		update_transform()
 	switch(light_system)
 		if(STATIC_LIGHT)
 			update_light()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1211,7 +1211,7 @@
 	if(species.default_language)
 		add_language(species.default_language)
 
-	if(species.icon_scale_x != 1 || species.icon_scale_y != 1)
+	if(species.icon_scale_x != DEFAULT_ICON_SCALE_X || species.icon_scale_y != DEFAULT_ICON_SCALE_Y)
 		update_transform()
 
 	if(example)						//VOREStation Edit begin

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -32,8 +32,8 @@
 	var/tail_animation										// If set, the icon to obtain tail animation states from.
 	var/tail_hair
 
-	var/icon_scale_x = 1										// Makes the icon wider/thinner.
-	var/icon_scale_y = 1										// Makes the icon taller/shorter.
+	var/icon_scale_x = DEFAULT_ICON_SCALE_X										// Makes the icon wider/thinner.
+	var/icon_scale_y = DEFAULT_ICON_SCALE_Y										// Makes the icon taller/shorter.
 
 	var/race_key = 0										// Used for mob icon cache string.
 	var/icon/icon_template									// Used for mob icon generation for non-32x32 species.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1307,5 +1307,5 @@
 
 /mob/living/set_dir(var/new_dir)
 	. = ..()
-	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
+	if(size_multiplier != 1 || icon_scale_x != DEFAULT_ICON_SCALE_X && center_offset > 0)
 		update_transform(TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -42,7 +42,6 @@
 	lastarea = get_area(src)
 	set_focus(src) // VOREStation Add - Key Handling
 	hook_vr("mob_new",list(src)) //VOREStation Code
-	update_transform() // Some mobs may start bigger or smaller than normal.
 	return ..()
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -33,6 +33,7 @@
 #include "code\__defines\admin_vr.dm"
 #include "code\__defines\appearance.dm"
 #include "code\__defines\atmos.dm"
+#include "code\__defines\atoms_movable.dm"
 #include "code\__defines\belly_modes_vr.dm"
 #include "code\__defines\callbacks.dm"
 #include "code\__defines\chat.dm"


### PR DESCRIPTION
### What this does

Moves the update_transform() proccall from mob/Initialize() to atom/movable/Initialize().

To avoid potential issues with performance due to calling a superfluous matrix transformation for way more atoms now that we cover mobs, we make a quick check if the matrix transform even needs to be done. This should keep it O(1) for all cases except where we need it.

To use it, in StrongDMM the mapper must edit the /obj entity's icon_scale_x , icon_scale_y or icon_rotation variables from 1, 1 or 0 respectively (ergo: must have a non-default value).

While at it, I went and made a define for the default values of these just in case.

### Why we need this

This enables mappers to change the size of ANY obj/ and mob/ that they spawn using the aforementioned icon_scale modification.

This was already possible for mobs and certain objs. Now it is universally possible

### Commit details

[add(atom/movable): Makes it possible for mappers to change scale/rota…](https://github.com/VOREStation/VOREStation/pull/15835/commits/bc2494b6ede23e2f1eb9a4c3ca70ff70307dcace) 
bc2494b
…tion of objs

* Removes update_transform() from mob/
* Adds new file to _defines to hold default scales
* Tweaks atom/movable to use new defines
* Tweaks mob, living, human, species to use new defines for comparisons
* On atom/movable, we check if it is rotated or otherwise scaled and then call update_transform()
