### PR TITLE
>200% size exploit

### DIFF
--- a/code/datums/components/resize_guard.dm
+++ b/code/datums/components/resize_guard.dm
@@ -15,5 +15,5 @@
 	var/area/A = get_area(parent)
 	if(A?.limit_mob_size)
 		var/mob/living/L = parent
-		L.resize(L.size_multiplier)
+		L.resize(L.size_multiplier, ignore_prefs = TRUE)
 		qdel(src)


### PR DESCRIPTION
🆑 Upstream
fix: fixes an exploit that allowed to circumvent the size limit outside of dorms / large size boundary areas
/🆑 