### PR TITLE
Belly Mode Addon: Spare Prosthetics 

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -21,6 +21,7 @@
 #define DM_FLAG_AFFECTWORN		0x10
 #define DM_FLAG_JAMSENSORS		0x20
 #define DM_FLAG_FORCEPSAY		0x40
+#define DM_FLAG_SPARELIMB		0x80
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -68,7 +68,7 @@
 	//Actual full digest modes
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_SELECT,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_EGG)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY)
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Spare Prosthetics" = DM_FLAG_SPARELIMB)
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST)
 	//drain modes

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -248,7 +248,11 @@
 			items_preserved |= I
 		if(IM_DIGEST_FOOD)
 			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ))
-				did_an_item = digest_item(I)
+				var/obj/item/organ/R = I
+				if(istype(R) && R.robotic >= ORGAN_ROBOT)
+					items_preserved |= I
+				else
+					did_an_item = digest_item(I)
 			else
 				items_preserved |= I
 		if(IM_DIGEST)
@@ -289,6 +293,13 @@
 	var/personal_nutrition_modifier = M.get_digestion_nutrition_modifier()
 	var/pred_digestion_efficiency = owner.get_digestion_efficiency_modifier()
 
+	if(ishuman(M) && (mode_flags & DM_FLAG_SPARELIMB) && M.digest_leave_remains)
+		var/mob/living/carbon/human/H = M
+		var/list/detachable_limbs = H.get_modular_limbs(return_first_found = FALSE, validate_proc = /obj/item/organ/external/proc/can_remove_modular_limb)
+		for(var/obj/item/organ/external/E in detachable_limbs)
+			if(H.species.name != SPECIES_PROTEAN)
+				E.removed(H)
+				E.dropInto(src)
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
 	digestion_death(M)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -298,6 +298,7 @@
 	throw_vore = P.throw_vore
 	stumble_vore = P.stumble_vore
 	food_vore = P.food_vore
+	digest_pain = P.digest_pain
 	eating_privacy_global = P.eating_privacy_global
 
 	nutrition_message_visible = P.nutrition_message_visible


### PR DESCRIPTION
Added a new Belly Mode Addon called Spare Prosthetics. With this active, when prey (that has leave remains turned on) is digested, they will drop any prosthetic arms and legs into the belly.

Changed Belly Item Mode: Digest (Food) to not digest robotic body parts such as prosthetic limbs. These can still be digested using the Item Mode: Digest.