### PR TITLE
Choose to rest left or right

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -32,6 +32,8 @@
 	var/active_regen_delay = 300
 	var/list/teleporters = list() //Used for lleill abilities
 
+	var/rest_dir = 0					//To lay down in a specific direction
+
 /mob/living/carbon/human/Initialize(mapload, var/new_species = null)
 	if(!dna)
 		dna = new /datum/dna(null)
@@ -1805,3 +1807,19 @@
 	vore_fullness = min(vore_capacity, vore_fullness)
 	update_vore_belly_sprite()
 	update_vore_tail_sprite()
+
+/mob/living/carbon/human/verb/lay_down_left()
+	set name = "Rest-Left"
+
+	rest_dir = -1
+	resting = !resting
+	to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+	update_canmove()
+
+/mob/living/carbon/human/verb/lay_down_right()
+	set name = "Rest-Right"
+
+	rest_dir = 1
+	resting = !resting
+	to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+	update_canmove()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -161,11 +161,19 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			update_tail_showing()
 			M.Scale(desired_scale_x, desired_scale_y)
 		else
-			var/randn = rand(1, 2)
-			if(randn <= 1) // randomly choose a rotation
-				M.Turn(-90)
+			if(rest_dir)
+				if(rest_dir < 0)
+					M.Turn(-90)
+					rest_dir = 0
+				else
+					M.Turn(90)
+					rest_dir = 0
 			else
-				M.Turn(90)
+				var/randn = rand(1, 2)
+				if(randn <= 1) // randomly choose a rotation
+					M.Turn(-90)
+				else
+					M.Turn(90)
 			if(species.icon_height == 64)
 				M.Translate(13,-22)
 			else

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -721,6 +721,12 @@ macro "hotkeymode"
 		name = "U"
 		command = "Rest"
 	elem
+		name = "SHIFT+U"
+		command = "Rest-Left"
+	elem
+		name = "CTRL+U"
+		command = "Rest-Right"
+	elem
 		name = "B"
 		command = "Resist"
 	elem


### PR DESCRIPTION
Added new hotkey mode combinations for resting. Ctrl+U now always rests to the right, whilst Shift+U always rests to the left. These can also be used with the Rest-Left and Rest-Right verbs in the command bar.