### PR TITLE
copy ai bellies onn first transfer and keep prefs synced

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_remote_control.dm
+++ b/code/modules/mob/living/silicon/ai/ai_remote_control.dm
@@ -57,6 +57,12 @@
 		deployed_shell = target
 		target.deploy_init(src)
 		mind.transfer_to(target)
+		if(target.first_transfer)
+			target.first_transfer = FALSE
+			target.copy_from_prefs_vr()
+			if(LAZYLEN(target.vore_organs))
+				target.vore_selected = target.vore_organs[1]
+		src.copy_vore_prefs_to_mob(target)
 		teleop = target // So the AI 'hears' messages near its core.
 		target.post_deploy()
 

--- a/code/modules/mob/living/silicon/robot/robot_remote_control.dm
+++ b/code/modules/mob/living/silicon/robot/robot_remote_control.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_EMPTY(available_ai_shells)
 	var/shell = FALSE
 	var/deployed = FALSE
 	var/mob/living/silicon/ai/mainframe = null
+	var/first_transfer = TRUE
 
 // Premade AI shell, for roundstart shells.
 /mob/living/silicon/robot/ai_shell/Initialize()
@@ -89,6 +90,7 @@ GLOBAL_LIST_EMPTY(available_ai_shells)
 	if(message)
 		to_chat(src, span("notice", message))
 	mind.transfer_to(mainframe)
+	src.copy_vore_prefs_to_mob(mainframe)
 	deployed = FALSE
 	update_icon()
 	mainframe.teleop = null


### PR DESCRIPTION
fixes #15883

🆑 Upstream
fix: ai bellies not being loaded on first shell transfer
fix: ai preferences not being synced between the AI and the shells
/🆑 