### PR TITLE
Redgates are no longer in space

### DIFF
--- a/maps/offmap_vr/common_offmaps.dm
+++ b/maps/offmap_vr/common_offmaps.dm
@@ -236,6 +236,7 @@
 	name = "Redgate Destination"
 	z = Z_LEVEL_REDGATE
 	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
+	base_turf = /turf/simulated/floor/outdoors/rocks/caves
 
 /datum/map_template/common_lateload/redgate/on_map_loaded(z)
 	. = ..()


### PR DESCRIPTION
Fixed the base tile of redgate locations being in space, which caused them to vent when breached.