### PR TITLE
tg chat loading improvement

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -210,21 +210,10 @@
 	if(prefs)
 		prefs.selecting_slots = FALSE
 
-	// Initialize tgui panel
-	tgui_panel.initialize()
-
 	connection_time = world.time
 	connection_realtime = world.realtime
 	connection_timeofday = world.timeofday
 
-	if(custom_event_msg && custom_event_msg != "")
-		to_chat(src, "<h1 class='alert'>Custom Event</h1>")
-		to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
-		to_chat(src, "<span class='alert'>[custom_event_msg]</span>")
-		to_chat(src, "<br>")
-
-	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
-		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
 	if(holder)
 		add_admin_verbs()
@@ -241,6 +230,23 @@
 	log_client_to_db()
 
 	send_resources()
+
+	// Initialize tgui panel
+	spawn(5)
+		tgui_panel.initialize(force=TRUE)
+
+		if(custom_event_msg && custom_event_msg != "")
+			to_chat(src, "<h1 class='alert'>Custom Event</h1>")
+			to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
+			to_chat(src, "<span class='alert'>[custom_event_msg]</span>")
+			to_chat(src, "<br>")
+
+		if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
+			to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
+
+
+
+
 
 	if(!void)
 		void = new()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -210,10 +210,21 @@
 	if(prefs)
 		prefs.selecting_slots = FALSE
 
+	// Initialize tgui panel
+	tgui_panel.initialize()
+
 	connection_time = world.time
 	connection_realtime = world.realtime
 	connection_timeofday = world.timeofday
 
+	if(custom_event_msg && custom_event_msg != "")
+		to_chat(src, "<h1 class='alert'>Custom Event</h1>")
+		to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
+		to_chat(src, "<span class='alert'>[custom_event_msg]</span>")
+		to_chat(src, "<br>")
+
+	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
+		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
 	if(holder)
 		add_admin_verbs()
@@ -230,19 +241,6 @@
 	log_client_to_db()
 
 	send_resources()
-
-	// Initialize tgui panel
-	spawn(5)
-		tgui_panel.initialize()
-
-		if(custom_event_msg && custom_event_msg != "")
-			to_chat(src, "<h1 class='alert'>Custom Event</h1>")
-			to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
-			to_chat(src, "<span class='alert'>[custom_event_msg]</span>")
-			to_chat(src, "<br>")
-
-		if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
-			to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
 	if(!void)
 		void = new()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -244,10 +244,6 @@
 		if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 			to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
-
-
-
-
 	if(!void)
 		void = new()
 	screen += void

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -233,7 +233,7 @@
 
 	// Initialize tgui panel
 	spawn(5)
-		tgui_panel.initialize(force=TRUE)
+		tgui_panel.initialize()
 
 		if(custom_event_msg && custom_event_msg != "")
 			to_chat(src, "<h1 class='alert'>Custom Event</h1>")

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -48,6 +48,7 @@
 		assets = list(
 			get_asset_datum(/datum/asset/simple/tgui_panel),
 		))
+	window.reinitialize() // Workaround for an early init fail...
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/fontawesome))
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/tgfont))
 	window.send_asset(get_asset_datum(/datum/asset/spritesheet/chat))

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -48,7 +48,6 @@
 		assets = list(
 			get_asset_datum(/datum/asset/simple/tgui_panel),
 		))
-	window.reinitialize() // Workaround as the window is currently not loading properly on first init...
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/fontawesome))
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/tgfont))
 	window.send_asset(get_asset_datum(/datum/asset/spritesheet/chat))

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -48,6 +48,7 @@
 		assets = list(
 			get_asset_datum(/datum/asset/simple/tgui_panel),
 		))
+	window.reinitialize() // Workaround as the window is currently not loading properly on first init...
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/fontawesome))
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/tgfont))
 	window.send_asset(get_asset_datum(/datum/asset/spritesheet/chat))


### PR DESCRIPTION
Most reliable is to just keep the workaround and re-init it once...

🆑 Upstream
fix: improves chat loading reliability
/🆑 