### PR TITLE
Loadout Restrictions Specified

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -155,17 +155,17 @@ var/list/gear_datums = list()
 	. += "<tr><td colspan=3><hr></td></tr>"
 	for(var/gear_name in LC.gear)
 		var/datum/gear/G = LC.gear[gear_name]
-		//VOREStation Edit Start
 		if(preference_mob && preference_mob.client)
 			if(G.ckeywhitelist && !(preference_mob.ckey in G.ckeywhitelist))
 				continue
 			if(G.character_name && !(preference_mob.client.prefs.real_name in G.character_name))
 				continue
-		//VOREStation Edit End
 		var/ticked = (G.display_name in pref.gear)
 		. += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[html_encode(G.display_name)]'>[G.display_name]</a></td>"
 		. += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
 		. += "<td><font size=2><i>[G.description]</i></font></td></tr>"
+		if(G.show_roles && G.allowed_roles)
+			. += "<td colspan=3>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Restricted to: [list2text(G.allowed_roles,", ")]</td>"
 		if(ticked)
 			. += "<tr><td colspan=3>"
 			for(var/datum/gear_tweak/tweak in G.gear_tweaks)
@@ -252,6 +252,7 @@ var/list/gear_datums = list()
 	var/cost = 1           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
+	var/show_roles = TRUE	//Show the role restrictions on this item?
 	var/whitelisted        //Term to check the whitelist for..
 	var/sort_category = "General"
 	var/list/gear_tweaks = list() //List of datums which will alter the item after it has been spawned.

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -75,7 +75,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(wcoats))
 
 /datum/gear/accessory/holster
-	display_name = "holster selection (Security, CD, HoP)"
+	display_name = "holster selection"
 	path = /obj/item/clothing/accessory/holster
 	allowed_roles = list("Site Manager", "Head of Personnel", "Security Officer", "Warden", "Head of Security","Detective")
 

--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -57,35 +57,35 @@
 	path = /obj/item/clothing/accessory/collar/holo/indigestible
 
 /datum/gear/accessory/holster
-	display_name = "holster selection (Security, SM, HoP)"
+	display_name = "holster selection"
 	allowed_roles = list("Site Manager", "Head of Personnel", "Security Officer", "Warden", "Head of Security","Detective","Talon Captain","Talon Guard")
 
 /datum/gear/accessory/brown_vest
-	display_name = "webbing, brown (Eng, Sec, Med, Miner)"
+	display_name = "webbing, brown"
 	allowed_roles = list("Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Shaft Miner","Talon Captain","Talon Doctor","Talon Engineer","Talon Guard", "Talon Miner")
 
 /datum/gear/accessory/black_vest
-	display_name = "webbing, black (Eng, Sec, Med, Miner)"
+	display_name = "webbing, black"
 	allowed_roles = list("Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Shaft Miner","Talon Captain","Talon Doctor","Talon Engineer","Talon Guard", "Talon Miner")
 
 /datum/gear/accessory/white_vest
-	display_name = "webbing, white (Medical)"
+	display_name = "webbing, white"
 	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Talon Doctor")
 
 /datum/gear/accessory/brown_drop_pouches
-	display_name = "drop pouches, brown (Eng, Sec, Med, Miner)"
+	display_name = "drop pouches, brown"
 	allowed_roles = list("Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Shaft Miner","Talon Captain","Talon Doctor","Talon Engineer","Talon Guard", "Talon Miner")
 
 /datum/gear/accessory/black_drop_pouches
-	display_name = "drop pouches, black (Eng, Sec, Med, Miner)"
+	display_name = "drop pouches, black"
 	allowed_roles = list("Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Shaft Miner","Talon Captain","Talon Doctor","Talon Engineer","Talon Guard", "Talon Miner")
 
 /datum/gear/accessory/white_drop_pouches
-	display_name = "drop pouches, white (Medical)"
+	display_name = "drop pouches, white"
 	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Talon Doctor")
 
 /datum/gear/accessory/bluespace
-	display_name = "bluespace badge (Eng, Sec, Med, Miner, Pilot)"
+	display_name = "bluespace badge"
 	path = /obj/item/clothing/accessory/storage/bluespace
 	allowed_roles = list("Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor","Chemist","Shaft Miner","Talon Captain","Talon Doctor","Talon Engineer","Talon Guard","Talon Miner","Pilot")
 	cost = 2

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -68,76 +68,76 @@
 	path = /obj/item/clothing/glasses/science
 
 /datum/gear/eyes/security
-	display_name = "Security HUD (Security)"
+	display_name = "Security HUD"
 	path = /obj/item/clothing/glasses/hud/security
 	allowed_roles = list("Security Officer","Head of Security","Warden", "Detective")
 
 /datum/gear/eyes/security/prescriptionsec
-	display_name = "Security HUD, prescription (Security)"
+	display_name = "Security HUD, prescription"
 	path = /obj/item/clothing/glasses/hud/security/prescription
 
 /datum/gear/eyes/security/sunglasshud
-	display_name = "Security HUD, sunglasses (Security)"
+	display_name = "Security HUD, sunglasses"
 	path = /obj/item/clothing/glasses/sunglasses/sechud
 
 /datum/gear/eyes/security/aviator
-	display_name = "Security HUD Aviators (Security)"
+	display_name = "Security HUD Aviators"
 	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator
 
 /datum/gear/eyes/security/aviator/prescription
-	display_name = "Security HUD Aviators, prescription (Security)"
+	display_name = "Security HUD Aviators, prescription"
 	path = /obj/item/clothing/glasses/sunglasses/sechud/aviator/prescription
 
 /datum/gear/eyes/medical
-	display_name = "Medical HUD (Medical)"
+	display_name = "Medical HUD"
 	path = /obj/item/clothing/glasses/hud/health
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
 
 /datum/gear/eyes/medical/prescriptionmed
-	display_name = "Medical HUD, prescription (Medical)"
+	display_name = "Medical HUD, prescription"
 	path = /obj/item/clothing/glasses/hud/health/prescription
 
 /datum/gear/eyes/medical/aviator
-	display_name = "Medical HUD Aviators (Medical)"
+	display_name = "Medical HUD Aviators"
 	path = /obj/item/clothing/glasses/hud/health/aviator
 
 /datum/gear/eyes/medical/aviator/prescription
-	display_name = "Medical HUD Aviators, prescription (Medical)"
+	display_name = "Medical HUD Aviators, prescription"
 	path = /obj/item/clothing/glasses/hud/health/aviator/prescription
 
 /datum/gear/eyes/janitor
-	display_name = "Contaminant HUD (Janitor)"
+	display_name = "Contaminant HUD"
 	path = /obj/item/clothing/glasses/hud/janitor
 	allowed_roles = list("Janitor")
 
 /datum/gear/eyes/janitor/prescriptionjan
-	display_name = "Contaminant HUD, prescription (Janitor)"
+	display_name = "Contaminant HUD, prescription"
 	path = /obj/item/clothing/glasses/hud/janitor/prescription
 
 /datum/gear/eyes/meson
-	display_name = "Optical Meson Scanners (Engineering, Science, Mining)"
+	display_name = "Optical Meson Scanners"
 	path = /obj/item/clothing/glasses/meson
 	allowed_roles = list("Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director", "Shaft Miner")
 
 /datum/gear/eyes/meson/prescription
-	display_name = "Optical Meson Scanners, prescription (Engineering, Science, Mining)"
+	display_name = "Optical Meson Scanners, prescription"
 	path = /obj/item/clothing/glasses/meson/prescription
 
 /datum/gear/eyes/material
-	display_name = "Optical Material Scanners (Mining)"
+	display_name = "Optical Material Scanners"
 	path = /obj/item/clothing/glasses/material
 	allowed_roles = list("Shaft Miner","Quartermaster")
 
 /datum/gear/eyes/material/prescription
-	display_name = "Prescription Optical Material Scanners (Mining)"
+	display_name = "Prescription Optical Material Scanners"
 	path = /obj/item/clothing/glasses/material/prescription
 
 /datum/gear/eyes/meson/aviator
-	display_name = "Optical Meson Aviators, (Engineering, Science, Mining)"
+	display_name = "Optical Meson Aviators"
 	path = /obj/item/clothing/glasses/meson/aviator
 
 /datum/gear/eyes/meson/aviator/prescription
-	display_name = "Optical Meson Aviators, prescription (Engineering, Science, Mining)"
+	display_name = "Optical Meson Aviators, prescription"
 	path = /obj/item/clothing/glasses/meson/aviator/prescription
 
 /datum/gear/eyes/glasses/fakesun
@@ -149,16 +149,16 @@
 	path = /obj/item/clothing/glasses/fakesunglasses/aviator
 
 /datum/gear/eyes/sun
-	display_name = "Sunglasses (Security/Command)"
+	display_name = "sunglasses (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses
 	allowed_roles = list("Security Officer","Head of Security","Warden","Site Manager","Head of Personnel","Quartermaster","Internal Affairs Agent","Detective")
 
 /datum/gear/eyes/sun/shades
-	display_name = "Sunglasses, fat (Security/Command)"
+	display_name = "sunglasses, fat (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses/big
 
 /datum/gear/eyes/sun/aviators
-	display_name = "Sunglasses, aviators (Security/Command)"
+	display_name = "sunglasses, aviators (Security/Command)"
 	path = /obj/item/clothing/glasses/sunglasses/aviator
 
 /datum/gear/eyes/sun/prescriptionsun
@@ -170,17 +170,17 @@
 	path = /obj/item/clothing/glasses/circuitry
 
 /datum/gear/eyes/glasses/rimless
-	display_name = "Glasses, rimless"
+	display_name = "glasses, rimless"
 	path = /obj/item/clothing/glasses/rimless
 
 /datum/gear/eyes/glasses/prescriptionrimless
-	display_name = "Glasses, prescription rimless"
+	display_name = "glasses, prescription rimless"
 	path = /obj/item/clothing/glasses/regular/rimless
 
 /datum/gear/eyes/glasses/thin
-	display_name = "Glasses, thin frame"
+	display_name = "glasses, thin frame"
 	path = /obj/item/clothing/glasses/thin
 
 /datum/gear/eyes/glasses/prescriptionthin
-	display_name = "Glasses, prescription thin frame"
+	display_name = "glasses, prescription thin frame"
 	path = /obj/item/clothing/glasses/regular/thin

--- a/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
@@ -21,27 +21,27 @@
 	path = /obj/item/clothing/glasses/omnihud/prescription
 
 /datum/gear/eyes/arglasses/sec
-	display_name = "AR-S glasses (Sec)"
+	display_name = "AR-Security glasses"
 	path = /obj/item/clothing/glasses/omnihud/sec
 	allowed_roles = list("Security Officer","Head of Security","Warden","Detective")
 
 /datum/gear/eyes/arglasses/sci
-	display_name = "AR-R glasses (Sci)"
+	display_name = "AR-Research glasses"
 	path = /obj/item/clothing/glasses/omnihud/rnd
 	allowed_roles = list("Research Director","Scientist","Xenobiologist","Xenobotanist","Roboticist")
 
 /datum/gear/eyes/arglasses/eng
-	display_name = "AR-E glasses (Eng)"
+	display_name = "AR-Engineering glasses"
 	path = /obj/item/clothing/glasses/omnihud/eng
 	allowed_roles = list("Engineer","Chief Engineer","Atmospheric Technician")
 
 /datum/gear/eyes/arglasses/med
-	display_name = "AR-M glasses (Medical)"
+	display_name = "AR-Medical glasses"
 	path = /obj/item/clothing/glasses/omnihud/med
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
 
 /datum/gear/eyes/arglasses/all
-	display_name = "AR-B glasses (SM, HoP)"
+	display_name = "AR-Command glasses"
 	path = /obj/item/clothing/glasses/omnihud/all
 	cost = 2
 	allowed_roles = list("Site Manager","Head of Personnel")
@@ -55,7 +55,7 @@
 	path = /obj/item/clothing/glasses/fluff/science_proper
 
 /datum/gear/eyes/meson/retinal
-	display_name = "retinal projector, meson (Eng, Sci, Explo)"
+	display_name = "retinal projector, meson"
 	path = /obj/item/clothing/glasses/omnihud/eng/meson
 
 /datum/gear/eyes/security/secpatch
@@ -67,7 +67,7 @@
 	path = /obj/item/clothing/glasses/hud/security/eyepatch2
 
 /datum/gear/eyes/security/tac_sec_visor
-	display_name = "Tactical AR visor (Security)"
+	display_name = "Tactical AR visor"
 	path = /obj/item/clothing/glasses/sunglasses/sechud/tactical_sec_vis
 
 /datum/gear/eyes/medical/medpatch

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -10,15 +10,15 @@
 	ckeywhitelist = list("This entry should never be choosable with this variable set.") //If it does, then that means somebody fucked up the whitelist system pretty hard
 	character_name = list("This entry should never be choosable with this variable set.")
 	cost = 0
+
 /*
 /datum/gear/fluff/testhorn
 	path = /obj/item/weapon/bikehorn
 	display_name = "Airhorn - Example Item"
 	description = "An example item that you probably shouldn't see!"
-	ckeywhitelist = list("mewchild")
+	ckeywhitelist = list("your_ckey_here")
 	allowed_roles = list("Engineer")
 */
-
 
 /datum/gear/fluff/collar //Use this as a base path for collars if you'd like to set tags in loadout. Make sure you don't use apostrophes in the display name or this breaks!
 	slot = slot_tie

--- a/code/modules/client/preference_setup/loadout/loadout_gloves.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves.dm
@@ -52,7 +52,7 @@
 	cost = 3
 
 /datum/gear/gloves/forensic
-	display_name = "gloves, forensic (Detective)"
+	display_name = "gloves, forensic"
 	path = /obj/item/clothing/gloves/forensic
 	allowed_roles = list("Detective")
 

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -144,6 +144,7 @@
 	display_name = "labcoat selection, cmo"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/cmo
 	allowed_roles = list("Chief Medical Officer")
+	show_roles = FALSE
 
 /datum/gear/suit/labcoat_cmo/New()
 	..()
@@ -163,6 +164,7 @@
 	display_name = "labcoat, research director"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/rd
 	allowed_roles = list("Research Director")
+	show_roles = FALSE
 
 /datum/gear/suit/miscellaneous/labcoat
 	display_name = "plague doctor's coat"
@@ -254,42 +256,49 @@
 	display_name = "cloak, head of security"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/hos
 	allowed_roles = list("Head of Security")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_cmo
 	display_name = "cloak, chief medical officer"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/cmo
 	allowed_roles = list("Chief Medical Officer")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_ce
 	display_name = "cloak, chief engineer"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/ce
 	allowed_roles = list("Chief Engineer")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_rd
 	display_name = "cloak, research director"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/rd
 	allowed_roles = list("Research Director")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_qm
 	display_name = "cloak, quartermaster"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/qm
 	allowed_roles = list("Quartermaster")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_captain
 	display_name = "cloak, site manager"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/captain
 	allowed_roles = list("Site Manager")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/roles/cloak_hop
 	display_name = "cloak, head of personnel"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/hop
 	allowed_roles = list("Head of Personnel")
+	show_roles = FALSE
 	cost = 1
 
 /datum/gear/suit/cloak_custom //A colorable cloak
@@ -344,7 +353,7 @@
 	path = /obj/item/clothing/suit/suspenders
 
 /datum/gear/suit/forensics
-	display_name = "forensics uniform selection (Detective)"
+	display_name = "forensics uniform selection"
 	path = /obj/item/clothing/suit/storage/forensics/red/long
 	allowed_roles = list("Detective")
 
@@ -362,11 +371,13 @@
 	display_name = "coat, quartermaster"
 	path = /obj/item/clothing/suit/storage/qm
 	allowed_roles = list("Quartermaster")
+	show_roles = FALSE
 
 /datum/gear/suit/cargo_coat
 	display_name = "coat, cargo tech"
 	path = /obj/item/clothing/suit/storage/cargo
 	allowed_roles = list("Quartermaster","Shaft Miner","Cargo Technician","Head of Personnel")
+	show_roles = FALSE
 
 // winter coats go here
 /datum/gear/suit/wintercoat
@@ -377,116 +388,139 @@
 	display_name = "winter coat, site manager"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/captain
 	allowed_roles = list("Site Manager")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/hop
 	display_name = "winter coat, head of personnel"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hop
 	allowed_roles = list("Head of Personnel")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/security
 	display_name = "winter coat, security"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
 	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/security/hos
 	display_name = "winter coat, head of security"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security/hos
 	allowed_roles = list("Head of Security")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical
 	display_name = "winter coat, medical"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/alt
 	display_name = "winter coat, medical alt"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/alt
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/viro
 	display_name = "winter coat, virologist"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/viro
 	allowed_roles = list("Medical Doctor","Chief Medical Officer")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/para
 	display_name = "winter coat, paramedic"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/para
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/chemist
 	display_name = "winter coat, chemist"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/chemist
 	allowed_roles = list("Chief Medical Officer","Chemist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/cmo
 	display_name = "winter coat, chief medical officer"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/cmo
 	allowed_roles = list("Chief Medical Officer")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/medical/sar
 	display_name = "winter coat, search and rescue"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar
 	allowed_roles = list("Chief Medical Officer","Paramedic")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
 	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist", "Xenobotanist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/science/robotics
 	display_name = "winter coat, robotics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science/robotics
 	allowed_roles = list("Research Director", "Roboticist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/science/rd
 	display_name = "winter coat, research director"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science/rd
 	allowed_roles = list("Research Director")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/engineering
 	display_name = "winter coat, engineering"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
 	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Engineer")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/engineering/atmos
 	display_name = "winter coat, atmospherics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
 	allowed_roles = list("Chief Engineer", "Atmospheric Technician")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/engineering/ce
 	display_name = "winter coat, chief engineer"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/ce
 	allowed_roles = list("Chief Engineer")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/hydro
 	display_name = "winter coat, hydroponics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
 	allowed_roles = list("Botanist", "Xenobotanist")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/cargo
 	display_name = "winter coat, cargo"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo
 	allowed_roles = list("Quartermaster","Cargo Technician")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/miner
 	display_name = "winter coat, mining"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
 	allowed_roles = list("Shaft Miner")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/cargo/qm
 	display_name = "winter coat, quartermaster"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/cargo/qm
 	allowed_roles = list("Quartermaster")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/bar
 	display_name = "winter coat, bartender"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/bar
 	allowed_roles = list("Bartender")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/janitor
 	display_name = "winter coat, janitor"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/janitor
 	allowed_roles = list("Janitor")
+	show_roles = FALSE
 
 /datum/gear/suit/wintercoat/aformal
 	display_name = "winter coat, assistant formal"
@@ -613,31 +647,37 @@
 	display_name = "snowsuit, command"
 	path = /obj/item/clothing/suit/storage/snowsuit/command
 	allowed_roles = list("Site Manager","Research Director","Head of Personnel","Head of Security","Chief Engineer","Command Secretary")
+	show_roles = FALSE
 
 /datum/gear/suit/snowsuit/security
 	display_name = "snowsuit, security"
 	path = /obj/item/clothing/suit/storage/snowsuit/security
 	allowed_roles = list("Security Officer", "Head of Security", "Warden", "Detective")
+	show_roles = FALSE
 
 /datum/gear/suit/snowsuit/medical
 	display_name = "snowsuit, medical"
 	path = /obj/item/clothing/suit/storage/snowsuit/medical
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
+	show_roles = FALSE
 
 /datum/gear/suit/snowsuit/science
 	display_name = "snowsuit, science"
 	path = /obj/item/clothing/suit/storage/snowsuit/science
 	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	show_roles = FALSE
 
 /datum/gear/suit/snowsuit/engineering
 	display_name = "snowsuit, engineering"
 	path = /obj/item/clothing/suit/storage/snowsuit/engineering
 	allowed_roles = list("Chief Engineer","Atmospheric Technician", "Engineer")
+	show_roles = FALSE
 
 /datum/gear/suit/snowsuit/cargo
 	display_name = "snowsuit, supply"
 	path = /obj/item/clothing/suit/storage/snowsuit/cargo
 	allowed_roles = list("Quartermaster","Shaft Miner","Cargo Technician","Head of Personnel")
+	show_roles = FALSE
 
 /datum/gear/suit/miscellaneous/cardigan
 	display_name = "cardigan, colorable"
@@ -651,6 +691,7 @@
 	display_name = "command dress jacket"
 	path = /obj/item/clothing/suit/storage/toggle/cmddressjacket
 	allowed_roles = list("Site Manager", "Head of Personnel", "Command Secretary")
+	show_roles = FALSE
 
 /datum/gear/suit/miscellaneous/kimono
 	display_name = "traditional kimono, colorable"

--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -55,7 +55,7 @@
 
 //Detective alternative
 /datum/gear/suit/detective_alt
-	display_name = "sleek modern coat selection, detective"
+	display_name = "sleek modern coat selection"
 	path = /obj/item/clothing/suit/storage/det_trench/alt
 	allowed_roles = list("Head of Security", "Detective")
 
@@ -112,7 +112,7 @@ Talon winter coat
 /datum/gear/suit/armor/combat/crusader_explo
 	display_name = "knight, explo"
 	path = /obj/item/clothing/suit/armor/combat/crusader_explo
-	allowed_roles = list("Explorer","Pathfinder")
+	//allowed_roles = list("Explorer","Pathfinder")
 
 /datum/gear/suit/armor/combat/crusader_explo/FM
 	display_name = "knight, Field Medic"
@@ -232,11 +232,13 @@ Talon winter coat
 	display_name = "boat cloak, site manager"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/boat/cap
 	allowed_roles = list("Site Manager")
+	show_roles = FALSE
 
 /datum/gear/suit/roles/hopboatcloak
 	display_name = "boat cloak, head of personnel"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/boat/hop
 	allowed_roles = list("Head of Personnel")
+	show_roles = FALSE
 
 /datum/gear/suit/roles/boatcloaks
 	display_name = "boat cloak selection"
@@ -268,11 +270,13 @@ Talon winter coat
 	display_name = "shroud, site manager"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/shroud/cap
 	allowed_roles = list("Site Manager")
+	show_roles = FALSE
 
 /datum/gear/suit/roles/hopshroud
 	display_name = "shroud, head of personnel"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/shroud/hop
 	allowed_roles = list("Head of Personnel")
+	show_roles = FALSE
 
 /datum/gear/suit/roles/shrouds
 	display_name = "shroud selection"

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -5,6 +5,7 @@
 	display_name = "DEPT - BLANK's Uniforms"
 	description = "Select from a range of outfits available to all BLANK personnel."
 	allowed_roles = list("")
+	show_roles = FALSE
 	path =
 	slot = slot_w_uniform
 	sort_category = "Uniforms"
@@ -23,6 +24,7 @@
 	display_name = "Command - Site Manager's Uniforms"
 	description = "Select from a range of outfits available to all Site Managers."
 	allowed_roles = list("Site Manager")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_captain
 	sort_category = "Uniforms"
 	cost = 1
@@ -52,6 +54,7 @@
 	display_name = "Command - Head of Personnel's Uniforms"
 	description = "Select from a range of outfits available to all Heads of Personnel."
 	allowed_roles = list("Head of Personnel")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_hop
 	sort_category = "Uniforms"
 	cost = 1
@@ -83,6 +86,7 @@
 	display_name = "Civilian - Pilot's Uniforms"
 	description = "Select from a range of outfits available to all Pilots."
 	allowed_roles = list("Pilot")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_pilot
 	sort_category = "Uniforms"
 	cost = 1
@@ -101,6 +105,7 @@
 	display_name = "Civilian - Janitor's Uniforms"
 	description = "Select from a range of outfits available to all Janitorial personnel."
 	allowed_roles = list("Janitor")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_janitor
 	sort_category = "Uniforms"
 	cost = 1
@@ -184,6 +189,7 @@
 	display_name = "Security - Basic Uniforms"
 	description = "Select from a range of outfits available to all Security personnel."
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/security/corp
 	sort_category = "Uniforms"
 	cost = 1
@@ -229,6 +235,7 @@
 	display_name = "Security - Warden's Uniforms"
 	description = "Select from a range of outfits available to Wardens."
 	allowed_roles = list("Head of Security","Warden")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/warden/corp
 	sort_category = "Uniforms"
 	cost = 1
@@ -250,6 +257,7 @@
 	display_name = "Security - Detective's Uniforms"
 	description = "Select from a range of outfits available to all Detectives."
 	allowed_roles = list("Head of Security","Detective")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/det/corporate
 	sort_category = "Uniforms"
 	cost = 1
@@ -266,6 +274,7 @@
 	display_name = "Security - Head's Uniforms"
 	description = "Select from a range of outfits available to all Heads of Security."
 	allowed_roles = list("Head of Security")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/head_of_security/corp
 	sort_category = "Uniforms"
 	cost = 1
@@ -305,6 +314,7 @@
 	display_name = "Cargo - Quartermaster's Uniforms"
 	description = "Select from a range of outfits available to all Quartermasters."
 	allowed_roles = list("Quartermaster")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/cargo/jeans
 	sort_category = "Uniforms"
 	cost = 1
@@ -336,6 +346,7 @@
 	display_name = "Cargo - Basic Uniforms"
 	description = "Select from a range of outfits available to all Cargo personnel."
 	allowed_roles = list("Cargo Technician","Shaft Miner","Quartermaster")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/cargotech/jeans
 	sort_category = "Uniforms"
 	cost = 1
@@ -364,6 +375,7 @@
 	display_name = "Cargo - Miner's Uniforms"
 	description = "Select from a range of outfits available to all Mining personnel."
 	allowed_roles = list("Shaft Miner","Quartermaster")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_miner
 	sort_category = "Uniforms"
 	cost = 1
@@ -382,6 +394,7 @@
 	display_name = "Engineering - Chief Engineer's Uniforms"
 	description = "Select from a range of outfits available to all Chief Engineers."
 	allowed_roles = list("Chief Engineer")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_chiefengi
 	sort_category = "Uniforms"
 	cost = 1
@@ -406,6 +419,7 @@
 	display_name = "Engineering - Basic Uniforms"
 	description = "Select from a range of outfits available to all Engineering personnel."
 	allowed_roles = list("Chief Engineer","Engineer","Atmospheric Technician")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_engi
 	sort_category = "Uniforms"
 	cost = 1
@@ -433,6 +447,7 @@
 	display_name = "Engineering - Atmos Tech's Uniforms"
 	description = "Select from a range of outfits available to all Atmospherics Technicians."
 	allowed_roles = list("Chief Engineer","Atmospheric Technician")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
 	sort_category = "Uniforms"
 	cost = 1
@@ -452,6 +467,7 @@
 	display_name = "Medical - Basic Uniforms"
 	description = "Select from a range of outfits available to all Medical personnel."
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_med
 	sort_category = "Uniforms"
 	cost = 1
@@ -484,6 +500,7 @@
 	display_name = "Medical - Chemist's Uniforms"
 	description = "Select from a range of outfits available to all Chemists."
 	allowed_roles = list("Chief Medical Officer","Chemist")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_chem
 	sort_category = "Uniforms"
 	cost = 1
@@ -503,6 +520,7 @@
 	display_name = "Medical - Paramedic's Uniforms"
 	description = "Select from a range of outfits available to all Paramedics."
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/paramedunidark
 	sort_category = "Uniforms"
 	cost = 1
@@ -525,6 +543,7 @@
 	display_name = "Medical - Chief Medical Officer's Uniforms"
 	description = "Select from a range of outfits available to all Chief Medical Officers."
 	allowed_roles = list("Chief Medical Officer")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_cmo
 	sort_category = "Uniforms"
 	cost = 2
@@ -553,6 +572,7 @@
 	display_name = "Science - Research Director's Uniforms"
 	description = "Select from a range of outfits available to all Research Directors."
 	allowed_roles = list("Research Director")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_rd_suit
 	sort_category = "Uniforms"
 	cost = 1
@@ -578,6 +598,7 @@
 	display_name = "Science - Basic Uniforms"
 	description = "Select from a range of outfits available to all Science personnel."
 	allowed_roles = list("Scientist","Research Director","Roboticist","Xenobiologist","Xenobotanist")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_science
 	sort_category = "Uniforms"
 	cost = 1
@@ -602,6 +623,7 @@
 	display_name = "Science - Roboticist's Uniforms"
 	description = "Select from a range of outfits available to all Roboticists."
 	allowed_roles = list("Research Director","Roboticist")
+	show_roles = FALSE
 	path = /obj/item/clothing/under/rank/neo_robo
 	sort_category = "Uniforms"
 	cost = 1

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -554,16 +554,19 @@
 	display_name = "warden belted cloak (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/wrdn
 	allowed_roles = list("Head of Security","Warden")
+	sort_category = "Xenowear"
 
 /datum/gear/suit/dept/beltcloak/jani
 	display_name = "janitor belted cloak (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/jani
 	allowed_roles = list("Janitor")
+	sort_category = "Xenowear"
 
 /datum/gear/suit/dept/beltcloak/cmd
 	display_name = "command belted cloak (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/beltcloak/jobs/command
 	allowed_roles = list("Site Manager","Head of Personnel","Head of Security","Chief Engineer","Chief Medical Officer","Research Director")
+	sort_category = "Xenowear"
 
 /datum/gear/suit/cloak_hood
 	display_name = "hooded cloak selection (Teshari)"


### PR DESCRIPTION
Adds a small inset below most items that specify what jobs they're restricted to, if any restrictions are present. Certain items do not show their restrictions if it's obvious from the item name or description (e.g. security uniforms are for security only).

This isn't quite as fancy as the other implementation I saw where the job name text will turn red/green depending on your currently selected jobs to let you know if a job is allowing or preventing taking a certain item, but I feel like it's better than adding `(Eng, Sec, etc.)` to the end of item names/descriptions.

:cl:
add: loadout items now show what jobs they're restricted to/enabled by
fix: fixed a couple of teshi belted cloaks being under general outerwear rather than in xenowear
/:cl: