### PR TITLE
Reduces vore death timer on autoresleever

### DIFF
--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -8,7 +8,7 @@
 	var/equip_body = FALSE				//If true, this will spawn the person with equipment
 	var/default_job = USELESS_JOB		//The job that will be assigned if equip_body is true and the ghost doesn't have a job
 	var/ghost_spawns = FALSE			//If true, allows ghosts who haven't been spawned yet to spawn
-	var/vore_respawn = 15 MINUTES		//The time to wait if you died from vore
+	var/vore_respawn = 5 MINUTES		//The time to wait if you died from vore
 	var/respawn = 30 MINUTES			//The time to wait if you didn't die from vore
 	var/spawn_slots = -1				//How many people can be spawned from this? If -1 it's unlimited
 	var/spawntype						//The kind of mob that will be spawned, if set.


### PR DESCRIPTION
Changed the timer on the autoresleever from 15 minutes to 5 minutes, a similar amount of time to being able to make a transcore announcement.

The idea behind this reduction is that the autoresleever is already considerably more popular than the resleever, and it does not make sense to inconvenience people for both engaging in their kinks and not wanting to get medical involved in their death. The normal resleever remains the best option for non-vore deaths, and for people who just want to offer that kind of interaction to medical.