### PR TITLE
small nif fix

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -293,7 +293,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			notify("Adjoining optic [human.isSynthetic() ? "interface" : "nerve"], please be patient.",TRUE)
 		else
 			notify("You are not an authorized user for this device. Please contact [owner].",TRUE)
-			unimplant()
+			unimplant(human)
 			stat = NIF_TEMPFAIL
 			return FALSE
 


### PR DESCRIPTION
It seems like the references of the NIF were never properly cleared if the owner didn't match. We should make sure it will get nulled again on the one who got it implanted.

It will now be the same as if the implanting fails. The nif remains inside, but is not referenced any more. This will allow removing it safely and / or installing new working nifs without leading to a softlock situation of a stuck reference.

🆑 Upstream
fix: an issue leading to non working ghost nifs when trying to exploit by installing other's nifs
/🆑 