### PR TITLE
scrolling fixes

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -216,7 +216,7 @@ class ChatRenderer {
       this.scrollToBottom();
     });
     // Flush the queue
-    this.tryFlushQueue(true);
+    this.tryFlushQueue();
   }
 
   onStateLoaded() {

--- a/tgui/packages/tgui/components/Autofocus.tsx
+++ b/tgui/packages/tgui/components/Autofocus.tsx
@@ -1,17 +1,23 @@
-import { createRef, PropsWithChildren, useEffect } from 'react';
+import { PropsWithChildren, useEffect, useRef } from 'react';
 
-export const Autofocus = (props: PropsWithChildren) => {
-  const ref = createRef<HTMLDivElement>();
+/** Used to force the window to steal focus on load. Children optional */
+export function Autofocus(props: PropsWithChildren) {
+  const { children } = props;
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       ref.current?.focus();
     }, 1);
+
+    return () => {
+      clearTimeout(timer);
+    };
   }, []);
 
   return (
     <div ref={ref} tabIndex={-1}>
-      {props.children}
+      {children}
     </div>
   );
-};
+}

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -5,7 +5,7 @@
  */
 
 import { canRender, classes } from 'common/react';
-import { forwardRef, ReactNode, RefObject, useEffect } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 
 import { addScrollableNode, removeScrollableNode } from '../events';
 import { BoxProps, computeBoxClassName, computeBoxProps } from './Box';
@@ -61,77 +61,76 @@ type Props = Partial<{
  * </Section>
  * ```
  */
-export const Section = forwardRef(
-  (props: Props, forwardedRef: RefObject<HTMLDivElement>) => {
-    const {
-      buttons,
-      children,
-      className,
-      fill,
-      fitted,
-      onScroll,
-      scrollable,
-      scrollableHorizontal,
-      title,
-      container_id,
-      flexGrow, // VOREStation Addition
-      noTopPadding, // VOREStation Addition
-      stretchContents, // VOREStation Addition
-      ...rest
-    } = props;
+export const Section = (props: Props) => {
+  const {
+    buttons,
+    children,
+    className,
+    fill,
+    fitted,
+    onScroll,
+    scrollable,
+    scrollableHorizontal,
+    title,
+    container_id,
+    flexGrow, // VOREStation Addition
+    noTopPadding, // VOREStation Addition
+    stretchContents, // VOREStation Addition
+    ...rest
+  } = props;
+  const currentRef = useRef(null);
 
-    const hasTitle = canRender(title) || canRender(buttons);
+  const hasTitle = canRender(title) || canRender(buttons);
 
-    /** We want to be able to scroll on hover, but using focus will steal it from inputs */
-    useEffect(() => {
-      if (!forwardedRef?.current) return;
-      if (!scrollable && !scrollableHorizontal) return;
+  /** We want to be able to scroll on hover, but using focus will steal it from inputs */
+  useEffect(() => {
+    if (!currentRef?.current) return;
+    if (!scrollable && !scrollableHorizontal) return;
 
-      addScrollableNode(forwardedRef.current);
+    addScrollableNode(currentRef.current);
 
-      return () => {
-        if (!forwardedRef?.current) return;
-        removeScrollableNode(forwardedRef.current!);
-      };
-    }, []);
+    return () => {
+      if (!currentRef?.current) return;
+      removeScrollableNode(currentRef.current!);
+    };
+  }, []);
 
-    return (
-      <div
-        id={container_id || ''}
-        className={classes([
-          'Section',
-          fill && 'Section--fill',
-          fitted && 'Section--fitted',
-          scrollable && 'Section--scrollable',
-          scrollableHorizontal && 'Section--scrollableHorizontal',
-          flexGrow && 'Section--flex', // VOREStation Addition
-          className,
-          computeBoxClassName(rest),
-        ])}
-        {...computeBoxProps(rest)}
-      >
-        {hasTitle && (
-          <div className="Section__title">
-            <span className="Section__titleText">{title}</span>
-            <div className="Section__buttons">{buttons}</div>
-          </div>
-        )}
-        <div className="Section__rest">
-          <div
-            className={classes([
-              'Section__content',
-              !!stretchContents && 'Section__content--stretchContents', // VOREStation Addition
-              !!noTopPadding && 'Section__content--noTopPadding', // VOREStation Addition
-            ])}
-            onScroll={onScroll}
-            // For posterity: the forwarded ref needs to be here specifically
-            // to actually let things interact with the scrolling.
-            ref={forwardedRef}
-          >
-            {children}
-          </div>
+  return (
+    <div
+      id={container_id || ''}
+      className={classes([
+        'Section',
+        fill && 'Section--fill',
+        fitted && 'Section--fitted',
+        scrollable && 'Section--scrollable',
+        scrollableHorizontal && 'Section--scrollableHorizontal',
+        flexGrow && 'Section--flex', // VOREStation Addition
+        className,
+        computeBoxClassName(rest),
+      ])}
+      {...computeBoxProps(rest)}
+    >
+      {hasTitle && (
+        <div className="Section__title">
+          <span className="Section__titleText">{title}</span>
+          <div className="Section__buttons">{buttons}</div>
+        </div>
+      )}
+      <div className="Section__rest">
+        <div
+          className={classes([
+            'Section__content',
+            !!stretchContents && 'Section__content--stretchContents', // VOREStation Addition
+            !!noTopPadding && 'Section__content--noTopPadding', // VOREStation Addition
+          ])}
+          onScroll={onScroll}
+          // For posterity: the forwarded ref needs to be here specifically
+          // to actually let things interact with the scrolling.
+          ref={currentRef}
+        >
+          {children}
         </div>
       </div>
-    );
-  },
-);
+    </div>
+  );
+};

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -78,21 +78,21 @@ export const Section = (props: Props) => {
     stretchContents, // VOREStation Addition
     ...rest
   } = props;
-  const currentRef = useRef(null);
+  const node = useRef(null);
 
   const hasTitle = canRender(title) || canRender(buttons);
 
   /** We want to be able to scroll on hover, but using focus will steal it from inputs */
   useEffect(() => {
-    if (!currentRef?.current) return;
+    if (!node?.current) return;
     if (!scrollable && !scrollableHorizontal) return;
-    let observerRefValue = currentRef.current;
+    const self = node.current;
 
-    addScrollableNode(observerRefValue);
+    addScrollableNode(self);
 
     return () => {
-      if (!observerRefValue) return;
-      removeScrollableNode(observerRefValue!);
+      if (!self) return;
+      removeScrollableNode(self!);
     };
   }, []);
 
@@ -127,7 +127,7 @@ export const Section = (props: Props) => {
           onScroll={onScroll}
           // For posterity: the forwarded ref needs to be here specifically
           // to actually let things interact with the scrolling.
-          ref={currentRef}
+          ref={node}
         >
           {children}
         </div>

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -23,6 +23,8 @@ type Props = Partial<{
   scrollableHorizontal: boolean;
   /** Title of the section. */
   title: ReactNode;
+  /** id to assosiate with the parent div element used by this section, for uses with procs like getElementByID */
+  container_id: string;
   /** @member Callback function for the `scroll` event */
   onScroll: ((this: GlobalEventHandlers, ev: Event) => any) | null;
 
@@ -71,6 +73,7 @@ export const Section = forwardRef(
       scrollable,
       scrollableHorizontal,
       title,
+      container_id,
       flexGrow, // VOREStation Addition
       noTopPadding, // VOREStation Addition
       stretchContents, // VOREStation Addition
@@ -94,6 +97,7 @@ export const Section = forwardRef(
 
     return (
       <div
+        id={container_id || ''}
         className={classes([
           'Section',
           fill && 'Section--fill',

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -86,12 +86,13 @@ export const Section = (props: Props) => {
   useEffect(() => {
     if (!currentRef?.current) return;
     if (!scrollable && !scrollableHorizontal) return;
+    let observerRefValue = currentRef.current;
 
-    addScrollableNode(currentRef.current);
+    addScrollableNode(observerRefValue);
 
     return () => {
-      if (!currentRef?.current) return;
-      removeScrollableNode(currentRef.current!);
+      if (!observerRefValue) return;
+      removeScrollableNode(observerRefValue!);
     };
   }, []);
 

--- a/tgui/packages/tgui/components/Tabs.tsx
+++ b/tgui/packages/tgui/components/Tabs.tsx
@@ -60,8 +60,16 @@ const Tab = (props: TabProps) => {
     leftSlot,
     rightSlot,
     children,
+    onClick,
     ...rest
   } = props;
+
+  const handleClick = (e) => {
+    if (onClick) {
+      onClick(e);
+      e.target.blur();
+    }
+  };
 
   return (
     <div
@@ -73,6 +81,7 @@ const Tab = (props: TabProps) => {
         className,
         computeBoxClassName(rest),
       ])}
+      onClick={handleClick}
       {...computeBoxProps(rest)}
     >
       {(canRender(leftSlot) && <div className="Tab__left">{leftSlot}</div>) ||

--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -107,6 +107,14 @@ const focusNearestTrackedParent = (node: HTMLElement | null) => {
 
 window.addEventListener('mousemove', (e) => {
   const node = e.target as HTMLElement;
+  if (node !== lastVisitedNode && trackedNodes.length < 2) {
+    lastVisitedNode = node;
+    focusNearestTrackedParent(node);
+  }
+});
+
+window.addEventListener('click', (e) => {
+  const node = e.target as HTMLElement;
   if (node !== lastVisitedNode) {
     lastVisitedNode = node;
     focusNearestTrackedParent(node);

--- a/tgui/packages/tgui/interfaces/BodyDesigner.jsx
+++ b/tgui/packages/tgui/interfaces/BodyDesigner.jsx
@@ -81,14 +81,16 @@ const BodyDesignerBodyRecords = (props) => {
         />
       }
     >
-      {bodyrecords.map((record) => (
-        <Button
-          icon="eye"
-          key={record.name}
-          content={record.name}
-          onClick={() => act('view_brec', { view_brec: record.recref })}
-        />
-      ))}
+      {bodyrecords
+        ? bodyrecords.map((record) => (
+            <Button
+              icon="eye"
+              key={record.name}
+              content={record.name}
+              onClick={() => act('view_brec', { view_brec: record.recref })}
+            />
+          ))
+        : ''}
     </Section>
   );
 };

--- a/tgui/packages/tgui/layouts/Layout.tsx
+++ b/tgui/packages/tgui/layouts/Layout.tsx
@@ -7,11 +7,21 @@
 import { classes } from 'common/react';
 import { useEffect, useRef } from 'react';
 
-import { computeBoxClassName, computeBoxProps } from '../components/Box';
+import {
+  BoxProps,
+  computeBoxClassName,
+  computeBoxProps,
+} from '../components/Box';
 import { addScrollableNode, removeScrollableNode } from '../events';
 
-export const Layout = (props) => {
+type Props = Partial<{
+  theme: string;
+}> &
+  BoxProps;
+
+export function Layout(props: Props) {
   const { className, theme = 'nanotrasen', children, ...rest } = props;
+
   return (
     <div className={'theme-' + theme}>
       <div
@@ -22,46 +32,44 @@ export const Layout = (props) => {
       </div>
     </div>
   );
-};
+}
 
-const LayoutContent = (props) => {
-  const {
-    className,
-    scrollable,
-    children,
-    scrollableHorizontal,
-    container_id,
-    ...rest
-  } = props;
-  const currentRef = useRef(null);
+type ContentProps = Partial<{
+  scrollable: boolean;
+}> &
+  BoxProps;
+
+function LayoutContent(props: ContentProps) {
+  const { className, scrollable, children, ...rest } = props;
+  const node = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!currentRef?.current) return;
-    if (!scrollable) return;
-    let observerRefValue = currentRef.current;
-    addScrollableNode(observerRefValue);
+    const self = node.current;
 
+    if (self && scrollable) {
+      addScrollableNode(self);
+    }
     return () => {
-      if (!observerRefValue) return;
-      removeScrollableNode(observerRefValue!);
+      if (self && scrollable) {
+        removeScrollableNode(self);
+      }
     };
   }, []);
 
   return (
     <div
-      ref={currentRef}
-      id={container_id || ''}
       className={classes([
         'Layout__content',
         scrollable && 'Layout__content--scrollable',
         className,
         computeBoxClassName(rest),
       ])}
+      ref={node}
       {...computeBoxProps(rest)}
     >
       {children}
     </div>
   );
-};
+}
 
 Layout.Content = LayoutContent;

--- a/tgui/packages/tgui/layouts/Layout.tsx
+++ b/tgui/packages/tgui/layouts/Layout.tsx
@@ -42,7 +42,7 @@ const LayoutContent = (props) => {
 
     return () => {
       if (!currentRef?.current) return;
-      removeScrollableNode(currentRef.current!);
+      removeScrollableNode(currentRef.current);
     };
   }, []);
 

--- a/tgui/packages/tgui/layouts/Layout.tsx
+++ b/tgui/packages/tgui/layouts/Layout.tsx
@@ -38,11 +38,12 @@ const LayoutContent = (props) => {
   useEffect(() => {
     if (!currentRef?.current) return;
     if (!scrollable) return;
-    addScrollableNode(currentRef.current);
+    let observerRefValue = currentRef.current;
+    addScrollableNode(observerRefValue);
 
     return () => {
-      if (!currentRef?.current) return;
-      removeScrollableNode(currentRef.current);
+      if (!observerRefValue) return;
+      removeScrollableNode(observerRefValue!);
     };
   }, []);
 

--- a/tgui/packages/tgui/layouts/Layout.tsx
+++ b/tgui/packages/tgui/layouts/Layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import { classes } from 'common/react';
+import { useEffect, useRef } from 'react';
 
 import { computeBoxClassName, computeBoxProps } from '../components/Box';
 import { addScrollableNode, removeScrollableNode } from '../events';
@@ -24,9 +25,31 @@ export const Layout = (props) => {
 };
 
 const LayoutContent = (props) => {
-  const { className, scrollable, children, ...rest } = props;
+  const {
+    className,
+    scrollable,
+    children,
+    scrollableHorizontal,
+    container_id,
+    ...rest
+  } = props;
+  const currentRef = useRef(null);
+
+  useEffect(() => {
+    if (!currentRef?.current) return;
+    if (!scrollable) return;
+    addScrollableNode(currentRef.current);
+
+    return () => {
+      if (!currentRef?.current) return;
+      removeScrollableNode(currentRef.current!);
+    };
+  }, []);
+
   return (
     <div
+      ref={currentRef}
+      id={container_id || ''}
       className={classes([
         'Layout__content',
         scrollable && 'Layout__content--scrollable',
@@ -38,11 +61,6 @@ const LayoutContent = (props) => {
       {children}
     </div>
   );
-};
-
-LayoutContent.defaultHooks = {
-  onComponentDidMount: (node) => addScrollableNode(node),
-  onComponentWillUnmount: (node) => removeScrollableNode(node),
 };
 
 Layout.Content = LayoutContent;


### PR DESCRIPTION
closes #15746

integrates the changes from TG on the AutoFocus and Layout. Their code on the latter looked cleaner 

fixes scrolling in tgui windows
fixes an issue where too many chat messages could get archived
fix a rare crash condition on the BodyRecords UI if there were no records available

Downstream has their own PR as we have some different UIs with other needs there. Close this on mirror.

Currently no bundles. Not too keen on conflicts with the 5.0.1 update.