### PR TITLE
adds an option for non-synced consoles

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -44,6 +44,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
+	var/is_public = FALSE //Above mentions the option for public consoles. But for that, we need to remove the sync tab from the console entirely
 
 	req_access = list(access_research)	//Data and setting manipulation requires scientist access.
 

--- a/code/modules/research/rdconsole_tgui.dm
+++ b/code/modules/research/rdconsole_tgui.dm
@@ -49,6 +49,7 @@
 	if(!locked && !busy_msg)
 		data["info"] = list(
 			"sync" = sync,
+			"is_public" = is_public,
 		)
 
 		data["info"]["linked_destroy"] = list("present" = FALSE)

--- a/tgui/packages/tgui/interfaces/ResearchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/ResearchConsole.jsx
@@ -699,7 +699,8 @@ const ResearchConsoleConstructor = (props) => {
 const ResearchConsoleSettings = (props) => {
   const { act, data } = useBackend();
 
-  const { sync, linked_destroy, linked_imprinter, linked_lathe } = data.info;
+  const { is_public, sync, linked_destroy, linked_imprinter, linked_lathe } =
+    data.info;
 
   return (
     <Section title="Settings">
@@ -721,20 +722,21 @@ const ResearchConsoleSettings = (props) => {
       </Tabs>
       {(props.settingsTab === 0 && (
         <Box>
-          {(sync && (
-            <>
-              <Button fluid icon="sync" onClick={() => act('sync')}>
-                Sync Database with Network
+          {!is_public &&
+            ((sync && (
+              <>
+                <Button fluid icon="sync" onClick={() => act('sync')}>
+                  Sync Database with Network
+                </Button>
+                <Button fluid icon="unlink" onClick={() => act('togglesync')}>
+                  Disconnect from Research Network
+                </Button>
+              </>
+            )) || (
+              <Button fluid icon="link" onClick={() => act('togglesync')}>
+                Connect to Research Network
               </Button>
-              <Button fluid icon="unlink" onClick={() => act('togglesync')}>
-                Disconnect from Research Network
-              </Button>
-            </>
-          )) || (
-            <Button fluid icon="link" onClick={() => act('togglesync')}>
-              Connect to Research Network
-            </Button>
-          )}
+            ))}
           <Button fluid icon="lock" onClick={() => act('lock')}>
             Lock Console
           </Button>


### PR DESCRIPTION
Currently mostly for downstream. But I'm not too keen to move the entire console into a modular folder for a small tgui change.

🆑 Upstream
add: Adds the possibility of non-syncable R&D consoles (tgui wise)
/🆑 