### PR TITLE
Uniform Insignia

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -180,3 +180,41 @@ Talon pin
 	"security-technician replikant chestplate" = /obj/item/clothing/accessory/replika/star
 	)
 	gear_tweaks += new/datum/gear_tweak/path(replika_vests)
+
+/datum/gear/accessory/insignia
+	display_name = "Insignia Selection"
+	path = /obj/item/clothing/accessory/solgov/department
+
+/datum/gear/accessory/insignia/New()
+	..()
+	var/insignia = list(
+	"Command - Crew" = /obj/item/clothing/accessory/solgov/department/command,
+	"Command - Crew Short" = /obj/item/clothing/accessory/solgov/department/command/service,
+	"Command - Bands" = /obj/item/clothing/accessory/solgov/department/command/fleet,
+	"Command - Echelons" = /obj/item/clothing/accessory/solgov/department/command/army,
+	"Security - Crew" = /obj/item/clothing/accessory/solgov/department/security,
+	"Security - Crew Short" = /obj/item/clothing/accessory/solgov/department/security/service,
+	"Security - Bands" = /obj/item/clothing/accessory/solgov/department/security/fleet,
+	"Security - Echelons" = /obj/item/clothing/accessory/solgov/department/security/army,
+	"Medical - Crew" = /obj/item/clothing/accessory/solgov/department/medical,
+	"Medical - Crew Short" = /obj/item/clothing/accessory/solgov/department/medical/service,
+	"Medical - Bands" = /obj/item/clothing/accessory/solgov/department/medical/fleet,
+	"Medical - Echelons" = /obj/item/clothing/accessory/solgov/department/medical/army,
+	"Science - Crew" = /obj/item/clothing/accessory/solgov/department/research,
+	"Science - Crew Short" = /obj/item/clothing/accessory/solgov/department/research/service,
+	"Science - Bands" = /obj/item/clothing/accessory/solgov/department/research/fleet,
+	"Science - Echelons" = /obj/item/clothing/accessory/solgov/department/research/army,
+	"Engineering - Crew" = /obj/item/clothing/accessory/solgov/department/engineering,
+	"Engineering - Crew Short" = /obj/item/clothing/accessory/solgov/department/engineering/service,
+	"Engineering - Bands" = /obj/item/clothing/accessory/solgov/department/engineering/fleet,
+	"Engineering - Echelons" = /obj/item/clothing/accessory/solgov/department/engineering/army,
+	"Supply - Crew" = /obj/item/clothing/accessory/solgov/department/supply,
+	"Supply - Crew Short" = /obj/item/clothing/accessory/solgov/department/supply/service,
+	"Supply - Bands" = /obj/item/clothing/accessory/solgov/department/supply/fleet,
+	"Supply - Echelons" = /obj/item/clothing/accessory/solgov/department/supply/army,
+	"Service - Crew" = /obj/item/clothing/accessory/solgov/department/service,
+	"Service - Crew Short" = /obj/item/clothing/accessory/solgov/department/service/service,
+	"Service - Bands" = /obj/item/clothing/accessory/solgov/department/service/fleet,
+	"Service - Echelons" = /obj/item/clothing/accessory/solgov/department/service/army
+	)
+	gear_tweaks += new/datum/gear_tweak/path(insignia)

--- a/code/modules/clothing/under/accessories/torch.dm
+++ b/code/modules/clothing/under/accessories/torch.dm
@@ -292,7 +292,7 @@ department tags
 **************/
 /obj/item/clothing/accessory/solgov/department
 	name = "department insignia"
-	desc = "Insignia denoting assignment to a department. These appear blank."
+	desc = "Insignia denoting assignment to a department."
 	icon_state = "dept_exped"
 	on_rolled = list("down" = "none", "rolled" = "dept_exped_sleeves")
 	slot = ACCESSORY_SLOT_DEPT
@@ -300,7 +300,7 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/command
 	name = "command insignia"
-	desc = "Insignia denoting assignment to the command department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the command department."
 	color = "#e5ea4f"
 
 /obj/item/clothing/accessory/solgov/department/command/service
@@ -312,17 +312,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/command/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the command department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/command/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the command department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/engineering
 	name = "engineering insignia"
-	desc = "Insignia denoting assignment to the engineering department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the engineering department."
 	color = "#ff7f00"
 
 /obj/item/clothing/accessory/solgov/department/engineering/service
@@ -333,17 +331,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/engineering/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the engineering department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/engineering/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the engineering department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/security
 	name = "security insignia"
-	desc = "Insignia denoting assignment to the security department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the security department."
 	color = "#bf0000"
 
 /obj/item/clothing/accessory/solgov/department/security/service
@@ -355,17 +351,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/security/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the security department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/security/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the security department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/medical
 	name = "medical insignia"
-	desc = "Insignia denoting assignment to the medical department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the medical department."
 	color = "#4c9ce4"
 
 /obj/item/clothing/accessory/solgov/department/medical/service
@@ -378,17 +372,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/medical/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the medical department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/medical/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the medical department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/supply
 	name = "supply insignia"
-	desc = "Insignia denoting assignment to the supply department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the supply department."
 	color = "#bb9042"
 
 /obj/item/clothing/accessory/solgov/department/supply/service
@@ -400,17 +392,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/supply/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the supply department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/supply/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the supply department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/service
 	name = "service insignia"
-	desc = "Insignia denoting assignment to the service department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the service department."
 	color = "#6eaa2c"
 
 /obj/item/clothing/accessory/solgov/department/service/service
@@ -422,17 +412,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/service/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the service department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/service/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the service department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/exploration
 	name = "exploration insignia"
-	desc = "Insignia denoting assignment to the exploration department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the exploration department."
 	color = "#68099e"
 
 /obj/item/clothing/accessory/solgov/department/exploration/service
@@ -443,17 +431,15 @@ department tags
 
 /obj/item/clothing/accessory/solgov/department/exploration/fleet
 	icon_state = "dept_fleet"
-	desc = "Insignia denoting assignment to the exploration department. These fit Fleet uniforms."
 	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/exploration/army
 	icon_state = "dept_army"
-	desc = "Insignia denoting assignment to the exploration department. These fit Marine uniforms."
 	on_rolled = list("down" = "none")
 
 /obj/item/clothing/accessory/solgov/department/research
 	name = "research insignia"
-	desc = "Insignia denoting assignment to the research department. These fit Expeditionary Corps uniforms."
+	desc = "Insignia denoting assignment to the research department."
 	color = "#68099e"
 
 /obj/item/clothing/accessory/solgov/department/research/service
@@ -462,6 +448,14 @@ department tags
 /obj/item/clothing/accessory/solgov/department/research/jumper
 	icon_state = "dept_exped_jumper"
 	color = "#916f8d"
+
+/obj/item/clothing/accessory/solgov/department/research/fleet
+	icon_state = "dept_fleet"
+	on_rolled = list("rolled" = "dept_fleet_sleeves", "down" = "none")
+
+/obj/item/clothing/accessory/solgov/department/research/army
+	icon_state = "dept_army"
+	on_rolled = list("down" = "none")
 
 /*********
 ranks - ec


### PR DESCRIPTION
Repurposes some old SolGov uniform insignias to lightly genericize them and make them available in loadouts. Now you can easily indicate whichever department you're part of with whatever casual dress or other outfit you happen to be wearing!