### PR TITLE
Disable ingame changelog notification

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -246,11 +246,14 @@
 		void = new()
 	screen += void
 
+	//disabled because we don't use the ingame changelog system any more
+	/*
 	if((prefs.lastchangelog != changelog_hash) && isnewplayer(src.mob)) //bolds the changelog button on the interface so we know there are updates.
 		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
 		winset(src, "rpane.changelog", "background-color=#eaeaea;font-style=bold")
 		if(config.aggressive_changelog)
 			src.changes()
+	*/
 
 	if(config.paranoia_logging)
 		var/alert = FALSE //VOREStation Edit start.


### PR DESCRIPTION
Cleaning up a loose end. Now that we no longer use the ingame changelog and the changelog button just goes to the wiki, this tidies up (well, comments out) some code that no longer has any function.

tl;dr: no more `You have unread updates in the changelog.` pings when you connect.