### PR TITLE
Ports : ability to dominate mobs and ghosted player bodies via dominate predator trait

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -293,7 +293,7 @@
 			if(db.ckey == db.pred_ckey)
 				to_chat(src, "<span class='notice'>You ease off of your control, releasing \the [db].</span>")
 				to_chat(db, "<span class='notice'>You feel the alien presence fade, and restore control of your body to you of their own will...</span>")
-				if(db.was_mob==1) //CHOMPEdit start - clean up if the dominated body was a playerless mob
+				if(db.was_mob==1) //clean up if the dominated body was a playerless mob
 					db.pred_ckey=null
 					db.ckey=null
 					db.restore_control()


### PR DESCRIPTION
Ports my PR from chomp station that I feel like might be interesting with the new redgate jungle.

https://github.com/CHOMPStation2/CHOMPStation2/pull/7793

Important to note, due to differences in maps, mobs they are on and so on I haven't ported over the mind binder whitelist for dominate-able mobs, should such whitelist be required obviously I will work on it.
It should be noted due to the way the dominate predator trait works it is only possible to dominate mobs with a belly.

Interactions :

player vs mob : domination, still asks if prefrences allign

player vs player (in body) : asks both parties
player vs player (client closed) : domination is declined
player vs player (ghosted or in some other way not assigned to body) : domination, unique log to admins "X is taking control over Y while they are out of their body."

player vs player mob (Maintpred spawn etc) : same as above for pvp

