### PR TITLE
Alcohol Trait Refactor

### DIFF
--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -179,7 +179,16 @@
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/drinks/self_feed_message(var/mob/user)
-	to_chat(user, "<span class='notice'>You swallow a gulp from \the [src].</span>")
+	if(amount_per_transfer_from_this == volume)	//I wanted to use a switch, but switch statements can't use vars and the maximum volume of containers varies
+		to_chat(user, "<span class='notice'>You knock back the entire [src] in one go!</span>")
+	else if(amount_per_transfer_from_this <= 4)	//below the standard 5
+		to_chat(user, "<span class='notice'>You take a modest sip from \the [src].</span>")
+	else if(amount_per_transfer_from_this <= 10)	//the standard five to a bit more
+		to_chat(user, "<span class='notice'>You swallow a gulp from \the [src].</span>")
+	else if(amount_per_transfer_from_this <= 30)
+		to_chat(user, "<span class='notice'>You take a long drag from \the [src].</span>")
+	else	//default message as a fallback
+		to_chat(user, "<span class='notice'>You swallow a gulp from \the [src].</span>")
 
 /obj/item/weapon/reagent_containers/food/drinks/feed_sound(var/mob/user)
 	playsound(src, 'sound/items/drink.ogg', rand(10, 50), 1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -108,7 +108,7 @@
 	var/chem_strength_heal =    1						// Multiplier to most beneficial chem strength
 	var/chem_strength_pain =    1						// Multiplier to painkiller strength (could be used in a negative trait to simulate long-term addiction reducing effects, etc.)
 	var/chem_strength_tox =	    1						// Multiplier to toxic chem strength (inc. chloral/sopo/mindbreaker/etc. thresholds)
-	var/chem_strength_alcohol = 1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
+	var/chem_strength_alcohol = 1						// Multiplier to alcohol effect thresholds; higher means more is needed to reach a given effect tier
 
 	var/chemOD_threshold =		1						// Multiplier to overdose threshold; lower = easier overdosing
 	var/chemOD_mod =		1						// Damage modifier for overdose; higher = more damage from ODs

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -61,7 +61,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	item_slowdown_mod = 1.33
 	throwforce_absorb_threshold = 10
 
-	chem_strength_alcohol = 2
+	chem_strength_alcohol = 0.5
 
 	cloning_modifier = /datum/modifier/cloning_sickness/promethean
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -71,7 +71,7 @@
 	name_language = LANGUAGE_UNATHI
 	species_language = LANGUAGE_UNATHI
 	health_hud_intensity = 2.5
-	chem_strength_alcohol = 0.75
+	chem_strength_alcohol = 1.25
 	throwforce_absorb_threshold = 10
 	digi_allowed = TRUE
 
@@ -198,7 +198,7 @@
 	name_language = LANGUAGE_SIIK
 	species_language = LANGUAGE_SIIK
 	health_hud_intensity = 2.5
-	chem_strength_alcohol = 1.25
+	chem_strength_alcohol = 0.75
 	digi_allowed = TRUE
 
 	min_age = 17
@@ -303,7 +303,7 @@
 	species_language = LANGUAGE_SKRELLIAN
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX, LANGUAGE_PROMETHEAN)
 	health_hud_intensity = 2
-	chem_strength_alcohol = 5
+	chem_strength_alcohol = 0.2
 
 	water_movement = -3
 
@@ -522,7 +522,7 @@
 	show_ssd = "completely quiescent"
 	health_hud_intensity = 2.5
 	item_slowdown_mod = 0.1
-	chem_strength_alcohol = 0
+	chem_strength_alcohol = 10000	//a little hacky, maybe? but whatever. nobody plays diona anyway.
 	throwforce_absorb_threshold = 5
 
 	num_alternate_languages = 3

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -482,21 +482,21 @@
 	desc = "The only way you can hold a drink is if it's in your own two hands, and even then you'd best not inhale too deeply near it. Alcohol hits you three times as hard as they do other people."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 3)
+	var_changes = list("chem_strength_alcohol" = 0.33)
 
 /datum/trait/neutral/alcohol_intolerance_basic
 	name = "Liver of Lilies"
 	desc = "You have a hard time with alcohol. Maybe you just never took to it, or maybe it doesn't agree with your system... either way, alcohol hits you twice as hard."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 2)
+	var_changes = list("chem_strength_alcohol" = 0.5)
 
 /datum/trait/neutral/alcohol_intolerance_slight
 	name = "Liver of Tulips"
 	desc = "You are what some might call 'a bit of a lightweight', but you can still keep your drinks down... most of the time. Alcohol hits you fifty percent harder."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 1.5)
+	var_changes = list("chem_strength_alcohol" = 0.75)
 
 /datum/trait/neutral/alcohol_tolerance_reset
 	name = "Liver of Unremarkableness"
@@ -511,21 +511,21 @@
 	desc = "You can hold drinks much better than those lily-livered land-lubbers! Arr! Alcohol's effects on you are reduced by about a quarter."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 0.75)
+	var_changes = list("chem_strength_alcohol" = 1.25)
 
 /datum/trait/neutral/alcohol_tolerance_advanced
 	name = "Liver of Steel"
 	desc = "Drinks tremble before your might! You can hold your alcohol twice as well as those blue-bellied barnacle boilers! Alcohol has just half the effect on you as it does on others."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 0.5)
+	var_changes = list("chem_strength_alcohol" = 2)
 
 /datum/trait/neutral/alcohol_immunity
 	name = "Liver of Durasteel"
 	desc = "You've drunk so much that most booze doesn't even faze you. It takes something like a Pan-Galactic or a pint of Deathbell for you to even get slightly buzzed."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("chem_strength_alcohol" = 0.25)
+	var_changes = list("chem_strength_alcohol" = 4)
 // Alcohol Traits End Here.
 
 /datum/trait/neutral/colorblind/mono

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -113,7 +113,7 @@
 	if(issmall(M))
 		removed *= 2
 
-	var/strength_mod = 3 * M.species.chem_strength_alcohol //Alcohol is 3x stronger when injected into the veins.
+	var/strength_mod = 3 //Alcohol is 3x stronger when injected into the veins.
 	if(!strength_mod)
 		return
 
@@ -121,19 +121,19 @@
 		M.add_chemical_effect(CE_ALCOHOL, 1)
 		var/effective_dose = dose * strength_mod * (1 + volume/60) //drinking a LOT will make you go down faster
 
-		if(effective_dose >= strength) // Early warning
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol)) // Early warning
 			M.make_dizzy(18) // It is decreased at the speed of 3 per tick
-		if(effective_dose >= strength * 2) // Slurring
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 2) // Slurring
 			M.slurring = max(M.slurring, 90)
-		if(effective_dose >= strength * 3) // Confusion - walking in random directions
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 3) // Confusion - walking in random directions
 			M.Confuse(60)
-		if(effective_dose >= strength * 4) // Blurry vision
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 4) // Blurry vision
 			M.eye_blurry = max(M.eye_blurry, 30)
-		if(effective_dose >= strength * 5) // Drowsyness - periodically falling asleep
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 5) // Drowsyness - periodically falling asleep
 			M.drowsyness = max(M.drowsyness, 60)
-		if(effective_dose >= strength * 6) // Toxic dose
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 6) // Toxic dose
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, toxicity*3)
-		if(effective_dose >= strength * 7) // Pass out
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 7) // Pass out
 			M.Paralyse(60)
 			M.Sleeping(90)
 
@@ -160,26 +160,26 @@
 	if(M.isSynthetic() && M.nutrition < 500 && M.species.robo_ethanol_proc)
 		M.adjust_nutrition(round(max(0,ep_base_power - strength) * removed)/ep_final_mod)	//the stronger it is, the more juice you gain
 
-	var/effective_dose = dose * M.species.chem_strength_alcohol
+	var/effective_dose = dose
 	if(!effective_dose)
 		return
 
 	if(M.species.robo_ethanol_drunk || !(M.isSynthetic()))
 		M.add_chemical_effect(CE_ALCOHOL, 1)
 
-		if(effective_dose >= strength) // Early warning
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol)) // Early warning
 			M.make_dizzy(6) // It is decreased at the speed of 3 per tick
-		if(effective_dose >= strength * 2) // Slurring
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 2) // Slurring
 			M.slurring = max(M.slurring, 30)
-		if(effective_dose >= strength * 3) // Confusion - walking in random directions
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 3) // Confusion - walking in random directions
 			M.Confuse(20)
-		if(effective_dose >= strength * 4) // Blurry vision
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 4) // Blurry vision
 			M.eye_blurry = max(M.eye_blurry, 10)
-		if(effective_dose >= strength * 5) // Drowsyness - periodically falling asleep
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 5) // Drowsyness - periodically falling asleep
 			M.drowsyness = max(M.drowsyness, 20)
-		if(effective_dose >= strength * 6) // Toxic dose
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 6) // Toxic dose
 			M.add_chemical_effect(CE_ALCOHOL_TOXIC, toxicity)
-		if(effective_dose >= strength * 7) // Pass out
+		if(effective_dose >= (strength * M.species.chem_strength_alcohol) * 7) // Pass out
 			M.Paralyse(20)
 			M.Sleeping(30)
 


### PR DESCRIPTION
After some *recent incidents* with the alcohol traits, I decided to refactor the tolerance traits as I'm starting suspect the initial implementation wasn't working as reliably as I thought. They are now effectively inverted, applying to the *thresholds* rather than the *dosage*.

I also threw in some fluff changes to the message displayed when you drink from a glass/container, to add a little flavour to the feedback.

:cl:
tweak: refactored alcohol traits
tweak: expanded feedback when you drink from a glass
/:cl: