### PR TITLE
prevent flags default exclusion

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -607,6 +607,8 @@ var/global/list/valid_bloodreagents = list("default","iron","copper","phoron","s
 						break varconflict
 
 					for(var/V in instance.var_changes)
+						if(V == "flags")
+							continue
 						if(V in instance_test.var_changes)
 							conflict = instance_test.name
 							break varconflict


### PR DESCRIPTION
Traits like hard feet touch the flags var, this would exclude all other traits touching this flag by default, so skip the check. To exclude flag traits against each other, use the `excludes = list(/datum/trait) ` var for the traits modifying the flag var

🆑 Upstream
fix: flag traits excluding each other by default
/🆑 