### PR TITLE
fix telecom filtering additions and nanomap autoscaling

### DIFF
--- a/code/ATMOSPHERICS/components/omni_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/filter.dm
@@ -131,8 +131,8 @@
 	if(portData.len)
 		data["ports"] = portData
 	if(output)
-		data["set_flow_rate"] = round(set_flow_rate*10)		//because nanoui can't handle rounded decimals.
-		data["last_flow_rate"] = round(last_flow_rate*10)
+		data["set_flow_rate"] = round(set_flow_rate)
+		data["last_flow_rate"] = round(last_flow_rate)
 
 	return data
 
@@ -154,7 +154,7 @@
 /obj/machinery/atmospherics/omni/atmos_filter/tgui_act(action, params)
 	if(..())
 		return TRUE
-	
+
 	switch(action)
 		if("power")
 			if(!configuring)

--- a/code/ATMOSPHERICS/components/omni_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/mixer.dm
@@ -158,8 +158,8 @@
 	if(portData.len)
 		data["ports"] = portData
 	if(output)
-		data["set_flow_rate"] = round(set_flow_rate*10)		//because nanoui can't handle rounded decimals.
-		data["last_flow_rate"] = round(last_flow_rate*10)
+		data["set_flow_rate"] = round(set_flow_rate)
+		data["last_flow_rate"] = round(last_flow_rate)
 
 	return data
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -313,7 +313,7 @@
 
 
 		if("freq")
-			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, null, 9999)
+			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, max_value=9999)
 			if(newfreq && canAccess(usr))
 				if(findtext(num2text(newfreq), "."))
 					newfreq *= 10 // shift the decimal one place

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -313,13 +313,13 @@
 
 
 		if("freq")
-			var/newfreq = input(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, network) as null|num
+			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, null, 9999)
 			if(newfreq && canAccess(usr))
 				if(findtext(num2text(newfreq), "."))
 					newfreq *= 10 // shift the decimal one place
 				if(!(newfreq in freq_listening) && newfreq < 10000)
 					freq_listening.Add(newfreq)
-					set_temp("-% New frequency filter assigned: \"[newfreq] GHz\" %-", "average")
+					set_temp("-% New frequency filter assigned: \"[newfreq/10] GHz\" %-", "average")
 				. = TRUE
 
 		if("delete")

--- a/code/modules/tgui/modules/atmos_control.dm
+++ b/code/modules/tgui/modules/atmos_control.dm
@@ -51,7 +51,7 @@
 	. = ..()
 
 	var/z = get_z(user)
-	var/list/map_levels = using_map.get_map_levels(z) 
+	var/list/map_levels = using_map.get_map_levels(z)
 
 	// TODO: Move these to a cache, similar to cameras
 	var/alarms[0]
@@ -68,12 +68,13 @@
 			"y" = alarm.y,
 			"z" = alarm.z)
 	.["alarms"] = alarms
+	.["zoomScale"] = world.maxx + world.maxy
 
 /datum/tgui_module/atmos_control/tgui_data(mob/user)
 	var/list/data = list()
 
 	var/z = get_z(user)
-	var/list/map_levels = using_map.get_map_levels(z) 
+	var/list/map_levels = using_map.get_map_levels(z)
 	data["map_levels"] = map_levels
 
 	return data

--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -10,7 +10,7 @@
 /datum/tgui_module/crew_monitor/tgui_act(action, params, datum/tgui/ui)
 	if(..())
 		return TRUE
-		
+
 	if(action && !issilicon(usr))
 		playsound(tgui_host(), "terminal_type", 50, 1)
 
@@ -34,7 +34,7 @@
 /datum/tgui_module/crew_monitor/tgui_interact(mob/user, datum/tgui/ui = null)
 	var/z = get_z(user)
 	var/list/map_levels = using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
-	
+
 	if(!map_levels.len)
 		to_chat(user, "<span class='warning'>The crew monitor doesn't seem like it'll work here.</span>")
 		if(ui)
@@ -47,6 +47,9 @@
 		ui.autoupdate = TRUE
 		ui.open()
 
+/datum/tgui_module/crew_monitor/tgui_static_data(mob/user)
+	. = ..()
+	.["zoomScale"] = world.maxx + world.maxy
 
 /datum/tgui_module/crew_monitor/tgui_data(mob/user)
 	var/data[0]
@@ -64,7 +67,7 @@
 	// This is apparently necessary, because the above loop produces an emergent behavior
 	// of telling you what coordinates someone is at even without sensors on,
 	// because it strictly sorts by zlevel from bottom to top, and by coordinates from top left to bottom right.
-	shuffle_inplace(crewmembers) 
+	shuffle_inplace(crewmembers)
 	data["crewmembers"] = crewmembers
 
 	return data

--- a/tgui/packages/tgui/components/NanoMap.jsx
+++ b/tgui/packages/tgui/components/NanoMap.jsx
@@ -15,8 +15,6 @@ const pauseEvent = (e) => {
   return false;
 };
 
-const zoomScale = 280;
-
 export class NanoMap extends Component {
   constructor(props) {
     super(props);
@@ -78,8 +76,8 @@ export class NanoMap extends Component {
     };
 
     this.handleOnClick = (e) => {
-      let byondX = e.offsetX / this.state.zoom / zoomScale;
-      let byondY = 1 - e.offsetY / this.state.zoom / zoomScale; // Byond origin is bottom left, this is top left
+      let byondX = e.offsetX / this.state.zoom / this.props.zoomScale;
+      let byondY = 1 - e.offsetY / this.state.zoom / this.props.zoomScale; // Byond origin is bottom left, this is top left
 
       e.byondX = byondX;
       e.byondY = byondY;
@@ -127,7 +125,7 @@ export class NanoMap extends Component {
 
     const mapUrl = config.map + '_nanomap_z' + config.mapZLevel + '.png';
     // (x * zoom), x Needs to be double the turf- map size. (for virgo, 140x140)
-    const mapSize = zoomScale * zoom + 'px';
+    const mapSize = this.props.zoomScale * zoom + 'px';
     const newStyle = {
       width: mapSize,
       height: mapSize,

--- a/tgui/packages/tgui/interfaces/AtmosControl.jsx
+++ b/tgui/packages/tgui/interfaces/AtmosControl.jsx
@@ -50,7 +50,7 @@ export const AtmosControlContent = (props) => {
     // and change the @for scss to match.
     body = (
       <Box height="526px" mb="0.5rem" overflow="hidden">
-        <NanoMap onZoom={(v) => setZoom(v)}>
+        <NanoMap zoomScale={data.zoomScale} onZoom={(v) => setZoom(v)}>
           {sortedAlarms
             .filter((x) => ~~x.z === ~~config.mapZLevel)
             .map((cm) => (

--- a/tgui/packages/tgui/interfaces/CrewMonitor.jsx
+++ b/tgui/packages/tgui/interfaces/CrewMonitor.jsx
@@ -165,7 +165,7 @@ const CrewMonitorMapView = (props) => {
   const { act, config, data } = useBackend();
   return (
     <Box height="526px" mb="0.5rem" overflow="hidden">
-      <NanoMap onZoom={(v) => props.onZoom(v)}>
+      <NanoMap zoomScale={data.zoomScale} onZoom={(v) => props.onZoom(v)}>
         {data.crewmembers
           .filter(
             (x) => x.sensor_type === 3 && ~~x.realZ === ~~config.mapZLevel,

--- a/tgui/packages/tgui/interfaces/OmniFilter.tsx
+++ b/tgui/packages/tgui/interfaces/OmniFilter.tsx
@@ -111,11 +111,11 @@ export const OmniFilter = (props) => {
               {config ? (
                 <Button
                   icon="wrench"
-                  content={set_flow_rate / 10 + ' L/s'}
+                  content={set_flow_rate + ' L/s'}
                   onClick={() => act('set_flow_rate')}
                 />
               ) : (
-                set_flow_rate / 10 + ' L/s'
+                set_flow_rate + ' L/s'
               )}
             </LabeledList.Item>
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/OmniMixer.tsx
+++ b/tgui/packages/tgui/interfaces/OmniMixer.tsx
@@ -91,11 +91,11 @@ export const OmniMixer = (props) => {
               {config ? (
                 <Button
                   icon="wrench"
-                  content={set_flow_rate / 10 + ' L/s'}
+                  content={set_flow_rate + ' L/s'}
                   onClick={() => act('set_flow_rate')}
                 />
               ) : (
-                set_flow_rate / 10 + ' L/s'
+                set_flow_rate + ' L/s'
               )}
             </LabeledList.Item>
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/TelecommsMultitoolMenu.jsx
+++ b/tgui/packages/tgui/interfaces/TelecommsMultitoolMenu.jsx
@@ -122,7 +122,17 @@ const TelecommsMultitoolMenuStatus = (props) => {
           ))}
         </LabeledList>
       </Section>
-      <Section title="Filtering Frequencies" mt={1}>
+      <Section
+        title="Filtering Frequencies"
+        mt={1}
+        buttons={
+          <Button
+            icon="pen"
+            content="Add Frequency"
+            onClick={() => act('freq')}
+          />
+        }
+      >
         {filter.map((f) => (
           <Button.Confirm
             key={f.index}


### PR DESCRIPTION
No bundle not to conflict.

🆑 Upstream
fix NanoMaps Marker offset on non 140x140 mapsize (NanoMaps now needs the zoomSize as props, handled as maxx+maxy in the tgui data)
fix: Telecomms filters can be added through the multitool menu
fix: omni_filter and omni_mixer showing too high flow values
/🆑 