### PR TITLE
borg typing indicator vanishing and pda hotkey drag for borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -952,6 +952,8 @@
 		return
 
 	cut_overlays()
+	if(typing)
+		add_overlay(typing_indicator, TRUE)
 
 	icon			= sprite_datum.sprite_icon
 	icon_state		= sprite_datum.sprite_icon_state

--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -85,10 +85,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		. += "The time [stationtime2text()] is displayed in the corner of the screen."
 
 /obj/item/device/pda/CtrlClick()
-	if(issilicon(usr))
-		return
-
-	if(can_use(usr))
+	if(can_use(usr) && !issilicon(usr))
 		remove_pen()
 		return
 	..()


### PR DESCRIPTION
🆑 Upstream
fix: borg typing indicator vanishing after a few seconds
fix: borgs unable to pull pdas on ctrl click
/🆑 