### PR TITLE
entrepreneurs start with permission ticket printer

### DIFF
--- a/code/datums/outfits/jobs/civilian_vr.dm
+++ b/code/datums/outfits/jobs/civilian_vr.dm
@@ -22,3 +22,4 @@
 
 /decl/hierarchy/outfit/job/assistant/entrepreneur
 	id_type = /obj/item/weapon/card/id/civilian/entrepreneur
+	belt = /obj/item/device/ticket_printer/train


### PR DESCRIPTION
Added permission ticket printers to entrepreneur's starting loadout.

(super tiny PR)