### PR TITLE
Make Patches Useful(?)

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -40,7 +40,7 @@
 			to_chat(H, "<span class='notice'>\The [src] is placed on your [affecting].</span>")
 			M.drop_from_inventory(src) //icon update
 			if(reagents.total_volume)
-				reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)
+				reagents.trans_to_mob(M, reagents.total_volume, CHEM_BLOOD) //CHEM_TOUCH
 			qdel(src)
 			return 1
 
@@ -74,7 +74,7 @@
 		M.drop_from_inventory(src) //icon update
 
 		if(reagents.total_volume)
-			reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)
+			reagents.trans_to_mob(M, reagents.total_volume, CHEM_BLOOD)	//CHEM_TOUCH
 		qdel(src)
 
 		return 1


### PR DESCRIPTION
Patches are a really cool idea as a non-invasive treatment alternative to syringes and pills, but they're locked behind the requirement of using the distillery which means going through cargo and doing the whole process of fucking around with that.

So instead I've just made them transfer reagents in the patch into the bloodstream. This is already possible IRL using compounds like [DMSO](https://en.wikipedia.org/wiki/Dimethyl_sulfoxide#Medicine).

Might mess around with them later and see if I can make it a progressive transfer thing rather than just slap-on-and-done, since otherwise they *are* kind of objectively better than syringes and pills alike. Possibly cap the max reagent amount to be lower as well?

This does sort of make all the -aze reagents redundant, but was anyone really using those anyway? It doesn't help there's only five of them, covering inaprovaline, bicaridine, dermaline, tricordrazine, and a custom antibiotic/painkiller combo.

:cl:
tweak: made patches transfer their reagents straight into blood, so you can use them for anything
/:cl: