### PR TITLE
Gives simple mobs thermals

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -175,6 +175,8 @@
 	// VOREStation Add End
 
 	var/has_recoloured = FALSE
+	var/hunting_cooldown = 0
+	var/hasthermals = TRUE
 
 /mob/living/simple_mob/Initialize()
 	verbs -= /mob/verb/observe
@@ -222,7 +224,8 @@
 /mob/living/simple_mob/Login()
 	. = ..()
 	to_chat(src,"<b>You are \the [src].</b> [player_msg]")
-	verbs |= /mob/living/simple_mob/proc/hunting_vision //So that maint preds can see prey through walls, to make it easier to find them.
+	if(hasthermals)
+		verbs |= /mob/living/simple_mob/proc/hunting_vision //So that maint preds can see prey through walls, to make it easier to find them.
 
 /mob/living/simple_mob/SelfMove(turf/n, direct, movetime)
 	var/turf/old_turf = get_turf(src)
@@ -357,9 +360,6 @@
 	to_chat(usr, "You've already recoloured yourself once. You are only allowed to recolour yourself once during a around.")
 
 //Thermal vision adding
-
-/mob/living/simple_mob
-	var/hunting_cooldown = 0
 
 /mob/living/simple_mob/proc/hunting_vision()
 	set name = "Track Prey Through Walls"

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -222,6 +222,7 @@
 /mob/living/simple_mob/Login()
 	. = ..()
 	to_chat(src,"<b>You are \the [src].</b> [player_msg]")
+	verbs |= /mob/living/simple_mob/proc/hunting_vision //So that maint preds can see prey through walls, to make it easier to find them.
 
 /mob/living/simple_mob/SelfMove(turf/n, direct, movetime)
 	var/turf/old_turf = get_turf(src)
@@ -354,3 +355,24 @@
 		recolour.tgui_interact(usr)
 		return
 	to_chat(usr, "You've already recoloured yourself once. You are only allowed to recolour yourself once during a around.")
+
+//Thermal vision adding
+
+/mob/living/simple_mob
+	var/hunting_cooldown = 0
+
+/mob/living/simple_mob/proc/hunting_vision()
+	set name = "Track Prey Through Walls"
+	set category = "Abilities"
+	set desc = "Uses you natural predatory instincts to seek out prey even through walls, or your natural survival instincts to spot predators from a distance."
+
+	if(hunting_cooldown + 5 MINUTES < world.time)
+		to_chat(usr, "You can sense other creatures by focusing carefully on your surroundings.")
+		sight |= SEE_MOBS
+		hunting_cooldown = world.time
+		spawn(600)
+			to_chat(usr, "Your concentration wears off.")
+			sight -= SEE_MOBS
+	else if(hunting_cooldown + 5 MINUTES > world.time)
+		to_chat(usr, "You must wait for a while before using this again.")
+

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -177,6 +177,7 @@
 	var/has_recoloured = FALSE
 	var/hunting_cooldown = 0
 	var/hasthermals = TRUE
+	var/isthermal = 0
 
 /mob/living/simple_mob/Initialize()
 	verbs -= /mob/verb/observe
@@ -376,3 +377,14 @@
 	else if(hunting_cooldown + 5 MINUTES > world.time)
 		to_chat(usr, "You must wait for a while before using this again.")
 
+/mob/living/simple_mob/proc/hunting_vision_plus()
+	set name = "Thermal vision toggle"
+	set category = "Abilities"
+	set desc = "Uses you natural predatory instincts to seek out prey even through walls, or your natural survival instincts to spot predators from a distance."
+
+	if(!isthermal)
+		to_chat(usr, "You can sense other creatures by focusing carefully on your surroundings.")
+		sight |= SEE_MOBS
+	else
+		to_chat(usr, "You stop sensing creatures beyond the walls.")
+		sight -= SEE_MOBS

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
@@ -40,6 +40,8 @@
 
 	say_list_type = /datum/say_list/mouse
 
+	hasthermals = FALSE
+
 	var/body_color //brown, gray, white and black, leave blank for random
 
 /mob/living/simple_mob/animal/passive/mouse/New()


### PR DESCRIPTION
Added a verb to all simple mobs controlled by players that lets them see mobs through walls for one minute, with a five minute cooldown. Intent is to make it so that maint preds can easily track down prey outside of maintenance without having to expose themselves.