### PR TITLE
Persistent papers should not replace the chat window

### DIFF
--- a/code/modules/persistence/effects/paper.dm
+++ b/code/modules/persistence/effects/paper.dm
@@ -18,7 +18,7 @@
 	paper.info = token["message"]
 	paper.name = token["title"]
 	if(!paper.name)
-		paper.name = "Unknown"
+		paper.name = "No Title"
 	paper.last_modified_ckey = token["author"]
 	paper.age = token["age"]+1
 	if(requires_noticeboard)

--- a/code/modules/persistence/effects/paper.dm
+++ b/code/modules/persistence/effects/paper.dm
@@ -17,6 +17,8 @@
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
 	paper.info = token["message"]
 	paper.name = token["title"]
+	if(!paper.name)
+		paper.name = "Unknown"
 	paper.last_modified_ckey = token["author"]
 	paper.age = token["age"]+1
 	if(requires_noticeboard)


### PR DESCRIPTION
 the windows opened on paper examination are relying on the paper name. IF NULL is given, the chat window is replaced.

fixes #15956

🆑 Upstream
fix: persistent papers no longe replace the chat on examine
/🆑 