### PR TITLE
Fixed Typing Indicators getting stuck on borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -952,8 +952,6 @@
 		return
 
 	cut_overlays()
-	if(typing)
-		add_overlay(typing_indicator, TRUE)
 
 	icon			= sprite_datum.sprite_icon
 	icon_state		= sprite_datum.sprite_icon_state


### PR DESCRIPTION
Fixed Typing Indicators getting stuck on borgs. The original fix was not necessary for this codebase and the typing indicators don't seem to work the same way here, so no problems are being reintroduced.