### PR TITLE
SD Explo Maint Door Fix

### DIFF
--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -15656,13 +15656,6 @@
 /turf/simulated/floor,
 /area/stellardelight/deck1/explobriefing)
 "Hf" = (
-/obj/machinery/door/airlock/angled_bay/standard/glass{
-	dir = 4;
-	door_color = "#333333";
-	name = "Auxiliary EVA Equipment Room";
-	req_one_access = list(18,19,43);
-	stripe_color = "#5a19a8"
-	},
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "1-2"
@@ -15671,6 +15664,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/angled_bay/hatch{
+	door_color = "#333333";
+	name = "Auxiliary EVA Equipment";
+	req_one_access = list(18,19,43);
+	stripe_color = "#5a19a8"
+	},
 /turf/simulated/floor,
 /area/stellardelight/deck1/exploequipment)
 "Hg" = (
@@ -17699,6 +17698,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploequipment)
+"Lz" = (
+/obj/machinery/door/airlock/angled_bay/standard/glass{
+	door_color = "#333333";
+	name = "Auxiliary EVA Equipment Room";
+	req_one_access = list(18,19,43);
+	stripe_color = "#5a19a8"
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "LA" = (
 /obj/structure/cable/pink{
 	icon_state = "1-8"
@@ -31594,7 +31602,7 @@ Ua
 Ua
 Ua
 Ec
-vT
+Lz
 pC
 HG
 LO


### PR DESCRIPTION
A door into maintenance in the exploration kit room was a glass airlock that was facing the wrong direction.

I have made it into a hatch-lock with the correct facing, and otherwise preserved its previous access levels and colouration.