### PR TITLE
Fix for Digest Pain not loading preference

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -298,6 +298,7 @@
 	throw_vore = P.throw_vore
 	stumble_vore = P.stumble_vore
 	food_vore = P.food_vore
+	digest_pain = P.digest_pain
 	eating_privacy_global = P.eating_privacy_global
 
 	nutrition_message_visible = P.nutrition_message_visible


### PR DESCRIPTION
Fixed Digestion Pain preference not loading from saved preferences, causing it to reset every shift.