### PR TITLE
Quick Radio Fix for Eggnog Town (Attempt 2)

### DIFF
--- a/maps/redgate/eggnogtownunderground.dmm
+++ b/maps/redgate/eggnogtownunderground.dmm
@@ -118,7 +118,7 @@
 "aH" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "ba" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -236,7 +236,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "fV" = (
 /obj/structure/closet/walllocker{
 	dir = 1;
@@ -343,7 +343,7 @@
 /area/redgate/eggnogtown/hotsprings)
 "kc" = (
 /turf/simulated/wall/shull,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "kA" = (
 /turf/simulated/wall/iron,
 /area/redgate/eggnogtown/underground)
@@ -440,7 +440,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "pn" = (
 /obj/structure/bed/chair/bay/comfy/red{
 	dir = 1
@@ -462,7 +462,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "qr" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/dark{
@@ -546,7 +546,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "tI" = (
 /turf/simulated/floor/tiled/dark{
 	temperature = 258.15
@@ -755,7 +755,7 @@
 	req_one_access = list()
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "Gq" = (
 /obj/structure/bed/chair/bay/comfy/red,
 /turf/simulated/floor/plating/eris/under{
@@ -854,7 +854,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "Mb" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled{
@@ -899,6 +899,11 @@
 	temperature = 303.15
 	},
 /area/redgate/eggnogtown/hotsprings)
+"MW" = (
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
+	temperature = 258.15
+	},
+/area/redgate/eggnogtown/telecomms)
 "Oa" = (
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 4
@@ -983,7 +988,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "Tx" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/flashlight/lamp/green,
@@ -1096,7 +1101,7 @@
 "XU" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "XV" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_alc/full{
@@ -1114,7 +1119,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/reinforced,
-/area/redgate/eggnogtown/underground)
+/area/redgate/eggnogtown/telecomms)
 "YF" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled{
@@ -7750,7 +7755,7 @@ LP
 fN
 oz
 kc
-aa
+MW
 ab
 ab
 ab
@@ -7892,7 +7897,7 @@ qe
 aH
 XU
 Gn
-aa
+MW
 aa
 ab
 ab
@@ -8034,7 +8039,7 @@ tm
 Yt
 Sz
 kc
-aa
+MW
 aa
 ab
 ab

--- a/maps/redgate/eggnogtownunderground.dmm
+++ b/maps/redgate/eggnogtownunderground.dmm
@@ -115,6 +115,10 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/vibeout)
+"aH" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "ba" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -224,6 +228,15 @@
 	temperature = 303.15
 	},
 /area/redgate/eggnogtown/hotsprings)
+"fN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "fV" = (
 /obj/structure/closet/walllocker{
 	dir = 1;
@@ -328,6 +341,9 @@
 	temperature = 303.15
 	},
 /area/redgate/eggnogtown/hotsprings)
+"kc" = (
+/turf/simulated/wall/shull,
+/area/redgate/eggnogtown/underground)
 "kA" = (
 /turf/simulated/wall/iron,
 /area/redgate/eggnogtown/underground)
@@ -419,6 +435,12 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/hotspring)
+"oz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "pn" = (
 /obj/structure/bed/chair/bay/comfy/red{
 	dir = 1
@@ -435,6 +457,12 @@
 	temperature = 303.15
 	},
 /area/redgate/eggnogtown/hotsprings)
+"qe" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "qr" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/dark{
@@ -513,6 +541,12 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/vibeout)
+"tm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "tI" = (
 /turf/simulated/floor/tiled/dark{
 	temperature = 258.15
@@ -714,6 +748,14 @@
 	temperature = 303.15
 	},
 /area/redgate/eggnogtown/hotsprings)
+"Gn" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Access";
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/redgate/eggnogtown/underground)
 "Gq" = (
 /obj/structure/bed/chair/bay/comfy/red,
 /turf/simulated/floor/plating/eris/under{
@@ -807,6 +849,12 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/vibeout)
+"LP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "Mb" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled{
@@ -930,6 +978,12 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/vibeout)
+"Sz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "Tx" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/flashlight/lamp/green,
@@ -1039,6 +1093,10 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/houserhomestead/basement)
+"XU" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "XV" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_alc/full{
@@ -1048,6 +1106,15 @@
 	temperature = 258.15
 	},
 /area/redgate/eggnogtown/houserhomestead/basement)
+"Yt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/redgate/eggnogtown/underground)
 "YF" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled{
@@ -7536,11 +7603,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+kc
+kc
+kc
+kc
+kc
 aa
 ab
 ab
@@ -7678,11 +7745,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+kc
+LP
+fN
+oz
+kc
 aa
 ab
 ab
@@ -7820,11 +7887,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+kc
+qe
+aH
+XU
+Gn
 aa
 aa
 ab
@@ -7962,11 +8029,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+kc
+tm
+Yt
+Sz
+kc
 aa
 aa
 ab
@@ -8104,11 +8171,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+kc
+kc
+kc
+kc
+kc
 aa
 aa
 ab


### PR DESCRIPTION
~~Second time's the charm, hopefully~~
~~This (still) probably should have been done sooner~~

Adds an extra copy of the communications relay on the above-ground level of the eggnog town map to the underground level. Radio and PDAs (should) work on both levels now (I hope)

![image](https://github.com/VOREStation/VOREStation/assets/42255398/84d878de-6103-4dcc-9181-7f788e70d19e)


_~~Now if only I could figure out how to make commlinks and NIFs work on redgate maps too~~_