### PR TITLE
Exact Temp & Pressure on Armour Examine

### DIFF
--- a/code/modules/examine/descriptions/armor.dm
+++ b/code/modules/examine/descriptions/armor.dm
@@ -43,7 +43,6 @@
 		else
 			return "It's difficult to tell how much it'll influence your speed."
 
-
 /obj/item/clothing/get_description_info()
 	var/armor_stats = description_info + "\
 	<br>"
@@ -70,28 +69,18 @@
 	if(flags & AIRTIGHT)
 		armor_stats += "It is airtight. \n"
 
-	if(min_pressure_protection == 0 && max_pressure_protection >= WARNING_HIGH_PRESSURE)	//0 to 325
-		armor_stats += "Wearing this will protect you from the vacuum of space and from high pressures. \n"
-	else if(min_pressure_protection <= WARNING_LOW_PRESSURE && max_pressure_protection >= WARNING_HIGH_PRESSURE) //50 to 325
-		armor_stats += "Wearing this will protect you from both low and high pressures, but not the vacuum of space. \n"
-	else if(min_pressure_protection == 0)
-		armor_stats += "Wearing this will protect you from the vacuum of space. \n"
-	else if(min_pressure_protection <= WARNING_LOW_PRESSURE) //50 or below
-		armor_stats += "Wearing this will protect you from low pressures, but not the vacuum of space. \n"
-	else if(max_pressure_protection >= WARNING_HIGH_PRESSURE) //325 or higher
-		armor_stats += "Wearing this will protect you from high pressures. \n"
+	if(min_pressure_protection != null)
+		armor_stats += "It is rated for pressures as low as [min_pressure_protection] kPa. \n"
+	if(max_pressure_protection)
+		armor_stats += "It is rated for pressures as high as [max_pressure_protection] kPa. \n"
 
 	if(flags & THICKMATERIAL)	//stops syringes
 		armor_stats += "The material is exceptionally thick. \n"
 
-	if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //30000 or higher and as low as 2
-		armor_stats += "It provides exceptional protection from extremely high and low temperatures alike. \n"
-	else if(max_heat_protection_temperature >= SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE) //5000 or above, but less than 30000
-		armor_stats += "It provides very good protection against hazardous temperatures at both extremes, but may not be sufficient for very high-intensity situations. \n"
-	else if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)	//30000 or above
-		armor_stats += "It provides exceptional protection from extremely high temperatures. \n"
-	else if(min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE)	//2 or less
-		armor_stats += "It provides exceptional protection against very low temperatures. \n"
+	if(min_cold_protection_temperature)
+		armor_stats += "It is rated for temperatures as low as [min_cold_protection_temperature] Kelvin. \n"
+	if(max_heat_protection_temperature)
+		armor_stats += "It is rated for temperatures as high as [max_heat_protection_temperature] Kelvin. \n"
 
 	var/list/covers = list()
 	var/list/slots = list()


### PR DESCRIPTION
Spurred by some conversation/questions in mentor-help the other day, I decided to just fully expose the pressure and temperature values for spacesuits since in any sane universe the values they're rated for would surely be printed somewhere on/in the suit itself.

Also means no more ugly `if/else if/else if/...` case switching nonsense.

:cl:
tweak: Armour now shows exact pressure (kPa) and temperature (Kelvin) protection values when examined (if it has any)
/:cl: