### PR TITLE
Tweaks the server config button for whether simple mobs and robots spawn with self-recolour to be all-staff from admin-only

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -130,7 +130,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/make_mentor,
 	/client/proc/unmake_mentor,
 	/client/proc/removetickets,
-	/client/proc/delbook
+	/client/proc/delbook,
+	/client/proc/toggle_spawning_with_recolour
 	)
 
 var/list/admin_verbs_ban = list(
@@ -222,8 +223,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/recipe_dump,
 	/client/proc/panicbunker,
 	/client/proc/paranoia_logging,
-	/client/proc/ip_reputation,
-	/client/proc/toggle_spawning_with_recolour
+	/client/proc/ip_reputation
 	)
 
 var/list/admin_verbs_debug = list(
@@ -561,7 +561,8 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/cmd_admin_delete,		//delete an instance/object/mob/etc,
 	/client/proc/cmd_debug_del_all,
 	/client/proc/toggle_random_events,
-	/client/proc/modify_server_news
+	/client/proc/modify_server_news,
+	/client/proc/toggle_spawning_with_recolour
 
 )
 

--- a/code/modules/admin/admin_verbs_vr.dm
+++ b/code/modules/admin/admin_verbs_vr.dm
@@ -126,7 +126,7 @@
 	set desc = "Makes it so new robots/simple_mobs spawn with a verb to recolour themselves for this round. You must set them separately."
 	set category = "Server"
 
-	if(!check_rights(R_SERVER))
+	if(!check_rights(R_ADMIN|R_EVENT|R_FUN))
 		return
 
 	var/which = tgui_alert(usr, "Which do you want to toggle?", "Choose Recolour Toggle", list("Robot", "Simple Mob"))


### PR DESCRIPTION
### What this does

Makes it so all staff R_ADMIN|R_EVENT|R_FUN) can use the temporary (only for this round) toggle of the config that sets whether simple mobs and robots can spawn with the recolour verb. Furthermore, it adds it to the admin and event_manager verb list everyone spawns with.

### Why we need this

Given this temp server config toggle is for making running events easier, it should be accessible for all staff. I had thought GMs have R_SERVER, but it seems not so I'm modifying it.

### Edits:
2024/03/27: Modified verb list and perms as per @Kashargul request.

### Commit log
[tweak(recolor_toggle): Makes it available for all staff](https://github.com/VOREStation/VOREStation/pull/15866/commits/26ee7495619a6911d5804977cdf1cc339c6b57db) 
[26ee749](https://github.com/VOREStation/VOREStation/pull/15866/commits/26ee7495619a6911d5804977cdf1cc339c6b57db)
- Changes verb obtaining proc to be all staff
- Changes check_rights for R_EVENT
Force pushed:
- adds verb to event_manager verblist as well
- Makes it work with ANY of R_ADMIN|R_EVENT|R_FUN