### PR TITLE
Fixes issue#15869 (RD not having access to department funds

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -177,7 +177,7 @@ var/max_explosion_range = 14
 // Announcer intercom, because too much stuff creates an intercom for one message then hard del()s it.
 var/global/obj/item/device/radio/intercom/omni/global_announcer = new /obj/item/device/radio/intercom/omni(null)
 
-var/list/station_departments = list("Command", "Medical", "Engineering", "Science", "Security", "Cargo", "Exploration", "Civilian") //VOREStation Edit
+var/list/station_departments = list("Command", "Medical", "Engineering", "Research", "Security", "Cargo", "Exploration", "Civilian") //VOREStation Edit
 
 //Icons for in-game HUD glasses. Why don't we just share these a little bit?
 var/static/icon/ingame_hud = icon('icons/mob/hud.dmi')


### PR DESCRIPTION
### What this does

Fixes https://github.com/VOREStation/VOREStation/issues/15869

Turns out, the bug wasn't that the RD didn't have access.
The problem was that the bank account was initialized the wrong way.
DEPARTMENT_RESEARCH is "Research", not "Science."

We were comparing "Research" with "Science" and of course it did not work.

### Why we need this

This is a bug caused by not updating all code upon changing things around. This fixes that issue.

Gameplay wise, heads of staff need their funds. Especially if it's Research, so that they can use it in events or to buy wacky shit or bribe test subjects

Again, this is a bugfix.

### Future Notes

The fact that this bug was caused by us comparing strings across multiple very disjointed files means this WILL happen again.

As such, it might be a good idea to change things around so those define macros really initialize first and include the global.dm file. After that's done, we should go in and tear up any mentions of "department name" where we expect comparisons and replace it with DEPARTMENT_MACRO. 

It's unlikely we'll ever change them, but as it is right now it's easy to break.

### Commit details
[fix(department_accounts): Fixes research department bank not generating](https://github.com/VOREStation/VOREStation/pull/15870/commits/823433ef0b92d27aaff1d3a3ff6e834937ac5334) 
[823433e](https://github.com/VOREStation/VOREStation/pull/15870/commits/823433ef0b92d27aaff1d3a3ff6e834937ac5334)
* NOTE: I wanted to change all of the strings to use __defines macros like DEPARTMENT_RESEARCH to avoid the bug happening again. Unfortunately, due to the hiearchy of when stuff is called, it did not work. It might be a good idea to refactor code down the line so we don't have this issue again.

Research department is called "Research" not "Science". This broke at least one code instance that compared the macro DEPARTMENT_RESEARCH with "science". There's probably
