### PR TITLE
seperate LOOC and OOC mute

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -3,9 +3,10 @@
 // Therefore there needs to be a gap between the flags for the automute flags.
 #define MUTE_IC        0x1
 #define MUTE_OOC       0x2
-#define MUTE_PRAY      0x4
-#define MUTE_ADMINHELP 0x8
-#define MUTE_DEADCHAT  0x10
+#define MUTE_LOOC      0x4
+#define MUTE_PRAY      0x8
+#define MUTE_ADMINHELP 0x10
+#define MUTE_DEADCHAT  0x20
 #define MUTE_ALL       0xFFFF
 
 // Number of identical messages required to get the spam-prevention auto-mute thing to trigger warnings and automutes.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -84,6 +84,7 @@ var/global/floorIsLava = 0
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |
 			<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_OOC]'><font color='[(muted & MUTE_OOC)?"red":"blue"]'>OOC</font></a> |
+			<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>LOOC</font></a> |
 			<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_PRAY]'><font color='[(muted & MUTE_PRAY)?"red":"blue"]'>PRAY</font></a> |
 			<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"blue"]'>ADMINHELP</font></a> |
 			<A href='?src=\ref[src];[HrefToken()];mute=\ref[M];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"blue"]'>DEADCHAT</font></a>\]

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -195,6 +195,7 @@
 	switch(mute_type)
 		if(MUTE_IC)			mute_string = "IC (say and emote)"
 		if(MUTE_OOC)		mute_string = "OOC"
+		if(MUTE_LOOC)		mute_string = "LOOC"
 		if(MUTE_PRAY)		mute_string = "pray"
 		if(MUTE_ADMINHELP)	mute_string = "adminhelp, admin PM and ASAY"
 		if(MUTE_DEADCHAT)	mute_string = "deadchat and DSAY"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -112,7 +112,7 @@
 		if(!config.dooc_allowed && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return
-		if(prefs.muted & MUTE_OOC)
+		if(prefs.muted & MUTE_LOOC)
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
 		if(findtext(msg, "byond://") && !config.allow_byond_links)
@@ -134,7 +134,7 @@
 	log_looc(msg,src)
 
 	if(msg)
-		handle_spam_prevention(MUTE_OOC)
+		handle_spam_prevention(MUTE_LOOC)
 
 	var/mob/source = mob.get_looc_source()
 	var/turf/T = get_turf(source)


### PR DESCRIPTION
Give it a quick test please, just done that on phone real quick.

🆑 Upstream
qol: separates LOOC and OOC muting to allow admins some more control about it
/🆑 