### PR TITLE
Food Preferences

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -548,3 +548,9 @@
 		if(src.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 			if(src.wear_mask.clean_blood())
 				src.update_inv_wear_mask(0)
+
+/mob/living/carbon/proc/food_preference(var/allergen_type)
+
+	if(allergen_type in species.food_preference)
+		return species.food_preference_bonus
+	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -549,7 +549,7 @@
 			if(src.wear_mask.clean_blood())
 				src.update_inv_wear_mask(0)
 
-/mob/living/carbon/proc/food_preference(var/allergen_type)
+/mob/living/carbon/proc/food_preference(var/allergen_type) //RS edit
 
 	if(allergen_type in species.food_preference)
 		return species.food_preference_bonus

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -42,6 +42,8 @@
 	var/can_climb = FALSE
 	var/climbing_delay = 1.5	// We climb with a quarter delay
 
+	var/list/food_preference = list()
+	var/food_preference_bonus = 0
 
 /datum/species/proc/give_numbing_bite() //Holy SHIT this is hacky, but it works. Updating a mob's attacks mid game is insane.
 	unarmed_attacks = list()

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -42,7 +42,7 @@
 	var/can_climb = FALSE
 	var/climbing_delay = 1.5	// We climb with a quarter delay
 
-	var/list/food_preference = list()
+	var/list/food_preference = list() //RS edit
 	var/food_preference_bonus = 0
 
 /datum/species/proc/give_numbing_bite() //Holy SHIT this is hacky, but it works. Updating a mob's attacks mid game is insane.

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -774,3 +774,231 @@
 /datum/trait/neutral/synth_cosmetic_pain/apply(var/datum/species/S,var/mob/living/carbon/human/H, var/trait_prefs = null)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/toggle_pain_module
+
+//Food preferences ported from RogueStar
+
+/datum/trait/neutral/food_pref
+	name = "Food Preference - Carnivore"
+	desc = "You prefer to eat meat, and gain extra nutrition for doing so!"
+	cost = 0
+	custom_only = FALSE
+	can_take = ORGANICS
+	var_changes = list("food_preference_bonus" = 5)
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	var/list/our_allergens = list(ALLERGEN_MEAT)
+
+/datum/trait/neutral/food_pref/apply(datum/species/S, mob/living/carbon/human/H, trait_prefs)
+	. = ..()
+	for(var/a in our_allergens)
+		S.food_preference |= a
+
+/datum/trait/neutral/food_pref/herbivore
+	name = "Food Preference - Herbivore"
+	desc = "You prefer to eat fruits and vegitables, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_VEGETABLE,ALLERGEN_FRUIT)
+
+/datum/trait/neutral/food_pref/beanivore
+	name = "Food Preference - Legumovore"
+	desc = "You prefer to eat bean related foods, such as tofu, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_BEANS)
+
+/datum/trait/neutral/food_pref/omnivore
+	name = "Food Preference - Omnivore"
+	desc = "You prefer to eat meat and vegitables, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_VEGETABLE,ALLERGEN_MEAT)
+
+/datum/trait/neutral/food_pref/fungivore
+	name = "Food Preference - Fungivore"
+	desc = "You prefer to eat mushrooms and fungus, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_FUNGI)
+
+/datum/trait/neutral/food_pref/piscivore
+	name = "Food Preference - Piscivore"
+	desc = "You prefer to eat fish, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_FISH)
+
+/datum/trait/neutral/food_pref/granivore
+	name = "Food Preference - Granivore"
+	desc = "You prefer to eat grains and seeds, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_GRAINS,ALLERGEN_SEEDS)
+
+/datum/trait/neutral/food_pref/cocoavore
+	name = "Food Preference - Cocoavore"
+	desc = "You prefer to eat chocolate, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_CHOCOLATE)
+
+/datum/trait/neutral/food_pref/glycovore
+	name = "Food Preference - Glycovore"
+	desc = "You prefer to eat sugar, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_SUGARS)
+
+/datum/trait/neutral/food_pref/lactovore
+	name = "Food Preference - Lactovore"
+	desc = "You prefer to eat and drink things with milk in them, and gain extra nutrition for doing so!"
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/coffee,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_DAIRY)
+
+/datum/trait/neutral/food_pref/coffee
+	name = "Food Preference - Coffee Dependant"
+	desc = "You can get by on coffee alone if you have to, and you like it that way."
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/stimulant
+	)
+	our_allergens = list(ALLERGEN_COFFEE)
+
+/datum/trait/neutral/food_pref/stimulant
+	name = "Food Preference - Stimulant Dependant"
+	desc = "You can get by on caffine alone if you have to, and you like it that way."
+	excludes = list(
+	/datum/trait/neutral/food_pref,
+	/datum/trait/neutral/food_pref/herbivore,
+	/datum/trait/neutral/food_pref/beanivore,
+	/datum/trait/neutral/food_pref/omnivore,
+	/datum/trait/neutral/food_pref/fungivore,
+	/datum/trait/neutral/food_pref/piscivore,
+	/datum/trait/neutral/food_pref/granivore,
+	/datum/trait/neutral/food_pref/cocoavore,
+	/datum/trait/neutral/food_pref/glycovore,
+	/datum/trait/neutral/food_pref/lactovore,
+	/datum/trait/neutral/food_pref/coffee
+	)
+	our_allergens = list(ALLERGEN_STIMULANT)

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -58,10 +58,10 @@
 	if(!M.isSynthetic())
 		if(!(M.species.allergens & allergen_type))	//assuming it doesn't cause a horrible reaction, we'll be ok!
 			M.heal_organ_damage(0.5 * removed, 0)
-			M.adjust_nutrition((nutriment_factor * removed) * M.species.organic_food_coeff)
+			M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.organic_food_coeff)
 			M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 	else
-		M.adjust_nutrition((nutriment_factor * removed) * M.species.synthetic_food_coeff)
+		M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.synthetic_food_coeff)
 
 	//VOREStation Edits Stop
 
@@ -957,7 +957,8 @@
 
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(!(M.species.allergens & allergen_type))
-		M.adjust_nutrition(nutrition * removed)
+		var/bonus = M.food_preference(allergen_type)
+		M.adjust_nutrition((nutrition + bonus) * removed)
 	M.dizziness = max(0, M.dizziness + adj_dizzy)
 	M.drowsyness = max(0, M.drowsyness + adj_drowsy)
 	M.AdjustSleeping(adj_sleepy)
@@ -2585,6 +2586,7 @@
 	if(M.species.robo_ethanol_drunk || !(M.isSynthetic()))
 		if(alien == IS_DIONA)
 			return
+		M.adjust_nutrition((M.food_preference(allergen_type) / 2) * removed)
 		M.jitteriness = max(M.jitteriness - 3, 0)
 
 /datum/reagent/ethanol/beer/lite

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -58,10 +58,10 @@
 	if(!M.isSynthetic())
 		if(!(M.species.allergens & allergen_type))	//assuming it doesn't cause a horrible reaction, we'll be ok!
 			M.heal_organ_damage(0.5 * removed, 0)
-			M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.organic_food_coeff)
+			M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.organic_food_coeff) //RS edit
 			M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 	else
-		M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.synthetic_food_coeff)
+		M.adjust_nutrition(((nutriment_factor + M.food_preference(allergen_type)) * removed) * M.species.synthetic_food_coeff) //RS edit
 
 	//VOREStation Edits Stop
 
@@ -958,7 +958,7 @@
 /datum/reagent/drink/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(!(M.species.allergens & allergen_type))
 		var/bonus = M.food_preference(allergen_type)
-		M.adjust_nutrition((nutrition + bonus) * removed)
+		M.adjust_nutrition((nutrition + bonus) * removed) //RS edit
 	M.dizziness = max(0, M.dizziness + adj_dizzy)
 	M.drowsyness = max(0, M.drowsyness + adj_drowsy)
 	M.AdjustSleeping(adj_sleepy)
@@ -2586,7 +2586,7 @@
 	if(M.species.robo_ethanol_drunk || !(M.isSynthetic()))
 		if(alien == IS_DIONA)
 			return
-		M.adjust_nutrition((M.food_preference(allergen_type) / 2) * removed)
+		M.adjust_nutrition((M.food_preference(allergen_type) / 2) * removed) //RS edit
 		M.jitteriness = max(M.jitteriness - 3, 0)
 
 /datum/reagent/ethanol/beer/lite


### PR DESCRIPTION
Ported from roguestar, originally made by VerySoft: https://github.com/TS-Rogue-Star/Rogue-Star/pull/37 
Numbers have been tweaked, and the bonus significantly lowered.

Added new neutral traits: Food Preferences.

Foods with the relevant allergens present will give you bonus nutrition, approximately a 25% boost on most foods that I tested.

Only one of these traits can be taken at a time.