### PR TITLE
Changes wall damage from being (usually) 25 brute to 12 and doesnt add a stun to it

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -301,9 +301,10 @@
 
 // Called when turf is hit by a thrown object
 /turf/hitby(atom/movable/AM as mob|obj, var/speed)
-	if(src.density)
-		spawn(2)
-			step(AM, turn(AM.last_move, 180))
+	if(density)
+		if(!has_gravity(AM)) //Checked a different codebase for reference. Turns out it's only supposed to happen in no-gravity
+			spawn(2)
+				step(AM, turn(AM.last_move, 180)) //This makes it float away after hitting a wall in 0G
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, speed)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -371,7 +371,7 @@
 //This is called when the mob is thrown into a dense turf
 /mob/living/proc/turf_collision(var/turf/T, var/speed)
 	src.take_organ_damage(12)	// used to be 5 * speed. That's a default of 25 and I dont see anything ever changing the "speed" value.
-	src.Weaken(3)				// That is absurdly high so im just setting it to a flat 12 with a bit of stun ontop.
+	//src.Weaken(3)				// That is absurdly high so im just setting it to a flat 12 with a bit of stun ontop. //Stun is too dangerous
 	playsound(src, get_sfx("punch"), 50) //ouch sound
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -370,7 +370,9 @@
 
 //This is called when the mob is thrown into a dense turf
 /mob/living/proc/turf_collision(var/turf/T, var/speed)
-	src.take_organ_damage(speed*5)
+	src.take_organ_damage(12)	// used to be 5 * speed. That's a default of 25 and I dont see anything ever changing the "speed" value.
+	src.Weaken(3)				// That is absurdly high so im just setting it to a flat 12 with a bit of stun ontop.
+	playsound(src, get_sfx("punch"), 50) //ouch sound
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)
 	var/turf/T = get_step(get_turf(src),direction)


### PR DESCRIPTION
25 damage for a wallthrow is pretty extremely high. That's higher than some low calibre bullets! It also turns bones into powder because your bones are made of glass. This makes the damage lower but it has a stun when you hit wall because oof ouchy. I dont think "speed" is ever passed in so the default value of 5 was always used. Consistency is also nice