### PR TITLE
Opens more positive and negative traits to non-custom species.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -6,30 +6,40 @@
 	desc = "Allows you to move slower on average than baseline."
 	cost = -2
 	var_changes = list("slowdown" = 0.5)
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_DIONA, SPECIES_UNATHI) //These are already this slow.
+	custom_only = FALSE
 
 /datum/trait/negative/speed_slow_plus
 	name = "Slowdown, Major"
 	desc = "Allows you to move MUCH slower on average than baseline."
 	cost = -3
 	var_changes = list("slowdown" = 1.0)
+	custom_only = FALSE
+	banned_species = list(SPECIES_DIONA) //Diona are even slower than this
 
 /datum/trait/negative/weakling
 	name = "Weakling"
 	desc = "Causes heavy equipment to slow you down more when carried."
 	cost = -1
 	var_changes = list("item_slowdown_mod" = 1.5)
+	custom_only = FALSE
+	banned_species = list(SPECIES_SHADEKIN_CREW, SPECIES_TESHARI) //These are already this weak.
 
 /datum/trait/negative/weakling_plus
 	name = "Weakling, Major"
 	desc = "Allows you to carry heavy equipment with much more slowdown."
 	cost = -2
 	var_changes = list("item_slowdown_mod" = 2.0)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TESHARI) //These are already this weak.
 
 /datum/trait/negative/endurance_low
 	name = "Low Endurance"
 	desc = "Reduces your maximum total hitpoints to 75."
 	cost = -2
 	var_changes = list("total_health" = 75)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TESHARI, SPECIES_SHADEKIN_CREW) //These are already this weak.
 
 /datum/trait/negative/endurance_low/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -40,6 +50,8 @@
 	desc = "Reduces your maximum total hitpoints to 50."
 	cost = -3 //Teshari HP. This makes the person a lot more suseptable to getting stunned, killed, etc.
 	var_changes = list("total_health" = 50)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TESHARI) //These are already this weak.
 
 /datum/trait/negative/endurance_very_low/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -49,18 +61,23 @@
 	name = "Brute Weakness, Minor"
 	desc = "Increases damage from brute damage sources by 15%"
 	cost = -1
+	custom_only = FALSE
 	var_changes = list("brute_mod" = 1.15)
+	banned_species = list(SPECIES_TESHARI, SPECIES_TAJ, SPECIES_ZADDAT, SPECIES_SHADEKIN_CREW) //These are already this weak.
 
 /datum/trait/negative/brute_weak
 	name = "Brute Weakness"
 	desc = "Increases damage from brute damage sources by 25%"
 	cost = -2
+	custom_only = FALSE
 	var_changes = list("brute_mod" = 1.25)
+	banned_species = list(SPECIES_TESHARI, SPECIES_SHADEKIN_CREW) //These are already this weak.
 
 /datum/trait/negative/brute_weak_plus
 	name = "Brute Weakness, Major"
 	desc = "Increases damage from brute damage sources by 50%"
 	cost = -3
+	custom_only = FALSE
 	var_changes = list("brute_mod" = 1.5)
 
 /datum/trait/negative/minor_burn_weak
@@ -128,6 +145,7 @@
 	cost = -1
 	var_changes = list("trauma_mod" = 2)
 	can_take = ORGANICS
+	custom_only = FALSE
 
 /datum/trait/negative/breathes
 	cost = -2

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -52,6 +52,8 @@
 	autohiss_exempt = list(LANGUAGE_UNATHI))
 
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_zaddat)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJARAN, SPECIES_UNATHI, SPECIES_ZADDAT)
 
 /datum/trait/neutral/autohiss_tajaran
 	name = "Autohiss (Tajaran)"
@@ -63,6 +65,8 @@
 		),
 	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI,LANGUAGE_ALAI))
 	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_zaddat)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJARAN, SPECIES_UNATHI, SPECIES_ZADDAT)
 
 /datum/trait/neutral/autohiss_zaddat
 	name = "Autohiss (Zaddat)"
@@ -81,6 +85,8 @@
 		),
 	autohiss_exempt = list(LANGUAGE_ZADDAT,LANGUAGE_VESPINAE))
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJARAN, SPECIES_UNATHI, SPECIES_ZADDAT)
 
 /datum/trait/neutral/bloodsucker
 	name = "Bloodsucker, Obligate"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -6,24 +6,32 @@
 	desc = "Allows you to move faster on average than baseline."
 	cost = 4
 	var_changes = list("slowdown" = -0.5)
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_TESHARI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_UNATHI) //Either not applicable or buffs ruin species flavour/balance
+	custom_only = FALSE
 
 /datum/trait/positive/hardy
 	name = "Hardy"
 	desc = "Allows you to carry heavy equipment with less slowdown."
 	cost = 1
 	var_changes = list("item_slowdown_mod" = 0.5)
+	custom_only = FALSE
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN) //Either not applicable or buffs are too strong
 
 /datum/trait/positive/hardy_plus
 	name = "Hardy, Major"
 	desc = "Allows you to carry heavy equipment with almost no slowdown."
 	cost = 2
 	var_changes = list("item_slowdown_mod" = 0.25)
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN) //Either not applicable or buffs are too strong
+	custom_only = FALSE
 
 /datum/trait/positive/endurance_high
 	name = "High Endurance"
 	desc = "Increases your maximum total hitpoints to 125"
 	cost = 4
 	var_changes = list("total_health" = 125)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_SHADEKIN_CREW) //Either not applicable or buffs are too strong
 
 /datum/trait/positive/endurance_high/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -46,12 +54,16 @@
 	desc = "Allows you to see a short distance in the dark."
 	cost = 1
 	var_changes = list("darksight" = 5, "flash_mod" = 1.1)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJARAN, SPECIES_SHADEKIN_CREW, SPECIES_SHADEKIN, SPECIES_XENOHYBRID, SPECIES_VULPKANIN, SPECIES_XENO, SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST) //These species already have strong darksight by default.
 
 /datum/trait/positive/darksight_plus
 	name = "Darksight, Major"
 	desc = "Allows you to see in the dark for the whole screen."
 	cost = 2
 	var_changes = list("darksight" = 8, "flash_mod" = 1.2)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJARAN, SPECIES_SHADEKIN_CREW, SPECIES_SHADEKIN, SPECIES_XENOHYBRID, SPECIES_VULPKANIN, SPECIES_XENO, SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST) //These species already have strong darksight by default.
 
 /datum/trait/positive/melee_attack
 	name = "Special Attack: Sharp Melee" // Trait Organization for easier browsing. TODO: Proper categorization of 'health/ability/resist/etc'
@@ -76,6 +88,8 @@
 	desc = "Adds 15% resistance to brute damage sources."
 	cost = 2
 	var_changes = list("brute_mod" = 0.85)
+	custom_only = FALSE
+	banned_species = list(SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST) //Most of these are already this resistant or stronger, or it'd be way too much of a boost for tesh.
 
 /datum/trait/positive/brute_resist
 	name = "Brute Resist"
@@ -211,6 +225,7 @@
 	var_changes = list("trauma_mod" = 0.85)
 	excludes = list(/datum/trait/negative/neural_hypersensitivity)
 	can_take = ORGANICS
+	custom_only = FALSE
 
 /datum/trait/positive/throw_resistance
 	name = "Firm Body"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -6,8 +6,8 @@
 	desc = "Allows you to move faster on average than baseline."
 	cost = 4
 	var_changes = list("slowdown" = -0.5)
-	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_TESHARI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_UNATHI) //Either not applicable or buffs ruin species flavour/balance
-	custom_only = FALSE
+//	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_TESHARI, SPECIES_TAJ, SPECIES_DIONA, SPECIES_UNATHI) //Either not applicable or buffs ruin species flavour/balance
+//	custom_only = FALSE //Keeping these in comments in case we decide to open them up in future, so the species are already organised.
 
 /datum/trait/positive/hardy
 	name = "Hardy"


### PR DESCRIPTION
Added access to various negative and positive traits for non-custom species, where it makes sense that there might be variations due to natural differences and body modifications. I have excluded specific species from accessing most of these where they are already meet those levels or would be buffed too much and lose their balanced flavour.
Whilst I realise there is a system in place to stop negatives making things stronger, I have excluded these species anyway so people don't accidentally waste points on them.

Specifically:
### **Positive traits:**
- Hardy and Hardy+ (excluding Tesh, Prommie and Protean to avoid balance. Alraune, Unathi and diona already have this).
- High Endurance (excluding Tesh and BESK to avoid buffs, and Unathi who already have this).
- Darksight and Darksight+ (excluding all those who already get to see in the dark)
- Brute resist minor only (exlcuding Tesh for the buffs and those that already have this level of resistance).
- Grit

### **Negatives:**
- Slow and Slow+ (excluding those that already move so slow)
- Weakling and weakling+ (excluding BESK and tesh who are already this weak)
- Low endurance and + (excluding besk for the first and tesh for both as they're already that weak)
- Brute weakness minor, normal and major (excluding those that are weak to specific levels)
- Neural Hypersensitivity
