### PR TITLE
Fixes teshari stomachs & Unathi Stomachs

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1290,6 +1290,7 @@
 			vessel.maximum_volume = species.blood_volume
 		fixblood()
 		species.update_attack_types() //VOREStation Edit - Required for any trait that updates unarmed_types in setup.
+		species.update_vore_belly_def_variant()
 
 	// Rebuild the HUD. If they aren't logged in then login() should reinstantiate it for them.
 	update_hud()

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -45,6 +45,9 @@
 	var/list/food_preference = list() //RS edit
 	var/food_preference_bonus = 0
 
+/datum/species/unathi
+	vore_belly_default_variant = "L"
+
 /datum/species/proc/give_numbing_bite() //Holy SHIT this is hacky, but it works. Updating a mob's attacks mid game is insane.
 	unarmed_attacks = list()
 	unarmed_types += /datum/unarmed_attack/bite/sharp/numbing
@@ -114,3 +117,11 @@
 
 /datum/species/get_bodytype()
 	return base_species
+
+/datum/species/proc/update_vore_belly_def_variant()
+	// Determine the actual vore_belly_default_variant, if the base species in the VORE tab is set
+	switch (base_species)
+		if("Teshari")
+			vore_belly_default_variant = "T"
+		if("Unathi")
+			vore_belly_default_variant = "L"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -148,6 +148,7 @@
 	revive()
 	mutations.Remove(HUSK)
 	setBrainLoss(braindamage)
+	species.update_vore_belly_def_variant()
 
 	if(!uninjured)
 		nutrition = old_nutrition * 0.5

--- a/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
@@ -17,6 +17,8 @@
 	male_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
 	female_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
 
+	vore_belly_default_variant = "T" //Teshari belly sprite
+
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/proc/hide,


### PR DESCRIPTION
- Makes Teshari stomachs show up properly.
- Makes Unathi stomachs show up properly.

I failed to notice a few lines of code from when I was porting tummies from RS.

Also ports over a few of CS's stomach fixes pertaining to stomach sprites.