### PR TITLE
Ports Venom Bite / Injection from Rogue Star

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1529,3 +1529,147 @@
 
 		if(Adjacent(target))	//We leapt at them but we didn't manage to hit them, let's see if we're next to them
 			target.Weaken(2)	//get knocked down, idiot
+
+
+/mob/living/proc/injection() // Allows the user to inject reagents into others somehow, like stinging, or biting.
+	set name = "Injection"
+	set category = "Abilities"
+	set desc = "Inject another being with something!"
+
+	if(stat || paralysis || weakened || stunned || world.time < last_special) //Epic copypasta from tongue grabbing.
+		to_chat(src, "<span class='warning'>You can't do that in your current state.</span>")
+		return
+
+	last_special = world.time + 10 //Anti-spam.
+
+	if (!istype(src, /mob/living))
+		to_chat(src, "<span class='warning'>It doesn't work that way.</span>")
+		return
+
+	var/list/choices = list("Inject")
+
+	if(trait_injection_reagents.len > 1) //Should never happen, but who knows!
+		choices += "Change reagent"
+	else if(!trait_injection_selected)
+		trait_injection_selected = trait_injection_reagents[1]
+
+	choices += "Change amount"
+	choices += "Change verb"
+	choices += "Chemical Refresher"
+
+	var/choice = tgui_alert(src, "Do you wish to inject somebody, or adjust settings?", "Selection List", choices)
+
+	if(choice == "Change reagent")
+		var/reagent_choice = tgui_input_list(usr, "Choose which reagent to inject!", "Select reagent", trait_injection_reagents)
+		if(reagent_choice)
+			trait_injection_selected = reagent_choice
+		to_chat(src, "<span class='notice'>You prepare to inject [trait_injection_amount] units of [trait_injection_selected ? "[trait_injection_selected]" : "...nothing. Select a reagent before trying to inject anything."]</span>")
+		return
+	if(choice == "Change amount")
+		var/amount_choice = tgui_input_number(usr, "How much of the reagent do you want to inject? (Up to 5 units) (Can select 0 for a bite that doesn't inject venom!)", "How much?", trait_injection_amount, 5, 0)
+		if(amount_choice)
+			trait_injection_amount = amount_choice
+		to_chat(src, "<span class='notice'>You prepare to inject [trait_injection_amount] units of [trait_injection_selected ? "[trait_injection_selected]" : "...nothing. Select a reagent before trying to inject anything."]</span>")
+		return
+	if(choice == "Change verb")
+		var/verb_choice = tgui_input_text(usr, "Choose the percieved manner of injection, such as 'bite' or 'sting', don't be misleading or abusive.", "How are you injecting?", trait_injection_verb, max_length = 60) //Whoaa there cowboy don't put a novel in there.
+		if(verb_choice)
+			trait_injection_verb = verb_choice
+		to_chat(src, "<span class='notice'>You will [trait_injection_verb] your targets.</span>")
+		return
+	if(choice == "Chemical Refresher")
+		var/output = {"<B>Chemical Refresher!</B><HR>
+					<B>Options for venoms</B><BR>
+					<BR>
+					<B>Size Chemnicals</B><BR>
+					Microcillin: Will make someone shrink. <br>
+					Macrocillin: Will make someone grow. <br>
+					Normalcillin: Will make someone normal size. <br>
+					Note: 1 unit = 100% size diff. 0.01 unit = 1% size diff. <br>
+					Note: Normacillin stops at 100%  size. <br>
+					<br>
+					<B>Gender Chemicals</B><BR>
+					Androrovir: Will transform someone's sex to male. <br>
+					Gynorovir: Will transform someone's sex to female. <br>
+					Androgynorovir: Will transform someone's sex to plural. <br>
+					<br>
+					<B>Special Chemicals</B><BR>
+					Stoxin: Will make someone drowsy. <br>
+					Rainbow Toxin: Will make someone see rainbows. <br>
+					Paralysis Toxin: Will make someone paralyzed. <br>
+					Numbing Enzyme: Will make someone unable to feel pain. <br>
+					Pain Enzyme: Will make someone feel amplified pain. <br>
+					<br>
+					<B>Side Notes</B><BR>
+					You can select a value of 0 to inject nothing! <br>
+					Overdose threshold for most chemicals is 30 units. <br>
+					Exceptions to OD is: (Numbing Enzyme:20)
+					<br>
+					"}
+		usr << browse(output,"window=chemicalrefresher")
+		return
+	else
+		var/list/targets = list() //IF IT IS NOT BROKEN. DO NOT FIX IT. AND KEEP COPYPASTING IT  (Pointing Rick Dalton: "That's my code!" ~CL)
+
+		for(var/mob/living/carbon/L in living_mobs(1, TRUE)) //Noncarbons don't even process reagents so don't bother listing others.
+			if(!istype(L, /mob/living/carbon))
+				continue
+			if(L == src) //no getting high off your own supply, get a nif or something, nerd.
+				continue
+			if(!L.resizable && (trait_injection_selected == "macrocillin" || trait_injection_selected == "microcillin" || trait_injection_selected == "normalcillin")) // If you're using a size reagent, ignore those with pref conflicts.
+				continue
+			if(!L.allow_spontaneous_tf && (trait_injection_selected == "androrovir" || trait_injection_selected == "gynorovir" || trait_injection_selected == "androgynorovir")) // If you're using a TF reagent, ignore those with pref conflicts.
+				continue
+			targets += L
+
+		if(!(targets.len))
+			to_chat(src, "<span class='notice'>No eligible targets found.</span>")
+			return
+
+		var/mob/living/target = tgui_input_list(src, "Please select a target.", "Victim", targets)
+
+		if(!target)
+			return
+
+		if(!istype(target, /mob/living/carbon)) //Safety.
+			to_chat(src, "<span class='warning'>That won't work on that kind of creature! (Only works on crew/monkeys)</span>")
+			return
+
+		if(target.isSynthetic())
+			to_chat(src, "<span class='notice'>There's no getting past that outer shell.</span>")
+			return
+
+		if(!trait_injection_selected)
+			to_chat(src, "<span class='notice'>You need to select a reagent.</span>")
+			return
+
+		if(!trait_injection_verb)
+			to_chat(src, "<span class='notice'>Somehow, you forgot your means of injecting. (Select a verb!)</span>")
+			return
+
+		if(do_after(src, 50, target)) //A decent enough timer.
+			add_attack_logs(src,target,"Injection trait ([trait_injection_selected], [trait_injection_amount])")
+			if(target.reagents && (trait_injection_amount > 0))
+				target.reagents.add_reagent(trait_injection_selected, trait_injection_amount)
+			var/ourmsg = "<span class='warning'>[usr] [trait_injection_verb] [target] "
+			switch(zone_sel.selecting)
+				if(BP_HEAD)
+					ourmsg += "on the head!"
+				if(BP_TORSO)
+					ourmsg += "on the chest!"
+				if(BP_GROIN)
+					ourmsg += "on the groin!"
+				if(BP_R_ARM, BP_L_ARM)
+					ourmsg += "on the arm!"
+				if(BP_R_HAND, BP_L_HAND)
+					ourmsg += "on the hand!"
+				if(BP_R_LEG, BP_L_LEG)
+					ourmsg += "on the leg!"
+				if(BP_R_FOOT, BP_L_FOOT)
+					ourmsg += "on the foot!"
+				if("mouth")
+					ourmsg += "on the mouth!"
+				if("eyes")
+					ourmsg += "on the eyes!"
+			ourmsg += "</span>"
+			visible_message(ourmsg)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1567,12 +1567,12 @@
 		return
 	if(choice == "Change amount")
 		var/amount_choice = tgui_input_number(usr, "How much of the reagent do you want to inject? (Up to 5 units) (Can select 0 for a bite that doesn't inject venom!)", "How much?", trait_injection_amount, 5, 0)
-		if(amount_choice)
+		if(amount_choice >= 0)
 			trait_injection_amount = amount_choice
 		to_chat(src, "<span class='notice'>You prepare to inject [trait_injection_amount] units of [trait_injection_selected ? "[trait_injection_selected]" : "...nothing. Select a reagent before trying to inject anything."]</span>")
 		return
 	if(choice == "Change verb")
-		var/verb_choice = tgui_input_text(usr, "Choose the percieved manner of injection, such as 'bite' or 'sting', don't be misleading or abusive.", "How are you injecting?", trait_injection_verb, max_length = 60) //Whoaa there cowboy don't put a novel in there.
+		var/verb_choice = tgui_input_text(usr, "Choose the percieved manner of injection, such as 'bites' or 'stings', don't be misleading or abusive. This will show up in game as ('X' 'Verb' 'Y'. Example: X bites Y.)", "How are you injecting?", trait_injection_verb, max_length = 60) //Whoaa there cowboy don't put a novel in there.
 		if(verb_choice)
 			trait_injection_verb = verb_choice
 		to_chat(src, "<span class='notice'>You will [trait_injection_verb] your targets.</span>")

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1542,10 +1542,6 @@
 
 	last_special = world.time + 10 //Anti-spam.
 
-	if (!istype(src, /mob/living))
-		to_chat(src, "<span class='warning'>It doesn't work that way.</span>")
-		return
-
 	var/list/choices = list("Inject")
 
 	if(trait_injection_reagents.len > 1) //Should never happen, but who knows!
@@ -1603,7 +1599,8 @@
 					<B>Side Notes</B><BR>
 					You can select a value of 0 to inject nothing! <br>
 					Overdose threshold for most chemicals is 30 units. <br>
-					Exceptions to OD is: (Numbing Enzyme:20)
+					Exceptions to OD is: (Numbing Enzyme:20)<br>
+					You can also bite synthetics, but due to how synths work, they won't have anything injected into them.
 					<br>
 					"}
 		usr << browse(output,"window=chemicalrefresher")
@@ -1635,9 +1632,10 @@
 			to_chat(src, "<span class='warning'>That won't work on that kind of creature! (Only works on crew/monkeys)</span>")
 			return
 
+
+		var/synth = 0
 		if(target.isSynthetic())
-			to_chat(src, "<span class='notice'>There's no getting past that outer shell.</span>")
-			return
+			synth = 1
 
 		if(!trait_injection_selected)
 			to_chat(src, "<span class='notice'>You need to select a reagent.</span>")
@@ -1649,7 +1647,7 @@
 
 		if(do_after(src, 50, target)) //A decent enough timer.
 			add_attack_logs(src,target,"Injection trait ([trait_injection_selected], [trait_injection_amount])")
-			if(target.reagents && (trait_injection_amount > 0))
+			if(target.reagents && (trait_injection_amount > 0) && !synth)
 				target.reagents.add_reagent(trait_injection_selected, trait_injection_amount)
 			var/ourmsg = "<span class='warning'>[usr] [trait_injection_verb] [target] "
 			switch(zone_sel.selecting)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1581,7 +1581,7 @@
 		var/output = {"<B>Chemical Refresher!</B><HR>
 					<B>Options for venoms</B><BR>
 					<BR>
-					<B>Size Chemnicals</B><BR>
+					<B>Size Chemicals</B><BR>
 					Microcillin: Will make someone shrink. <br>
 					Macrocillin: Will make someone grow. <br>
 					Normalcillin: Will make someone normal size. <br>

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -143,6 +143,45 @@
 	H.verbs |= /mob/living/carbon/human/proc/succubus_drain_finalize
 	H.verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal
 
+/datum/trait/neutral/venom_bite
+	name = "Venomous Injection"
+	desc = "Allows for injecting prey through one method or another to inject them with a variety of chemicals with varying effects!"
+	tutorial = "This trait allows you to bite prey with varying effects! <br> \
+		Options for venoms: <br> \
+		=====Size Chemicals ===== <br> \
+		Microcillin: Will make someone shrink. (This is 1% per 0.01 units. So 1 unit = 100% size change) <br> \
+		Macrocillin: Will make someone grow. (This is 1% per 0.01 units. So 1 unit = 100% size change) <br> \
+		Normalcillin: Will make someone normal size. (This is 1% per 0.01 units. So 1 unit = 100% size change) Stops at 100% size. <br> \
+		===== Gender Chemicals ===== <br> \
+		Androrovir: Will transform someone's sex to male. <br> \
+		Gynorovir: Will transform someone's sex to female. <br> \
+		Androgynorovir: Will transform someone's sex to pleural. <br> \
+		===== Special Chemicals ===== <br> \
+		Stoxin: Will make someone drowsy. <br> \
+		Rainbow Toxin: Will make someone see rainbows. <br> \
+		Paralysis Toxin: Will make someone paralyzed. <br> \
+		Numbing Enzyme: Will make someone unable to feel pain. <br> \
+		Pain Enzyme: Will make someone feel pain, amplifieed <br> \
+		===== Side Notes ===== <br> \
+		You aren't required to inject anything if you prefer to just use it as a normal bite!"
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/venom_bite/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.verbs |= /mob/living/proc/injection
+	H.trait_injection_reagents += "microcillin"		// get small
+	H.trait_injection_reagents += "macrocillin"		// get BIG
+	H.trait_injection_reagents += "normalcillin"	// normal
+	H.trait_injection_reagents += "numbenzyme"		// no feelings
+	H.trait_injection_reagents += "androrovir" 		// -> MALE
+	H.trait_injection_reagents += "gynorovir" 		// -> FEMALE
+	H.trait_injection_reagents += "androgynorovir" 	// -> PLURAL
+	H.trait_injection_reagents += "stoxin"			// night night chem
+	H.trait_injection_reagents += "rainbowtoxin" 	// Funny flashing lights.
+	H.trait_injection_reagents += "paralysistoxin" 	// Paralysis!
+	H.trait_injection_reagents += "painenzyme"		// Pain INCREASER
+
 /datum/trait/neutral/long_vore
 	name = "Long Predatorial Reach"
 	desc = "Makes you able to use an unspecified appendage to grab creatures."

--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -187,6 +187,9 @@
 				H.visible_message("<span class='notice'>[H] suddenly twitches as some of their features seem to contort and reshape, adjusting... In the end, it seems they are now of mixed gender.</span>",
 								"<span class='warning'>Your body suddenly contorts, feeling very different in various ways... By the time the rushing feeling is over it seems you just became of mixed gender.</span>")
 
+
+////////////////////////// Misc Drugs //////////////////////////
+
 /datum/reagent/drugs/rainbow_toxin /// Replaces Space Drugs.
 	name = "Rainbow Toxin"
 	id = "rainbowtoxin"
@@ -219,24 +222,9 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
 
-/datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.paralysis < 10) //Let's not leave them PERMA paralyzed, after all.
-		M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
-
-/datum/reagent/pain_toxin
-	name = "Tetrodotoxin"
-	id = "paralysistoxin"
-	description = "A commonly found, potent"
-	taste_description = "bitterness"
-	reagent_state = LIQUID
-	color = "#37007f"
-	metabolism = REM * 0.25
-	overdose = REAGENTS_OVERDOSE
-	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
-
-/datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.paralysis < 10) //Let's not leave them PERMA paralyzed, after all.
-		M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
+/datum/reagent/paralysis_toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.weakened < 50) //Let's not leave them PERMA stuck, after all.
+		M.AdjustWeakened(5) //Stand in for paralyze so you can still talk/emote/see
 
 /datum/reagent/pain_enzyme
 	name = "Pain Enzyme"
@@ -244,11 +232,11 @@
 	description = "Some sort of organic painkiller."
 	taste_description = "sourness"
 	reagent_state = LIQUID
-	color = "#800080"
+	color = "#04b8fa" //Light blue in honor of Perry.
 	metabolism = 0.1 //Lasts up to 50 seconds if you give 5 units.
 	mrate_static = TRUE
 	overdose = 100 //There is no OD. You already are taking the worst of it.
-	scannable = 0 //Let's not have medical mechs able to make an extremely strong organic painkiller
+	scannable = 0 //Let's not have medical mechs able to make an extremely strong 'I hit you you fall down in agony' chem.
 
 /datum/reagent/pain_enzyme/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, -200)

--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -253,5 +253,4 @@
 /datum/reagent/pain_enzyme/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.add_chemical_effect(CE_PAINKILLER, -200)
 	if(prob(0.01)) //1 in 10000 chance per tick. Extremely rare.
-		to_chat(M,"<span class='warning'>Your body feels numb as a light, tingly sensation spreads throughout it, like some odd warmth.</span>")
-	//Not noted here, but a movement debuff of 1.5 is handed out in human_movement.dm when numbing_enzyme is in a person's bloodstream!
+		to_chat(M,"<span class='warning'>Your body feels as though it's on fire!</span>")

--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -186,3 +186,72 @@
 				H.change_gender_identity(PLURAL)
 				H.visible_message("<span class='notice'>[H] suddenly twitches as some of their features seem to contort and reshape, adjusting... In the end, it seems they are now of mixed gender.</span>",
 								"<span class='warning'>Your body suddenly contorts, feeling very different in various ways... By the time the rushing feeling is over it seems you just became of mixed gender.</span>")
+
+/datum/reagent/drugs/rainbow_toxin /// Replaces Space Drugs.
+	name = "Rainbow Toxin"
+	id = "rainbowtoxin"
+	description = "Known for providing a euphoric high, this psychoactive drug is often injected into unknowing prey by serpents and other fanged beasts. Highly valuable and frequently sought after by hypno-enthusiasts and party-goers."
+	taste_description = "mixed euphoria"
+	taste_mult = 0.8 //You ARE going to taste this!
+	scannable = 1	//Sure! If you manage to milk a snake for some of this, go ahead and scan it and mass produce it. Your local club will love you!
+
+/datum/reagent/drugs/rainbow_toxin/affect_blood(mob/living/carbon/M, var/alien, var/removed)
+	..()
+	var/drug_strength = 20
+	M.druggy = max(M.druggy, drug_strength)
+
+/datum/reagent/drugs/bliss/overdose(var/mob/living/M as mob)
+	if(prob_proc == TRUE && prob(20))
+		M.hallucination = max(M.hallucination, 5)
+		prob_proc = FALSE
+	M.adjustBrainLoss(0.25*REM) //Too much isn't good for your long term health...
+	M.adjustToxLoss(0.01*REM)	//Enough that it'll make your HUD dummy update, but not enough that you'll vomit mid scene. (Sorry emetophiliacs!)
+	..()
+
+/datum/reagent/paralysis_toxin
+	name = "Tetrodotoxin"
+	id = "paralysistoxin"
+	description = "A commonly found, potent"
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#37007f"
+	metabolism = REM * 0.25
+	overdose = REAGENTS_OVERDOSE
+	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
+
+/datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.paralysis < 10) //Let's not leave them PERMA paralyzed, after all.
+		M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
+
+/datum/reagent/pain_toxin
+	name = "Tetrodotoxin"
+	id = "paralysistoxin"
+	description = "A commonly found, potent"
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#37007f"
+	metabolism = REM * 0.25
+	overdose = REAGENTS_OVERDOSE
+	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
+
+/datum/reagent/alkysine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.paralysis < 10) //Let's not leave them PERMA paralyzed, after all.
+		M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
+
+/datum/reagent/pain_enzyme
+	name = "Pain Enzyme"
+	id = "painenzyme"
+	description = "Some sort of organic painkiller."
+	taste_description = "sourness"
+	reagent_state = LIQUID
+	color = "#800080"
+	metabolism = 0.1 //Lasts up to 50 seconds if you give 5 units.
+	mrate_static = TRUE
+	overdose = 100 //There is no OD. You already are taking the worst of it.
+	scannable = 0 //Let's not have medical mechs able to make an extremely strong organic painkiller
+
+/datum/reagent/pain_enzyme/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_PAINKILLER, -200)
+	if(prob(0.01)) //1 in 10000 chance per tick. Extremely rare.
+		to_chat(M,"<span class='warning'>Your body feels numb as a light, tingly sensation spreads throughout it, like some odd warmth.</span>")
+	//Not noted here, but a movement debuff of 1.5 is handed out in human_movement.dm when numbing_enzyme is in a person's bloodstream!

--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -214,7 +214,7 @@
 /datum/reagent/paralysis_toxin
 	name = "Tetrodotoxin"
 	id = "paralysistoxin"
-	description = "A commonly found, potent"
+	description = "A potent toxin commonly found in a plethora of species. When exposed to the toxin, causes extreme, paralysis for a prolonged period, with only essential functions of the body being unhindered. Commonly used by covert operatives and used as a crowd control tool."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#37007f"
@@ -229,7 +229,7 @@
 /datum/reagent/pain_enzyme
 	name = "Pain Enzyme"
 	id = "painenzyme"
-	description = "Some sort of organic painkiller."
+	description = "An enzyme found in a variety of species. When exposed to the toxin, will cause severe, agonizing pain. The effects can last for hours depending on the dose. Only known cure is an equally strong painkiller or dialysis."
 	taste_description = "sourness"
 	reagent_state = LIQUID
 	color = "#04b8fa" //Light blue in honor of Perry.

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -34,6 +34,10 @@
 		'sound/effects/mob_effects/xenochimera/regen_5.ogg'
 	)
 	var/trash_catching = FALSE				//Toggle for trash throw vore from chompstation
+	var/list/trait_injection_reagents = list()	//List of all the reagents allowed to be used for injection via venom bite
+	var/trait_injection_selected = null			//RSEdit: What trait reagent you're injecting.
+	var/trait_injection_amount = 5				//RSEdit: How much you're injecting with traits.
+	var/trait_injection_verb = "bites"			//RSEdit: Which fluffy manner you're doing the injecting.
 
 //
 // Hook for generic creation of stuff on new creatures


### PR DESCRIPTION
And adds a few extras

Venomous bite trait is Complete. (Bulk of code was ported from Rogue Star.) Additions:
- Added a 'Chemical Refresher' button that tells you each chem and what it does. Added all the gender TF chems to the bite.
- Added Stoxin to the list of injectable chems.
- Added three new chems: 'Rainbow Toxin' 'Paralysis Toxin' and 'Pain Enzyme'. Rainbow toxin: Makes you druggy like ambrosia, without the stuttering/vomiting/random walking. Paralysis Toxin: Does exactly what it says on the tin. Pain Enzyme: Acts as a reverse numbing enzyme. Pain is AMPLIFIED by 200. One bite and you're going to be whimpering on the floor.
- Adds a 'master list' to let you know what each chemical does!
- Allows biting synths

Total time spent porting & coding ~3 hours.