### PR TITLE
fixes execution order for stair pulling

### DIFF
--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -214,14 +214,15 @@
 		if(L.buckled)
 			L.buckled.forceMove(get_turf(top))
 
-		var/atom/movable/P
-		if(L.pulling)
+		var/atom/movable/P = null
+		if(L.pulling && !L.pulling.anchored)
 			P = L.pulling
+			P.forceMove(get_turf(L))
 
 		L.forceMove(get_turf(top))
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
-		if(P && !P.anchored)
+		if(P)
 			P.forceMove(get_turf(top))
 			L.continue_pulling(P)
 
@@ -472,14 +473,15 @@
 		if(L.buckled)
 			L.buckled.forceMove(get_turf(bottom))
 
-		var/atom/movable/P
-		if(L.pulling)
+		var/atom/movable/P = null
+		if(L.pulling && !L.pulling.anchored)
 			P = L.pulling
+			P.forceMove(get_turf(L))
 
 		L.forceMove(get_turf(bottom))
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
-		if(P && !P.anchored)
+		if(P)
 			P.forceMove(get_turf(bottom))
 			L.continue_pulling(P)
 

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -214,11 +214,14 @@
 		if(L.buckled)
 			L.buckled.forceMove(get_turf(top))
 
+		var/atom/movable/P
+		if(L.pulling)
+			P = L.pulling
+
 		L.forceMove(get_turf(top))
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
-		if(L.pulling && !L.pulling.anchored)
-			var/atom/movable/P = L.pulling
+		if(P && !P.anchored)
 			P.forceMove(get_turf(top))
 			L.continue_pulling(P)
 
@@ -469,15 +472,14 @@
 		if(L.buckled)
 			L.buckled.forceMove(get_turf(bottom))
 
-		var/atom/movable/P = null
-		if(L.pulling && !L.pulling.anchored)
+		var/atom/movable/P
+		if(L.pulling)
 			P = L.pulling
-			P.forceMove(get_turf(L))
 
 		L.forceMove(get_turf(bottom))
 
 		// If the object is pulling or grabbing anything, we'll want to move those too. A grab chain may be disrupted in doing so.
-		if(P)
+		if(P && !P.anchored)
 			P.forceMove(get_turf(bottom))
 			L.continue_pulling(P)
 


### PR DESCRIPTION
Somehow, we were checking the object pulling only after we have moved... force move breaks pulling though, in the case of normal stair use, pulling objects along never could've worked. We first need to check if we are pulling and assign it to a variable then move ourselves.

🆑 Upstream
fix: fixed and issue preventing objects to be pulled through stairs
/🆑 