### PR TITLE
Event character role

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -44,6 +44,7 @@
 #define BE_CORGI		0x80000
 #define BE_CURSEDSWORD	0x100000
 #define BE_SURVIVOR		0x200000
+#define BE_EVENT		0x400000
 //VOREStation Add End
 
 var/list/be_special_flags = list(
@@ -114,6 +115,7 @@ var/list/be_special_flags = list(
 #define MODE_THUG "thug"
 #define MODE_STOWAWAY "stowaway"
 #define MODE_SURVIVOR "Shipwreck Survivor"
+#define MODE_EVENT "Event Character"
 
 #define DEFAULT_TELECRYSTAL_AMOUNT 120
 

--- a/code/game/antagonist/station/event.dm
+++ b/code/game/antagonist/station/event.dm
@@ -1,0 +1,15 @@
+var/datum/antagonist/event/event
+
+// Inherits most of its vars from the base datum.
+/datum/antagonist/event
+	id = MODE_EVENT
+	role_type = BE_EVENT
+	role_text = "Event Character"
+	role_text_plural = "Event Characters"
+	can_hear_aooc = TRUE		// If FALSE, the antag can neither speak nor hear AOOC. If TRUE, they can at least hear it.
+	can_speak_aooc = TRUE		// If TRUE, the antag can freely spean in AOOC.
+
+	welcome_text = "You are an event character."
+	antag_text = "You are have been selected as an event character, this gives you \
+		access to the AOOC chat channel to organise with other event characters. <b>Please remember all \
+		rules aside from those with explicit exceptions apply to event characters.</b>"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -591,6 +591,7 @@
 #include "code\game\antagonist\outsider\wizard.dm"
 #include "code\game\antagonist\station\changeling.dm"
 #include "code\game\antagonist\station\cultist.dm"
+#include "code\game\antagonist\station\event.dm"
 #include "code\game\antagonist\station\highlander.dm"
 #include "code\game\antagonist\station\infiltrator.dm"
 #include "code\game\antagonist\station\loyalist.dm"


### PR DESCRIPTION
A simple "antag" role for event characters generally. Simply gives event characters the ability to use AOOC without having a persistent antag icon next to their sprite, which event players have found annoying in the past.