### PR TITLE
Ports cooker changes

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/_cooker.dm
+++ b/code/modules/food/kitchen/cooking_machines/_cooker.dm
@@ -5,7 +5,7 @@
 	var/optimal_power = 0.6 //cooking power at 100% - This variable determines the MAXIMUM increase in do_cooking_ticks, once math goes through. If you want ticks of 0.5, set it to 0.5, etc.
 
 	var/loss = 1	//Temp lost per proc when equalising
-	var/resistance = 32000	//Resistance to heating. combines with heating power to determine how long heating takes. 32k by default.
+	var/resistance = 1200	//Resistance to heating. combines with heating power to determine how long heating takes. 32k by default.
 
 	var/light_x = 0
 	var/light_y = 0

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -24,7 +24,7 @@
 	// Power used to maintain temperature once it's heated.
 	// Going with 25% of the active power. This is a somewhat arbitrary value.
 
-	resistance = 10 KILOWATTS	// Approx. 10 minutes to heat up.
+	resistance = 2 KILOWATTS	// Approx. 2 minutes to heat up.
 
 	max_contents = 2
 	container_type = /obj/item/weapon/reagent_containers/cooking_container/fryer

--- a/code/modules/food/kitchen/cooking_machines/grill.dm
+++ b/code/modules/food/kitchen/cooking_machines/grill.dm
@@ -21,7 +21,7 @@
 	// Grill is faster to heat and setup than the rest.
 	optimal_temp = 120 + T0C
 	min_temp = 60 + T0C
-	resistance = 8 KILOWATTS // Very fast to heat up.
+	resistance = 2 KILOWATTS // Very fast to heat up.
 
 	max_contents = 3 // Arbitrary number, 3 grill 'racks'
 	container_type = /obj/item/weapon/reagent_containers/cooking_container/grill

--- a/code/modules/food/kitchen/cooking_machines/oven.dm
+++ b/code/modules/food/kitchen/cooking_machines/oven.dm
@@ -13,7 +13,7 @@
 	heating_power = 6 KILOWATTS
 	//Based on a double deck electric convection oven
 
-	resistance = 12 KILOWATTS // Approx. 12 minutes to heat up.
+	resistance = 2 KILOWATTS // Approx. 2 minutes to heat up.
 	idle_power_usage = 2 KILOWATTS
 	//uses ~30% power to stay warm
 	optimal_power = 0.8 // Oven cooks .2 faster than the default speed.


### PR DESCRIPTION
Ports cooker changes from RogueStar by VerySoft: https://github.com/TS-Rogue-Star/Rogue-Star/pull/173 Does not include everything (retains oven doors).

Added a "Toggle Safety" option to cooking appliances. This is off by default, can be toggled with a verb on the appliance. When on, instead of food burning when it reaches that point, it is instead ejected from the machine safe to eat.

Significantly sped up the speed that machines reach cooking temperature at. Generally reducing the wait time from about 10 minutes to 2 minutes.

Reduced cooking time of most food significantly.

Main goal of this to make it less frustrating to produce large spreads of food.

I want feedback from players who play chef or enjoy kitchen related RP in general, these numbers are easily tweaked.