### PR TITLE
Entrepreneur Expansion Part 2

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -2676,6 +2676,12 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/outdoors/sidewalk/slab,
 /area/groundbase/level1/centsquare)
 "fQ" = (
@@ -3392,9 +3398,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/lobby)
 "hv" = (
-/obj/effect/landmark/start/entrepreneur,
-/turf/simulated/floor/tiled,
-/area/groundbase/civilian/apparel)
+/turf/simulated/wall,
+/area/groundbase/civilian/entrepreneur)
 "hw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6531,7 +6536,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/apparel)
 "og" = (
@@ -6668,6 +6672,14 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/workshop)
+"ow" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/item/device/tape,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "ox" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6736,6 +6748,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/office)
+"oE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "oF" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 6
@@ -6902,6 +6929,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/morgue)
+"oW" = (
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "oX" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -6959,6 +6991,12 @@
 "pc" = (
 /turf/simulated/floor/outdoors/grass/seasonal/dark/lowsnow,
 /area/groundbase/unexplored/outdoors)
+"pd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "pe" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -7307,6 +7345,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/warden)
+"pZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "qa" = (
 /turf/simulated/wall/r_wall,
 /area/groundbase/security/iaa1)
@@ -7419,6 +7463,22 @@
 "qp" = (
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/office)
+"qq" = (
+/obj/machinery/door/airlock{
+	id_tag = "session_room";
+	name = "Session Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "qr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -7550,6 +7610,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/civilian/bar)
+"qH" = (
+/obj/structure/bed/chair/office/light,
+/obj/machinery/alarm,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "qI" = (
 /obj/structure/bed/chair/sofa/bench/right{
 	dir = 8
@@ -7769,6 +7834,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/lobby)
+"ri" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/sidewalk/slab,
+/area/groundbase/level1/westspur)
 "rj" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/circuitboard/rdserver{
@@ -8192,6 +8272,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/equipment)
+"si" = (
+/obj/structure/closet/walllocker_double/misc_civ/south{
+	name = "vanity"
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/essential_oil,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/makeover,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/nailpolish_remover,
+/obj/item/weapon/nailpolish,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "sj" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -8898,6 +8995,22 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/side,
 /area/groundbase/level1/centsquare)
+"tQ" = (
+/obj/structure/closet/walllocker_double/misc_civ/north{
+	name = "streamer equipment"
+	},
+/obj/item/device/tvcamera/streamer,
+/obj/item/device/camera/selfie,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
+"tR" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "tS" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/gun/energy/laser{
@@ -9241,6 +9354,9 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/groundbase/civilian/bar)
+"uE" = (
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "uF" = (
 /obj/structure/table/bench/padded,
 /obj/machinery/light,
@@ -10014,6 +10130,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/or1)
+"wD" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "wE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -10040,6 +10164,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/equipment)
+"wH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "wI" = (
 /obj/item/weapon/storage/backpack/parachute{
 	pixel_x = 4;
@@ -10219,6 +10355,13 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/groundbase/civilian/gateway)
+"wW" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "wX" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10349,6 +10492,14 @@
 	},
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/groundbase/level1/southwestspur)
+"xl" = (
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/item/weapon/clipboard,
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "xm" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -10467,6 +10618,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/groundbase/command/ai/hall)
+"xv" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	nightshift_setting = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "xw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -10545,6 +10711,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/civilian/womensrestroom)
+"xG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "xH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -10841,6 +11022,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/groundbase/engineering/atmos)
+"yt" = (
+/obj/structure/flora/pottedplant/flower,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "yu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -11065,6 +11250,13 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/groundbase/security/iaa2)
+"yT" = (
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "yU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11212,6 +11404,9 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/groundbase/engineering/techstorage)
+"zm" = (
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "zn" = (
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/outdoors/sidewalk,
@@ -11312,6 +11507,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/command/tcomms/foyer)
+"zA" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "zB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -11402,6 +11602,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/iaa1)
+"zL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "zM" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -11422,6 +11634,17 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor,
 /area/maintenance/groundbase/trashpit)
+"zO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "zP" = (
 /turf/simulated/floor/tiled/white,
 /area/groundbase/civilian/mensrestroom)
@@ -11695,6 +11918,30 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/groundbase/trashpit)
+"Aw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor,
+/area/groundbase/civilian/entrepreneur)
+"Ax" = (
+/obj/machinery/door/airlock/glass{
+	name = "Shared Office Space"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/groundbase/civilian/entrepreneur)
 "Ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11846,6 +12093,13 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/groundbase/civilian/foodplace)
+"AR" = (
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "AS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -12751,6 +13005,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/gateway)
+"Da" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "session_room";
+	pixel_x = 27;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "Db" = (
 /turf/simulated/floor/outdoors/newdirt,
 /area/groundbase/level1/southeastspur)
@@ -12779,6 +13045,17 @@
 	outdoors = 0
 	},
 /area/maintenance/groundbase/level1/netunnel)
+"Df" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	nightshift_setting = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/alarm,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "Dg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13355,6 +13632,18 @@
 	},
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/bar)
+"Ew" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Ex" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/reset,
@@ -13599,6 +13888,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/lhallway)
+"Fd" = (
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "meeting_room";
+	pixel_x = 27;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "Fe" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -13724,6 +14022,19 @@
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/lobby)
+"Fs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Ft" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/effect/landmark/start/hos,
@@ -13863,6 +14174,12 @@
 	name = "impassable rock"
 	},
 /area/groundbase/level1/nw)
+"FM" = (
+/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/item/weapon/clipboard,
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13992,6 +14309,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/bcarpet,
 /area/groundbase/security/briefing)
+"Gd" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Ge" = (
 /obj/structure/bed/chair/sofa/bench/left{
 	dir = 8
@@ -14607,6 +14933,24 @@
 	name = "impassable rock"
 	},
 /area/groundbase/level1/southeastspur)
+"HA" = (
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "HB" = (
 /obj/structure/sign/double/barsign{
 	pixel_y = -32
@@ -14958,6 +15302,12 @@
 /obj/machinery/alarm,
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/atmos/monitoring)
+"Iq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Ir" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/gun/energy/ionrifle/pistol,
@@ -15156,6 +15506,22 @@
 	dir = 6
 	},
 /turf/simulated/floor/outdoors/sidewalk/slab,
+/area/groundbase/level1/centsquare)
+"IL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/outdoors/sidewalk,
 /area/groundbase/level1/centsquare)
 "IM" = (
 /obj/structure/sign/painting/public{
@@ -15538,6 +15904,21 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/groundbase/medical/resleeving)
+"JK" = (
+/obj/structure/closet{
+	name = "meeting room closet"
+	},
+/obj/item/weapon/entrepreneur/emf,
+/obj/item/weapon/entrepreneur/spirit_board,
+/obj/item/weapon/entrepreneur/crystal_ball,
+/obj/item/weapon/entrepreneur/horoscope,
+/obj/item/weapon/entrepreneur/magnifying_glass,
+/obj/item/device/camera,
+/obj/item/device/taperecorder,
+/obj/item/device/tape,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "JL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15625,6 +16006,21 @@
 /obj/item/weapon/shield/riot,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/armory)
+"JV" = (
+/obj/structure/closet/walllocker_double/misc_civ/south{
+	name = "dentistry tools"
+	},
+/obj/item/device/flashlight/pen,
+/obj/item/weapon/entrepreneur/dentist_mirror,
+/obj/item/weapon/entrepreneur/dentist_probe,
+/obj/item/weapon/entrepreneur/dentist_scaler,
+/obj/item/weapon/entrepreneur/dentist_sickle,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "JW" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -15809,6 +16205,26 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/equipment)
+"Kk" = (
+/obj/structure/closet/walllocker_double/misc_civ/west{
+	name = "Office Supplies"
+	},
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/accepted,
+/obj/item/weapon/stamp/denied,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "Kl" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/circuitboard/algae_farm{
@@ -15840,6 +16256,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/medical/autoresleeving)
+"Kp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/sidewalk/slab,
+/area/groundbase/level1/centsquare)
 "Kq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -15913,6 +16344,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/armory)
+"Kz" = (
+/obj/machinery/door/airlock{
+	id_tag = "meeting_room";
+	name = "Meeting Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "KA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -16116,6 +16563,22 @@
 	outdoors = 0
 	},
 /area/groundbase/level1/eastspur)
+"Lc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Ld" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/cable/yellow{
@@ -16372,6 +16835,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/atmos)
+"LE" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "LF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16775,6 +17246,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/ce)
+"MB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "MC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -17406,10 +17881,23 @@
 /obj/effect/landmark/start/intern,
 /turf/simulated/floor/outdoors/newdirt_nograss,
 /area/groundbase/level1/centsquare)
+"Od" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Oe" = (
 /obj/effect/landmark/start/hos,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/lobby)
+"Of" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "Og" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17699,6 +18187,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/groundbase/engineering/atmos)
+"OV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "OW" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -18259,6 +18754,18 @@
 "Qr" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
+"Qs" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Qt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18384,6 +18891,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/groundbase/civilian/arrivals)
+"QG" = (
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "QH" = (
 /obj/structure/table/reinforced,
 /obj/item/device/sleevemate,
@@ -18864,6 +19374,18 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/groundbase/substation/medcargo)
+"RN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "RO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -18871,6 +19393,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/eva)
+"RP" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "RQ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -18891,15 +19424,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/outdoors/sidewalk/slab,
 /area/groundbase/level1/centsquare)
 "RS" = (
@@ -19039,6 +19568,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/outdoors/sidewalk,
 /area/groundbase/level1/centsquare)
+"Sk" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "Sl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19291,6 +19825,15 @@
 	outdoors = 0
 	},
 /area/groundbase/security/halls)
+"SL" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/alarm{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "SM" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -19354,6 +19897,13 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/groundbase/command/ai/chamber)
+"SU" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "SV" = (
 /obj/effect/map_effect/portal/line/side_a,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
@@ -19426,6 +19976,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/medical/autoresleeving)
+"Td" = (
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur/meeting)
 "Te" = (
 /obj/machinery/shower{
 	dir = 8
@@ -19765,6 +20321,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/groundbase/cargo/mining)
+"TP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "TQ" = (
 /obj/machinery/computer/aifixer,
 /turf/simulated/floor/bluegrid,
@@ -19958,6 +20529,26 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/halls)
+"Un" = (
+/obj/structure/closet/walllocker_double/misc_civ/north{
+	name = "office equipment"
+	},
+/obj/item/weapon/storage/briefcase{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/weapon/storage/briefcase{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/weapon/storage/briefcase{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/device/measuring_tape,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "Up" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
@@ -20049,6 +20640,9 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/lhallway)
+"UB" = (
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "UC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -20161,11 +20755,34 @@
 "UQ" = (
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/morgue)
+"UR" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	nightshift_setting = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "US" = (
 /obj/structure/bed/chair/sofa/bench,
 /obj/effect/landmark/start/visitor,
 /turf/simulated/floor/outdoors/newdirt_nograss,
 /area/groundbase/level1/centsquare)
+"UT" = (
+/obj/structure/closet{
+	name = "session equipment"
+	},
+/obj/item/roller/massage,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/clothing/under/pants/yogapants,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "UU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -20273,6 +20890,18 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/groundbase/engineering/lobby)
+"Vj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "Vk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -20492,6 +21121,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/cargo/mining)
+"VJ" = (
+/obj/machinery/photocopier{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/sign/poster{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/groundbase/civilian/entrepreneur)
 "VK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -21302,6 +21941,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/groundbase/civilian/arrivals)
+"Xy" = (
+/turf/simulated/wall,
+/area/groundbase/civilian/entrepreneur/meeting)
 "Xz" = (
 /obj/structure/table/reinforced,
 /obj/random/tech_supply,
@@ -21396,6 +22038,12 @@
 /obj/random/coin/sometimes,
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/foodplace)
+"XM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/bottle/essential_oil,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "XN" = (
 /turf/simulated/wall/r_wall,
 /area/groundbase/command/ai/hall)
@@ -21595,6 +22243,16 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/slab,
 /area/groundbase/level1/northspur)
+"Yn" = (
+/obj/structure/bed/chair/office/dark,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "Yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21708,6 +22366,15 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/slab,
 /area/groundbase/level1/southwestspur)
+"YB" = (
+/obj/machinery/disposal/wall{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/groundbase/civilian/entrepreneur)
 "YC" = (
 /turf/simulated/floor/outdoors/newdirt,
 /area/groundbase/level1/centsquare)
@@ -22076,6 +22743,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/bluegrid,
 /area/groundbase/command/ai/robot)
+"Zv" = (
+/turf/simulated/wall,
+/area/groundbase/civilian/entrepreneur/session)
 "Zw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22235,6 +22905,10 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/alphadeck)
+"ZQ" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/groundbase/civilian/entrepreneur/session)
 "ZR" = (
 /turf/simulated/floor/outdoors/sidewalk/side,
 /area/groundbase/level1/northspur)
@@ -27625,9 +28299,9 @@ ce
 Bk
 Bk
 Bk
-Bk
-Bk
-Bk
+ce
+ce
+ce
 ce
 ce
 ce
@@ -27767,16 +28441,16 @@ Bk
 Bk
 Bk
 Bk
-Bk
 ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+Xy
+Xy
+Xy
+Xy
+Xy
+Zv
+Zv
+Zv
+Zv
 AZ
 AZ
 cB
@@ -27908,17 +28582,17 @@ Bk
 Bk
 Bk
 Bk
-Bk
-Bk
-Bk
 ce
 ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+Xy
+Of
+SU
+Td
+Xy
+UT
+yT
+JV
+Zv
 AZ
 AZ
 cB
@@ -28052,15 +28726,15 @@ ce
 ce
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+Xy
+zm
+ow
+LE
+Xy
+qH
+QG
+si
+Zv
 AZ
 AZ
 OL
@@ -28194,15 +28868,15 @@ ce
 ce
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+Xy
+Df
+oE
+pd
+Xy
+UR
+tR
+ZQ
+Zv
 AZ
 AZ
 AZ
@@ -28336,15 +29010,15 @@ ce
 ce
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+Xy
+JK
+RN
+Fd
+Xy
+XM
+zL
+Da
+Zv
 AZ
 AZ
 AZ
@@ -28476,17 +29150,17 @@ Bk
 Bk
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
-AZ
+hv
+hv
+Xy
+Xy
+Kz
+Xy
+Xy
+Zv
+qq
+Zv
+Zv
 AZ
 AZ
 cB
@@ -28618,16 +29292,16 @@ Bk
 Bk
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
+hv
+VJ
+Kk
+pZ
+wH
+xv
+HA
+zO
+Vj
+hv
 AZ
 AZ
 AZ
@@ -28760,16 +29434,16 @@ Bk
 ce
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
+hv
+wD
+UB
+UB
+Gd
+OV
+Fs
+RP
+UB
+hv
 AZ
 XP
 RF
@@ -28902,16 +29576,16 @@ ce
 ce
 ce
 ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-ce
-AZ
-AZ
+hv
+hv
+hv
+Yn
+xl
+uE
+Ew
+oW
+wW
+hv
 tN
 pm
 VW
@@ -29046,14 +29720,14 @@ AZ
 AZ
 AZ
 AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
+hv
+Un
+Od
+MB
+Lc
+Sk
+YB
+hv
 tN
 eT
 sy
@@ -29188,14 +29862,14 @@ AZ
 AZ
 AZ
 AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
+hv
+zA
+AR
+uE
+TP
+FM
+wW
+hv
 AZ
 rs
 JW
@@ -29330,14 +30004,14 @@ AZ
 Eb
 Eb
 AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-AZ
-cB
+hv
+tQ
+Qs
+Iq
+xG
+SL
+yt
+hv
 cB
 cB
 cB
@@ -29472,14 +30146,14 @@ Eb
 Nv
 Nv
 Eb
-Eb
-cB
-cB
-cB
-cB
-cB
-cB
-cB
+hv
+Aw
+hv
+hv
+Ax
+hv
+Aw
+hv
 cB
 cB
 cB
@@ -29618,7 +30292,7 @@ Nv
 Nv
 Nv
 QD
-QD
+ri
 QD
 QD
 QD
@@ -29760,7 +30434,7 @@ Nv
 Nv
 Nv
 Nv
-QD
+ri
 QD
 cB
 QD
@@ -29902,7 +30576,7 @@ Dt
 Dt
 Eb
 Eb
-Eb
+Kp
 Eb
 cB
 cB
@@ -30044,7 +30718,7 @@ lq
 Dt
 rD
 fP
-Uj
+IL
 Uj
 Uj
 Uj
@@ -33005,7 +33679,7 @@ vi
 Yx
 hr
 pi
-hv
+Pb
 vP
 ye
 CD
@@ -33431,7 +34105,7 @@ hr
 hr
 hr
 bL
-hv
+Pb
 rG
 BS
 zj
@@ -33715,7 +34389,7 @@ qE
 qE
 dk
 Vb
-hv
+Pb
 ll
 ye
 CD

--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -11373,6 +11373,12 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/groundbase/civilian/kitchen)
+"FZ" = (
+/turf/simulated/floor{
+	edge_blending_priority = -1;
+	outdoors = 1
+	},
+/area/groundbase/level2/westspur)
 "Ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -25506,7 +25512,7 @@ bY
 bY
 bY
 bY
-eN
+FZ
 eN
 eN
 eN
@@ -25641,14 +25647,14 @@ eN
 eN
 eN
 eN
-eN
-eN
-eN
-eN
-eN
-eN
-eN
-eN
+FZ
+FZ
+FZ
+FZ
+FZ
+FZ
+FZ
+FZ
 eN
 eN
 eN

--- a/maps/groundbase/groundbase_areas.dm
+++ b/maps/groundbase/groundbase_areas.dm
@@ -429,6 +429,17 @@
 	lightswitch = 1
 	forbid_events = TRUE
 
+/area/groundbase/civilian/entrepreneur
+	name = "\improper Shared Office"
+	icon_state = "entertainment"
+
+/area/groundbase/civilian/entrepreneur/session
+	name = "\improper Shared Office Session Room"
+
+/area/groundbase/civilian/entrepreneur/meeting
+	name = "\improper Shared Office Meeting Room"
+
+
 /area/groundbase/exploration
 	name = "Exploration"
 	holomap_color = HOLOMAP_AREACOLOR_SCIENCE

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -247,13 +247,21 @@
 /turf/simulated/floor/tiled/white,
 /area/stellardelight/deck1/shower)
 "ay" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/standard,
-/obj/item/device/multitool/station_buffered{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "az" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -372,16 +380,8 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/shuttlebay)
 "aJ" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/command{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/aft)
 "aK" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -2324,26 +2324,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenobiology)
 "em" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/standard,
-/obj/item/device/gps{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/device/gps{
-	pixel_x = 6;
-	pixel_y = -4
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/machinery/alarm/angled{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "en" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -2410,29 +2397,17 @@
 /turf/space,
 /area/space)
 "eu" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/structure/closet/walllocker_double/misc_civ/east{
+	name = "supernatural supplies"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
+/obj/item/weapon/entrepreneur/spirit_board,
+/obj/item/weapon/entrepreneur/emf,
+/obj/item/weapon/entrepreneur/crystal_ball,
+/obj/item/weapon/entrepreneur/horoscope,
+/obj/item/weapon/deck/tarot,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "ev" = (
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 8
@@ -2560,25 +2535,12 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "eJ" = (
-/obj/structure/table/rack/shelf,
-/obj/item/device/radio{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/device/radio{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/device/radio{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/device/radio{
-	pixel_x = 4;
-	pixel_y = 5
-	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/storage/briefcase,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "eK" = (
 /obj/structure/closet/walllocker_double/generic_civ/west,
 /turf/simulated/floor/carpet/purcarpet,
@@ -4201,14 +4163,19 @@
 	color = "#42038a";
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
@@ -5066,7 +5033,20 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "jR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "jT" = (
@@ -5076,6 +5056,19 @@
 /obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
+"jU" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/tank/oxygen,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/expedition_medical,
+/obj/item/clothing/head/helmet/space/void/expedition_medical,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "jV" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -5590,6 +5583,23 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/stellardelight/deck1/dorms/dorm6)
+"lj" = (
+/obj/structure/table/rack,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
+"lk" = (
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/entrepreneur)
 "ll" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5888,29 +5898,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
 "lO" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
+/turf/simulated/wall/bay/r_wall{
+	desc = "It has a steel stripe! A huge chunk of metal used to seperate rooms.";
+	stripe_color = "#3d5e80"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/angled_bay/standard/glass{
-	dir = 4;
-	door_color = "#333333";
-	name = "Auxiliary EVA Equipment Room";
-	req_one_access = list(18,19,43);
-	stripe_color = "#5a19a8"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "lP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -6567,18 +6559,19 @@
 /turf/simulated/floor/airless,
 /area/stellardelight/deck1/exterior)
 "nd" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/tank/oxygen,
-/obj/item/device/suit_cooling_unit,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/expedition_medical,
-/obj/item/clothing/head/helmet/space/void/expedition_medical,
-/obj/machinery/door/window/brigdoor/eastright{
-	req_access = list(5)
+/obj/structure/table/woodentable,
+/obj/structure/closet/walllocker_double/misc_civ/west{
+	name = "personality supplies"
 	},
+/obj/item/device/camera/selfie,
+/obj/item/device/tvcamera/streamer,
+/obj/item/weapon/makeover,
+/obj/item/weapon/nailpolish,
+/obj/item/weapon/nailpolish_remover,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "ne" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Exploration Substation Bypass"
@@ -7116,12 +7109,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "oq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_x = -32
-	},
+/obj/machinery/door/airlock/angled_bay/standard/glass,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/area/stellardelight/deck1/entrepreneur)
 "or" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -7417,6 +7408,23 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"oV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "oW" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -7463,14 +7471,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "pd" = (
-/obj/structure/closet,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "pe" = (
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/stellardelight/deck1/miningshuttle)
@@ -8024,8 +8029,12 @@
 /area/stellardelight/deck1/explobriefing)
 "ql" = (
 /obj/structure/table/woodentable,
-/obj/machinery/microwave{
-	pixel_y = 7
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/network/command{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
@@ -8589,6 +8598,15 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/stellardelight/substation/civilian)
 "rB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/bay/reinforced,
+/obj/structure/low_wall/bay/reinforced/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "4-8"
@@ -8596,21 +8614,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/angled_bay/hatch{
-	dir = 4;
-	door_color = "#ffffff";
-	name = "maintenance access";
-	req_one_access = null;
-	stripe_color = "#5a19a8"
-	},
 /turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/entrepreneur)
 "rC" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -9230,8 +9235,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "sP" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Security Substation Bypass"
@@ -9268,16 +9274,15 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/mining)
 "sT" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-2"
+/obj/machinery/camera/network/command{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm/angled{
-	dir = 8
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/area/stellardelight/deck1/entrepreneur)
 "sU" = (
 /obj/structure/closet/coffin,
 /obj/structure/cable/green{
@@ -9370,10 +9375,22 @@
 /turf/simulated/wall/bay/r_wall/steel,
 /area/maintenance/stellardelight/deck1/portcent)
 "te" = (
-/obj/machinery/firealarm/angled,
-/obj/machinery/chemical_analyzer,
+/obj/structure/closet/walllocker_double/misc_civ/north{
+	name = "health and wellbeing supplies"
+	},
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/reagent_containers/glass/bottle/essential_oil,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/roller/massage,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "tf" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /turf/simulated/floor/tiled/dark,
@@ -9701,18 +9718,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "tW" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "tX" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -9765,21 +9776,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "uc" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/tank/oxygen,
-/obj/item/device/suit_cooling_unit,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/exploration,
-/obj/item/clothing/head/helmet/space/void/exploration,
-/obj/machinery/door/window/brigdoor/eastright{
-	req_access = list(43)
+/obj/structure/table/woodentable,
+/obj/machinery/microwave{
+	pixel_y = 7
 	},
-/obj/item/device/bluespaceradio/sd_prelinked,
-/obj/item/device/cataloguer/compact,
-/obj/item/device/cataloguer/compact,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "ue" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -10217,9 +10219,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "ve" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "vf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/yellow{
@@ -10360,19 +10365,12 @@
 /turf/simulated/floor/tiled/eris,
 /area/stellardelight/deck1/researchequip)
 "vw" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "vx" = (
 /turf/simulated/wall/bay/r_wall/red,
 /area/security/armoury)
@@ -10566,6 +10564,11 @@
 	},
 /turf/simulated/floor/tiled/eris/white/gray_platform,
 /area/gateway)
+"vS" = (
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/passive/tindalos/twigs,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "vT" = (
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
@@ -10702,24 +10705,24 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "wk" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc/angled{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
-"wm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploration)
+"wm" = (
+/obj/machinery/power/apc/angled{
+	dir = 4;
+	name = "night shift APC";
+	nightshift_setting = 2
+	},
+/obj/structure/cable/green{
+	color = "#42038a"
+	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
 "wn" = (
@@ -10743,13 +10746,11 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/mining)
 "wq" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/entrepreneur)
 "ws" = (
 /obj/structure/cable/pink{
 	icon_state = "4-8"
@@ -10894,6 +10895,27 @@
 "wG" = (
 /turf/simulated/wall/bay/r_wall/steel,
 /area/maintenance/stellardelight/deck1/starboardfore)
+"wH" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "wI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/seed_storage/xenobotany,
@@ -11152,12 +11174,17 @@
 /turf/simulated/floor/tiled/eris,
 /area/rnd/xenobiology/xenoflora)
 "xk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/structure/closet/walllocker_double/misc_civ/south{
+	name = "dentistry tools"
 	},
-/obj/structure/dispenser/oxygen,
+/obj/item/weapon/entrepreneur/dentist_mirror,
+/obj/item/weapon/entrepreneur/dentist_probe,
+/obj/item/weapon/entrepreneur/dentist_scaler,
+/obj/item/weapon/entrepreneur/dentist_sickle,
+/obj/item/device/flashlight/pen,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "xl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/steel,
@@ -11584,9 +11611,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
 "yj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "yk" = (
@@ -12276,9 +12301,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "zK" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "zL" = (
 /obj/machinery/firealarm/angled,
 /obj/effect/landmark{
@@ -12435,44 +12466,19 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "Aa" = (
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/table/woodentable,
+/obj/structure/closet/walllocker_double/misc_civ/west{
+	name = "investigation tools"
 	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/machinery/alarm/angled{
-	dir = 4
-	},
+/obj/item/weapon/entrepreneur/magnifying_glass,
+/obj/item/sticky_pad/random,
+/obj/item/sticky_pad/random,
+/obj/item/device/camera,
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/taperecorder,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "Ab" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/steel_grid,
@@ -12520,9 +12526,6 @@
 	color = "#42038a";
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "1-8"
@@ -12629,9 +12632,19 @@
 /turf/simulated/floor/tiled/eris,
 /area/rnd/xenobiology/xenoflora)
 "At" = (
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/tank/oxygen,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/exploration,
+/obj/item/clothing/head/helmet/space/void/exploration,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list(43)
 	},
+/obj/item/device/bluespaceradio/sd_prelinked,
+/obj/item/device/cataloguer/compact,
+/obj/item/device/cataloguer/compact,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploequipment)
 "Au" = (
@@ -12699,18 +12712,13 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardcent)
 "AD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/wall{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/computer/shuttle_control/explore/stellardelight/exploration{
-	dir = 8
+/obj/machinery/photocopier,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "AF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12975,6 +12983,23 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/security_port)
+"Bg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/entrepreneur)
+"Bh" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm/angled{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "Bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -13057,6 +13082,10 @@
 /obj/item/device/mmi,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/assembly/robotics)
+"Bq" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Br" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/firealarm/angled{
@@ -13170,23 +13199,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "BC" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "BD" = (
@@ -13496,13 +13521,17 @@
 /turf/simulated/floor/wood,
 /area/library)
 "Cl" = (
-/obj/structure/table/rack/shelf,
-/obj/random/contraband,
-/obj/random/maintenance/research,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "Cm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/up{
@@ -13763,11 +13792,13 @@
 /turf/simulated/wall/bay/r_wall/purple,
 /area/rnd/xenobiology)
 "CT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/mineral/equipment_vendor/survey,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploequipment)
 "CU" = (
@@ -14194,9 +14225,51 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
+"DR" = (
+/turf/simulated/wall/bay/r_wall/purple,
+/area/stellardelight/deck1/entrepreneur)
 "DS" = (
 /turf/simulated/wall/bay/red,
 /area/prison/cell_block)
+"DT" = (
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/machinery/alarm/angled{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "DV" = (
 /obj/machinery/suit_cycler/pilot,
 /obj/machinery/light,
@@ -14302,6 +14375,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
+"Ej" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/bay/reinforced,
+/obj/structure/low_wall/bay/reinforced/purple,
+/turf/simulated/floor,
+/area/stellardelight/deck1/entrepreneur)
 "Ek" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/warning{
@@ -14532,6 +14611,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"EL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "EM" = (
 /obj/structure/table/rack,
 /obj/item/device/defib_kit/compact/loaded,
@@ -15270,9 +15356,18 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/portcent)
 "Gy" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/tank/oxygen,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/expedition_medical,
+/obj/item/clothing/head/helmet/space/void/expedition_medical,
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "GA" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -15281,18 +15376,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "GB" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "GC" = (
 /obj/structure/stairs/spawner/north,
 /obj/structure/railing/grey{
@@ -15389,6 +15475,23 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/portcent)
+"GO" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "GP" = (
 /obj/structure/cable/pink{
 	icon_state = "2-4"
@@ -15553,11 +15656,23 @@
 /turf/simulated/floor,
 /area/stellardelight/deck1/explobriefing)
 "Hf" = (
-/obj/structure/table/rack/shelf,
-/obj/random/maintenance/research,
-/obj/random/maintenance,
+/obj/machinery/door/airlock/angled_bay/standard/glass{
+	dir = 4;
+	door_color = "#333333";
+	name = "Auxiliary EVA Equipment Room";
+	req_one_access = list(18,19,43);
+	stripe_color = "#5a19a8"
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/exploequipment)
 "Hg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15795,16 +15910,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "HG" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/command{
-	dir = 4
-	},
+/obj/machinery/chemical_analyzer,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/area/stellardelight/deck1/exploequipment)
 "HH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/window/bay/reinforced,
@@ -15830,6 +15942,19 @@
 /obj/machinery/vending/nifsoft_shop,
 /turf/simulated/floor/tiled/techfloor,
 /area/stellardelight/deck1/starboard)
+"HM" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/shuttle_control/explore/stellardelight/exploration{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "HN" = (
 /obj/structure/cable/pink{
 	icon_state = "4-8"
@@ -15872,6 +15997,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"HQ" = (
+/obj/structure/flora/pottedplant/orientaltree,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "HR" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -15881,26 +16011,8 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/exam_room)
 "HS" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
@@ -16144,16 +16256,6 @@
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
 	},
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -16956,21 +17058,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
 "Ke" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/tank/oxygen,
-/obj/item/device/suit_cooling_unit,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/exploration,
-/obj/item/clothing/head/helmet/space/void/exploration,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(43)
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/item/device/mapping_unit,
-/obj/item/device/cataloguer,
-/obj/item/device/cataloguer,
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "Kf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm/angled,
@@ -17489,16 +17584,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
 "Lp" = (
-/obj/structure/closet,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/research,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/tank/oxygen,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/exploration,
+/obj/item/clothing/head/helmet/space/void/exploration,
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access = list(43)
+	},
+/obj/item/device/mapping_unit,
+/obj/item/device/cataloguer,
+/obj/item/device/cataloguer,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "Lq" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -17590,23 +17690,15 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/shuttlebay)
 "Ly" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/power/apc/angled{
-	dir = 4;
-	name = "night shift APC";
-	nightshift_setting = 2
-	},
-/obj/structure/cable/green{
-	color = "#42038a"
-	},
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "LA" = (
 /obj/structure/cable/pink{
 	icon_state = "1-8"
@@ -17743,11 +17835,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
 "LO" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/standard,
+/obj/item/device/multitool/station_buffered{
+	pixel_y = 2
 	},
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "LP" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -18430,22 +18524,9 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/stellardelight/deck1/dorms/dorm2)
 "Np" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "Nq" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -18560,18 +18641,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "Nx" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/tank/oxygen,
-/obj/item/device/suit_cooling_unit,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/expedition_medical,
-/obj/item/clothing/head/helmet/space/void/expedition_medical,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(5)
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "Nz" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8
@@ -18608,6 +18683,10 @@
 /obj/structure/cable/pink,
 /turf/simulated/floor/airless,
 /area/stellardelight/deck1/exterior)
+"NE" = (
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "NF" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -18754,15 +18833,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "NY" = (
-/obj/machinery/door/airlock/angled_bay/hatch{
-	dir = 4;
-	door_color = "#e6ab22";
-	name = "Exploration Substation";
-	req_one_access = list(10);
-	stripe_color = "#e6ab22"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/angled{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	color = "#42038a"
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "NZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -19141,6 +19226,29 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
+"OP" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "OQ" = (
 /turf/simulated/wall/bay/brown,
 /area/security/detectives_office)
@@ -20765,15 +20873,39 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/substation/security)
 "Sn" = (
-/obj/structure/dogbed,
-/mob/living/simple_mob/animal/passive/tindalos/twigs,
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	color = "#42038a";
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/standard/glass{
+	dir = 4;
+	door_color = "#333333";
+	name = "Auxiliary EVA Equipment Room";
+	req_one_access = list(18,19,43);
+	stripe_color = "#5a19a8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/stellardelight/deck1/exploequipment)
 "Sq" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -21282,11 +21414,20 @@
 "Tr" = (
 /obj/structure/cable/green{
 	color = "#42038a";
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "Ts" = (
 /obj/machinery/door/blast/angled{
 	id = "xenobiodiv2";
@@ -21356,10 +21497,26 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "TD" = (
-/obj/structure/flora/pottedplant/orientaltree,
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/standard,
+/obj/item/device/gps{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/device/gps{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/area/stellardelight/deck1/exploequipment)
 "TE" = (
 /obj/effect/floor_decal/milspec/color/orange/half,
 /turf/simulated/floor/tiled/dark,
@@ -21478,13 +21635,12 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardcent)
 "TR" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/machinery/firealarm/angled{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "TS" = (
 /obj/random/maintenance/security,
 /obj/random/maintenance/security,
@@ -21733,12 +21889,16 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "Up" = (
-/obj/structure/table/rack/shelf,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/maintenance,
-/turf/simulated/floor,
-/area/maintenance/stellardelight/deck1/exploration)
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc/angled{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "Uq" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -21989,14 +22149,10 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
 "UR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "US" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/glasses/hud/security,
@@ -22192,8 +22348,10 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/woodentable,
+/obj/item/weapon/book/manual/security_space_law,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "Vp" = (
 /obj/structure/bookcase{
 	name = "bookcase (Reference)"
@@ -22915,6 +23073,26 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
+"WI" = (
+/obj/structure/table/rack/shelf,
+/obj/item/device/radio{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/device/radio{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "WJ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -23338,29 +23516,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "XD" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/door/airlock/angled_bay/hatch{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
 	dir = 4;
-	door_color = "#ffffff";
-	name = "maintenance access";
-	req_one_access = null;
-	stripe_color = "#5a19a8"
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/stellardelight/deck1/explobriefing)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/exploequipment)
 "XE" = (
 /obj/structure/table/reinforced,
 /obj/item/roller,
@@ -24362,18 +24525,35 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/portfore)
+"ZL" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "ZM" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/eris,
 /area/rnd/xenobiology/xenoflora)
 "ZN" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/mineral/equipment_vendor/survey,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploequipment)
+/area/stellardelight/deck1/entrepreneur)
 "ZO" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -30704,15 +30884,15 @@ um
 um
 um
 In
-wm
+iU
 Ag
+iU
+iU
 wm
-Ly
-wm
-wm
-wm
-Np
 vT
+vT
+vT
+lj
 ra
 RF
 vF
@@ -30845,17 +31025,17 @@ Ql
 KD
 KP
 um
-if
+Ec
 RS
-RS
-NY
-RS
-RS
-RS
-RS
-rB
-RS
-ra
+pC
+pC
+pC
+pC
+pC
+pC
+pC
+pC
+pC
 RF
 vF
 bD
@@ -30987,17 +31167,17 @@ jm
 ng
 cC
 um
-if
-RS
-Cl
-vT
-mP
+Ec
+Bq
+pC
+At
 Lp
-RS
-wq
-if
+pC
+DT
+pC
+jU
 Gy
-ra
+pC
 bD
 hE
 JE
@@ -31130,16 +31310,16 @@ um
 Jp
 um
 if
-RS
+zK
 Hf
-vT
-vT
-Jz
-RS
+Cl
+Ly
+NY
+oV
 TR
-if
+ZQ
 ve
-ra
+pC
 RF
 vF
 uq
@@ -31272,16 +31452,16 @@ Mn
 PL
 DQ
 XM
-RS
-Up
-vT
-vT
+NE
+pC
+CT
+tY
 pd
-RS
-LO
-if
-pd
-ra
+GO
+tY
+tY
+WI
+pC
 bD
 vF
 uq
@@ -31414,16 +31594,16 @@ Ua
 Ua
 Ua
 Ec
-RS
-tm
-WM
-WM
-WM
-WM
-WM
+vT
+pC
+HG
+LO
+TD
+OP
+HM
 XD
-WM
-nk
+EL
+pC
 uq
 vF
 uq
@@ -31557,15 +31737,15 @@ Pu
 Ua
 Ec
 Jz
-tm
-HG
-oq
-wk
+pC
+tu
+tu
+pC
 Sn
-sT
-HS
-TD
-nk
+pC
+tu
+tu
+pC
 bD
 vF
 uq
@@ -31701,12 +31881,12 @@ gt
 Oz
 tm
 ql
-Rz
-Rz
-Rz
-Rz
-sN
-Rz
+Np
+Up
+wH
+Bh
+ZL
+HQ
 ny
 bD
 vF
@@ -31833,16 +32013,16 @@ Vh
 wF
 Xq
 yS
-pC
-pC
-pC
-pC
-pC
-pC
-pC
-pC
-pC
-Rz
+lO
+lO
+lO
+lO
+lO
+lO
+lO
+lO
+DR
+HS
 Uo
 kg
 kg
@@ -31975,22 +32155,22 @@ Vh
 Pd
 Xq
 ma
-pC
+lO
 uc
 Ke
-pC
+sT
 Aa
-pC
+Nx
 nd
 Nx
-pC
+DR
 XH
 TC
 zZ
 yP
 zZ
 OB
-Rz
+vS
 nk
 bD
 hE
@@ -32117,15 +32297,15 @@ Vh
 fO
 vf
 fO
-pC
+lO
 Vo
 Tr
-aJ
+Bg
 tW
-ZQ
-ZQ
+Bg
+wq
 sO
-pC
+DR
 CK
 TC
 oZ
@@ -32259,15 +32439,15 @@ Aj
 vj
 vU
 uu
-pC
+lO
 ZN
-tY
-tY
+ay
+lk
 GB
-tY
-tY
-zK
-pC
+lk
+lk
+lk
+oq
 Rz
 NA
 An
@@ -32401,15 +32581,15 @@ Aj
 gn
 OZ
 Bl
-pC
+lO
 te
-tY
-At
+ay
+lk
 vw
-tY
-tY
+lk
+lk
 eJ
-pC
+DR
 PE
 jZ
 Fx
@@ -32542,16 +32722,16 @@ mK
 Aj
 rk
 OZ
-Bl
-pC
-CT
+aJ
+oq
+lk
 ay
 em
 eu
 AD
 UR
 xk
-pC
+DR
 vy
 mW
 WM
@@ -32685,15 +32865,15 @@ Aj
 Dm
 Gh
 Bl
-pC
-tu
-tu
-pC
-lO
-pC
-tu
-tu
-pC
+DR
+Ej
+rB
+DR
+DR
+DR
+Ej
+Ej
+DR
 zL
 SE
 Dt
@@ -32830,7 +33010,7 @@ cI
 sC
 yj
 jR
-Dt
+wk
 BC
 Pr
 YB

--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -3785,13 +3785,6 @@
 /obj/structure/low_wall/bay/reinforced/steel,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/portfore)
-"hP" = (
-/obj/structure/bed/chair/bay/comfy/brown{
-	dir = 1
-	},
-/obj/effect/landmark/start/entrepreneur,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/recreation_area)
 "hQ" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/surgery,
@@ -3879,7 +3872,6 @@
 	pixel_y = -32
 	},
 /obj/structure/table/bench/steel,
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/eris/dark/cargo,
 /area/crew_quarters/recreation_area)
 "ib" = (
@@ -3898,7 +3890,6 @@
 /area/crew_quarters/bar)
 "id" = (
 /obj/structure/table/bench/steel,
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled/eris/dark/cargo,
 /area/crew_quarters/recreation_area)
 "ie" = (
@@ -33100,7 +33091,7 @@ Dl
 UX
 UX
 UX
-hP
+vS
 mt
 mt
 mt
@@ -33668,7 +33659,7 @@ Dl
 UX
 UX
 UX
-hP
+vS
 mt
 mt
 mt

--- a/maps/stellar_delight/stellar_delight_areas.dm
+++ b/maps/stellar_delight/stellar_delight_areas.dm
@@ -307,3 +307,7 @@
 	name = "Deck Two Exterior"
 /area/stellardelight/deck3/exterior
 	name = "Deck Three Exterior"
+
+/area/stellardelight/deck1/entrepreneur
+	name = "\improper Shared Office"
+	icon_state = "entertainment"

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -16586,12 +16586,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
-"aCc" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/grey/border,
-/obj/effect/landmark/start/entrepreneur,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/visitor_laundry)
 "aCd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17479,7 +17473,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aDL" = (
@@ -17558,7 +17551,6 @@
 /obj/structure/table/bench/standard,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/grey/border,
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aDU" = (
@@ -17982,7 +17974,6 @@
 /obj/effect/floor_decal/corner/grey/border,
 /obj/machinery/light/small,
 /obj/structure/table/bench/standard,
-/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aEO" = (
@@ -53733,7 +53724,7 @@ aSX
 aTG
 aSo
 arm
-aCc
+bcT
 aVf
 aUs
 aUu

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -32953,7 +32953,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bgu" = (
-/obj/structure/bed/chair,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -33278,7 +33277,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "bhg" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)
 "bhi" = (
@@ -33321,14 +33322,10 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
 "bhl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/southhall)
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/entrepreneur/dumbbell,
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "bhm" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/monotile,
@@ -33374,7 +33371,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/southhall)
+/area/tether/surfacebase/entrepreneur)
 "bhs" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -36368,6 +36365,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cafeteria)
+"bvM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "meeting_room";
+	name = "Meeting Room"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "bxa" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -36386,6 +36400,17 @@
 "bzK" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/processing)
+"bCj" = (
+/obj/structure/closet/walllocker_double/misc_civ/south{
+	name = "dentist supplies"
+	},
+/obj/item/weapon/entrepreneur/dentist_mirror,
+/obj/item/weapon/entrepreneur/dentist_probe,
+/obj/item/weapon/entrepreneur/dentist_scaler,
+/obj/item/weapon/entrepreneur/dentist_sickle,
+/obj/item/device/flashlight/pen,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "bCV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -36432,6 +36457,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"bJC" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "bJF" = (
 /obj/structure/toilet{
 	dir = 8
@@ -36580,6 +36614,14 @@
 /obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
+"ccu" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "ccN" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "tourbus";
@@ -36679,6 +36721,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
+"crz" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/manual/engineering_construction,
+/obj/item/weapon/book/manual/detective,
+/obj/item/weapon/book/manual/standard_operating_procedure,
+/obj/item/weapon/book/codex/lore/vir,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
+"csD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "cta" = (
 /obj/machinery/shipsensors/fancy_shuttle,
 /turf/simulated/wall/fancy_shuttle/nondense{
@@ -36786,6 +36844,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
+"cIL" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/entrepreneur)
 "cJL" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -36798,6 +36859,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"cLR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "cMO" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -37007,6 +37086,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"dkV" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/entrepreneur/meeting)
 "dmH" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -37150,6 +37232,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"dBg" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "dDl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -37252,6 +37343,30 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"dNe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
+"dQa" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -10
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "dQY" = (
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/wood,
@@ -37309,6 +37424,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"dYE" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "eaj" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
@@ -37427,6 +37553,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"eye" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "eyH" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/engineering,
@@ -37583,6 +37716,51 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"eSh" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/structure/closet{
+	name = "session equipment"
+	},
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/entrepreneur/dumbbell,
+/obj/item/weapon/storage/box/dentist,
+/obj/item/roller/massage,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
+"eSQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/entrepreneur/session)
+"eUZ" = (
+/obj/structure/closet{
+	name = "entrepreneur equipment"
+	},
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/taperecorder,
+/obj/item/weapon/entrepreneur/magnifying_glass,
+/obj/item/weapon/entrepreneur/emf,
+/obj/item/weapon/entrepreneur/spirit_board,
+/obj/item/weapon/entrepreneur/crystal_ball,
+/obj/item/device/tvcamera/streamer,
+/obj/item/weapon/deck/tarot,
+/obj/item/weapon/entrepreneur/horoscope,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "eWw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -37595,6 +37773,9 @@
 /area/crew_quarters/pool)
 "eWS" = (
 /obj/machinery/vending/sovietsoda,
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cafeteria)
 "eYm" = (
@@ -37773,6 +37954,10 @@
 /area/shuttle/tether{
 	base_turf = /turf/simulated/floor/reinforced
 	})
+"fzK" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "fCR" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -38052,6 +38237,13 @@
 	fancy_shuttle_tag = "tourbus"
 	},
 /area/shuttle/tourbus/general)
+"glm" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "gnE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -38090,6 +38282,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"guy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "gvp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -38103,6 +38307,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
+"gxf" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/cafeteria)
 "gym" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38283,6 +38491,30 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/public_garden_three)
+"gPA" = (
+/obj/structure/closet/walllocker_double/misc_civ/north{
+	name = "office supplies"
+	},
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/folder,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/accepted,
+/obj/item/weapon/stamp/denied,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/clipboard,
+/obj/item/sticky_pad,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "gRG" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
@@ -38335,6 +38567,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"gVY" = (
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "gWX" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -38374,6 +38611,14 @@
 /obj/item/weapon/storage/box/donut,
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
+"gZq" = (
+/obj/structure/bed/chair/office/light,
+/obj/structure/sign/painting/public{
+	pixel_x = -30
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "gZR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -38413,6 +38658,17 @@
 /obj/machinery/computer/operating,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery1)
+"hfv" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "hfN" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -38494,6 +38750,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"hsp" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "hth" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -38657,6 +38919,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/west)
+"hTB" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "hVc" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -38768,6 +39035,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/barrestroom)
+"ioo" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "ioG" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
@@ -38973,6 +39244,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"jei" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/entrepreneur)
 "jkW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -39028,6 +39306,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"jpq" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "jpB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
@@ -39125,8 +39415,20 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/southhall)
+"jCU" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "jDF" = (
 /obj/machinery/light{
 	dir = 8
@@ -39257,6 +39559,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"jLb" = (
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "jPW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -39278,6 +39583,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
+"jRn" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "jRO" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/item/weapon/stool/padded{
@@ -39888,6 +40203,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
+"lnV" = (
+/obj/structure/table/hardwoodtable,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "lpg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39960,6 +40282,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"lto" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "ltu" = (
 /obj/structure/railing{
 	dir = 8
@@ -40055,6 +40390,9 @@
 	},
 /turf/simulated/floor/carpet,
 /area/tether/surfacebase/security/hos)
+"lHq" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/entrepreneur/session)
 "lHr" = (
 /obj/structure/table/woodentable,
 /obj/random/paicard,
@@ -40121,6 +40459,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"lVA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	id_tag = "session_room";
+	name = "Session Room"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "lVB" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "tourbus";
@@ -40337,6 +40692,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
+"mEW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/closet/walllocker_double/misc_civ/south{
+	name = "vanity supplies"
+	},
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/entrepreneur/crystal,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/reagent_containers/glass/bottle/essential_oil,
+/obj/item/weapon/makeover,
+/obj/item/weapon/nailpolish,
+/obj/item/weapon/nailpolish_remover,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "mFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40396,6 +40779,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"mTG" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "mUv" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
@@ -40497,6 +40887,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
+"ngT" = (
+/obj/structure/table/standard,
+/obj/item/weapon/bedsheet/pillow/exercise,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "ngV" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "tourbus";
@@ -40595,6 +40990,15 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/public_garden_three)
+"npz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "nrN" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -40647,6 +41051,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"ntK" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "nue" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -40723,6 +41131,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/west)
+"nDH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "nKy" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -40793,6 +41211,18 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
+"nVQ" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "nXZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -40916,6 +41346,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/nwest)
+"oAA" = (
+/obj/machinery/photocopier,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "oBJ" = (
 /obj/structure/sign/painting/public{
 	pixel_x = 30
@@ -40987,6 +41427,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"oJe" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "oJw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -41135,6 +41581,9 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/southhall)
 "oWP" = (
@@ -41179,6 +41628,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
+"pcI" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "peS" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -41210,6 +41662,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"phg" = (
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "phS" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -41278,6 +41736,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
+"prf" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "prD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41299,6 +41768,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa)
+"pse" = (
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "psh" = (
 /obj/machinery/door/airlock{
 	id_tag = "bathroomlock18";
@@ -41334,6 +41806,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/nwest)
+"pwR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "pAh" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
@@ -41370,6 +41854,20 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"pFe" = (
+/obj/structure/table/hardwoodtable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "pHl" = (
 /obj/structure/table/steel,
 /obj/item/weapon/folder/red,
@@ -41573,6 +42071,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"qfc" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "qfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41626,6 +42130,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
+"qoE" = (
+/obj/machinery/light,
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "qoL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -41750,12 +42266,24 @@
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
+"qDx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "qDF" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/southhall)
+"qEs" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "qFL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -41842,6 +42370,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
+"qSG" = (
+/obj/machinery/newscaster{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "qTm" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/effect/floor_decal/industrial/warning{
@@ -41902,6 +42436,12 @@
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"raz" = (
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "rbR" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "tourbus";
@@ -42498,6 +43038,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
+"sVx" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "sVC" = (
 /obj/machinery/door/firedoor/glass/hidden/shuttle,
 /obj/machinery/door/blast/shuttle/open{
@@ -42677,6 +43229,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"tDm" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "meeting_room";
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
 "tJk" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -42763,6 +43328,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/west)
+"tVW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "tWn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
@@ -42794,12 +43367,39 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa/officecommon)
+"tYV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "uaN" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"udb" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "uee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -42918,6 +43518,23 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
+"usc" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "office space"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/entrepreneur)
 "ute" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -42963,6 +43580,40 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/west)
+"uxx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/misc_civ/east{
+	name = "entrepreneur supplies"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/item/weapon/storage/briefcase{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/weapon/storage/briefcase{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/device/measuring_tape,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/wrapping_paper,
+/obj/item/weapon/wrapping_paper,
+/obj/item/weapon/wrapping_paper,
+/obj/item/device/camera/selfie,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "uxT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 8
@@ -42987,6 +43638,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
+"uyI" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "uzl" = (
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "lifeboat1";
@@ -43034,6 +43698,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall/west)
+"uKb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/entrepreneur/meeting)
 "uLh" = (
 /obj/machinery/door/firedoor/glass/hidden/shuttle,
 /obj/machinery/door/blast/shuttle/open{
@@ -43059,6 +43732,15 @@
 "uNt" = (
 /turf/simulated/open,
 /area/tether/surfacebase/security/upperhall)
+"uNx" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "uOL" = (
 /obj/structure/table/standard,
 /obj/item/clothing/gloves/sterile/nitrile,
@@ -43108,6 +43790,16 @@
 /obj/effect/floor_decal/steeldecal/monofloor,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"vdl" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/structure/sign/painting/public{
+	pixel_x = -30
+	},
+/obj/effect/landmark/start/entrepreneur,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "viF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -43359,6 +44051,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"vQt" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "vTf" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -43731,6 +44431,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"wHC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur/meeting)
+"wIs" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "session_room";
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "wIw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -43835,6 +44560,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"xac" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entrepreneur)
 "xan" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -44085,6 +44821,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/tourbus/cockpit)
+"xtz" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/tether/surfacebase/entrepreneur)
 "xud" = (
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/storage/backpack/parachute{
@@ -44347,6 +45093,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"xUX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/entrepreneur/session)
 "xZw" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -52279,7 +53033,7 @@ kuQ
 rkn
 akx
 gLg
-fxh
+bhl
 jBB
 amv
 arU
@@ -57313,7 +58067,7 @@ aPL
 bhj
 cYm
 oWt
-beV
+sVx
 bhj
 beV
 pPe
@@ -57455,7 +58209,7 @@ aPM
 ely
 bhp
 jCE
-hId
+nVQ
 bhq
 hId
 cHf
@@ -57593,14 +58347,14 @@ aKj
 aKj
 aKj
 aPs
-bhl
-bhl
-aPs
-aPs
-aPs
-aPs
-aPs
-aPs
+cIL
+cIL
+cIL
+jei
+usc
+cIL
+cIL
+cIL
 qDF
 bhy
 bhs
@@ -57735,14 +58489,14 @@ aKj
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+cIL
+gZq
+dQa
+uNx
+uyI
+ioo
+vdl
+cIL
 beU
 bhx
 beU
@@ -57877,13 +58631,13 @@ aKj
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+cIL
+jLb
+hTB
+uNx
+uyI
+hTB
+jLb
 bhr
 beU
 bhx
@@ -58019,13 +58773,13 @@ aKj
 aNi
 aNi
 aKj
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+cIL
+xac
+hsp
+jpq
+uyI
+qEs
+jLb
 bhr
 beU
 bhx
@@ -58161,14 +58915,14 @@ aKj
 aUu
 beW
 aKj
-aKj
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+cIL
+tVW
+ioo
+uNx
+uyI
+ioo
+qoE
+cIL
 bht
 bhx
 beU
@@ -58303,21 +59057,21 @@ aKj
 bde
 bfh
 bgu
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+cIL
+vQt
+oJe
+xtz
+hfv
+ccu
+phg
+cIL
 bhv
 bhz
 bhC
 biH
 dyV
 bja
-han
+gxf
 ieh
 bju
 biF
@@ -58445,14 +59199,14 @@ hCz
 beN
 bfh
 bhg
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+cIL
+gPA
+jLb
+jCU
+udb
+jLb
+mTG
+cIL
 ieF
 bhx
 beU
@@ -58586,14 +59340,14 @@ aOP
 aKj
 beQ
 bfh
-bhg
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
+gVY
+cIL
+qSG
+jLb
+lnV
+pFe
+jLb
+raz
 bhr
 beU
 bhx
@@ -58729,13 +59483,13 @@ aKj
 beT
 bfi
 aKj
-aKj
-aac
-aac
-aac
-aac
-aac
-aac
+cIL
+guy
+qDx
+cLR
+uxx
+lto
+oAA
 bhr
 beU
 bhx
@@ -58870,15 +59624,15 @@ aPt
 aKj
 xku
 xku
-aKj
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+lHq
+lHq
+lVA
+lHq
+dkV
+dkV
+bvM
+dkV
+dkV
 beU
 bhx
 iOw
@@ -59012,15 +59766,15 @@ aKj
 aKj
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+lHq
+ngT
+tYV
+wIs
+dkV
+crz
+wHC
+tDm
+dkV
 qDF
 bhy
 bhs
@@ -59154,15 +59908,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+lHq
+prf
+pwR
+eye
+dkV
+dYE
+dNe
+glm
+dkV
 bht
 bhx
 beU
@@ -59296,15 +60050,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-bhr
+lHq
+xUX
+npz
+nDH
+dkV
+dBg
+jRn
+csD
+dkV
 beU
 bhx
 beU
@@ -59438,15 +60192,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-bhr
+lHq
+ntK
+pcI
+bCj
+dkV
+fzK
+qfc
+pse
+dkV
 beU
 bhx
 beU
@@ -59580,15 +60334,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+lHq
+eSh
+bJC
+mEW
+dkV
+eUZ
+pse
+pse
+dkV
 beU
 bhx
 beU
@@ -59722,15 +60476,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aPs
+lHq
+lHq
+eSQ
+lHq
+dkV
+dkV
+uKb
+dkV
+dkV
 qQF
 bhA
 bhC

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -493,6 +493,16 @@
 /area/tether/surfacebase/entertainment/stage
 	name = "\improper Entertainment Stage"
 
+/area/tether/surfacebase/entrepreneur
+	name = "\improper Shared Office"
+	icon_state = "entertainment"
+
+/area/tether/surfacebase/entrepreneur/session
+	name = "\improper Shared Office Session Room"
+
+/area/tether/surfacebase/entrepreneur/meeting
+	name = "\improper Shared Office Meeting Room"
+
 /area/tether/surfacebase/funny/clownoffice
 	name = "\improper Clown's Office"
 	icon_state = "library"


### PR DESCRIPTION
Added a new shared office space and entrepreneur equipment to these spaces on the Tether, Stellar Delight and Rascal's Pass. None of this is access locked, intentionally letting anyone play with it.

RP:
![image](https://github.com/VOREStation/VOREStation/assets/98125273/f223d7f5-1d90-4152-a3a2-bb2c9363e82c)

Tether:
![image](https://github.com/VOREStation/VOREStation/assets/98125273/606f3d3f-6dba-49cd-bfac-5bc053151ab3)

Stellar Delight (Also moves the away team equipment room down next to the briefing room):
![image](https://github.com/VOREStation/VOREStation/assets/98125273/57319fd3-b3ad-470e-a03c-2fb0d034f915)
