### PR TITLE
Helmet Cams on Networks

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -9,6 +9,7 @@
 	min_pressure_protection = 0  * ONE_ATMOSPHERE
 	max_pressure_protection = 15 * ONE_ATMOSPHERE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE+5000
+	camera_networks = list(NETWORK_ENGINEERING)
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
@@ -110,6 +111,7 @@
 	item_state_slots = list(slot_r_hand_str = "mining_helm", slot_l_hand_str = "mining_helm")
 	armor = list(melee = 50, bullet = 15, laser = 25, energy = 15, bomb = 55, bio = 100, rad = 50)
 	light_overlay = "helmet_light_dual"
+	camera_networks = list(NETWORK_CARGO)
 
 /obj/item/clothing/suit/space/void/mining
 	name = "mining voidsuit"
@@ -142,6 +144,7 @@
 	icon_state = "rig0-medical"
 	item_state_slots = list(slot_r_hand_str = "medical_helm", slot_l_hand_str = "medical_helm")
 	armor = list(melee = 30, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 80)
+	camera_networks = list(NETWORK_MEDICAL)
 
 /obj/item/clothing/suit/space/void/medical
 	name = "medical voidsuit"
@@ -274,6 +277,7 @@
 	armor = list(melee = 50, bullet = 25, laser = 25, energy = 15, bomb = 45, bio = 100, rad = 10)
 	siemens_coefficient = 0.7
 	light_overlay = "helmet_light_dual"
+	camera_networks = list(NETWORK_SECURITY)
 
 /obj/item/clothing/suit/space/void/security
 	name = "security voidsuit"
@@ -333,6 +337,7 @@
 	light_overlay = "helmet_light_dual"
 	min_pressure_protection = 0 * ONE_ATMOSPHERE
 	max_pressure_protection = 20* ONE_ATMOSPHERE
+	camera_networks = list(NETWORK_ENGINEERING)
 
 /obj/item/clothing/suit/space/void/atmos
 	name = "atmos voidsuit"
@@ -371,6 +376,7 @@
 	item_state_slots = list(slot_r_hand_str = "syndicate-helm-black", slot_l_hand_str = "syndicate-helm-black")
 	armor = list(melee = 50, bullet = 15, laser = 35, energy = 25, bomb = 30, bio = 100, rad = 70)
 	light_overlay = "helmet_light_dual" //explorer_light
+	camera_networks = list(NETWORK_EXPLORATION)
 
 /obj/item/clothing/suit/space/void/exploration
 	name = "exploration voidsuit"
@@ -426,6 +432,7 @@
 	item_state_slots = list(slot_r_hand_str = "atmos_helm", slot_l_hand_str = "atmos_helm")
 	armor = list(melee = 40, bullet = 10, laser = 25, energy = 15, bomb = 25, bio = 100, rad = 60)
 	light_overlay = "helmet_light_dual"
+	camera_networks = list(NETWORK_CIVILIAN)
 
 /obj/item/clothing/suit/space/void/pilot
 	desc = "An atmos resistant voidsuit for space and planet exploration."

--- a/code/modules/clothing/spacesuits/void/station_vr.dm
+++ b/code/modules/clothing/spacesuits/void/station_vr.dm
@@ -51,7 +51,7 @@
 // Alt mining voidsuit
 /obj/item/clothing/suit/space/void/mining/alt2
 	desc = "A surplus Commonwealth mining voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_mining_bay"
@@ -59,10 +59,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0
-	
+
 /obj/item/clothing/head/helmet/space/void/mining/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_mining_bay"
@@ -73,7 +73,7 @@
 // Alt anomaly/excavation suit
 /obj/item/clothing/suit/space/anomaly/alt
 	desc = "A surplus Commonwealth anomaly suit! Slightly more comfortable and easier to move in than your average anomaly suit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_excavation_bay"
@@ -81,21 +81,22 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0.5
-	
+
 /obj/item/clothing/head/helmet/space/anomaly/alt
 	desc = "A surplus Commonwealth helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_excavation_bay"
 	item_state = null
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_HEAD_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_HEAD_ITEM
+	camera_networks = list(NETWORK_RESEARCH)
 
 // Alt riot suit
 /obj/item/clothing/suit/space/void/security/riot/alt
 	desc = "A surplus Commonwealth riot control voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_secalt_bay"
@@ -103,10 +104,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0.5
-	
+
 /obj/item/clothing/head/helmet/space/void/security/riot/alt
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_secalt_bay"
@@ -117,7 +118,7 @@
 // Alt pilot suit
 /obj/item/clothing/suit/space/void/pilot/alt2
 	desc = "A surplus Commonwealth pilot voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_pilot_bay"
@@ -125,10 +126,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0
-	
+
 /obj/item/clothing/head/helmet/space/void/pilot/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_pilot_bay"
@@ -139,7 +140,7 @@
 // Alt medical/emt suit
 /obj/item/clothing/suit/space/void/medical/alt2
 	desc = "A surplus Commonwealth medical voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_medicalalt_bay"
@@ -147,10 +148,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0
-	
+
 /obj/item/clothing/head/helmet/space/void/medical/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_medicalalt_bay"
@@ -161,7 +162,7 @@
 // Alt explorer suit
 /obj/item/clothing/suit/space/void/exploration/alt2
 	desc = "A surplus Commonwealth exploration voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_explorer_bay"
@@ -169,10 +170,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0
-	
+
 /obj/item/clothing/head/helmet/space/void/exploration/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_explorer_bay"
@@ -183,7 +184,7 @@
 // Alt engineering voidsuit
 /obj/item/clothing/suit/space/void/engineering/alt2
 	desc = "A surplus Commonwealth engineering voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_engineeringalt_bay"
@@ -191,10 +192,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0.5
-	
+
 /obj/item/clothing/head/helmet/space/void/engineering/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_engineeringalt_bay"
@@ -205,7 +206,7 @@
 // Alt atmos voidsuit
 /obj/item/clothing/suit/space/void/atmos/alt2
 	desc = "A surplus Commonwealth atmospherics voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_atmosalt_bay"
@@ -213,10 +214,10 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 0.5
-	
+
 /obj/item/clothing/head/helmet/space/void/atmos/alt2
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_atmosalt_bay"
@@ -227,7 +228,7 @@
 // Alt command voidsuit
 /obj/item/clothing/suit/space/void/captain/alt
 	desc = "A surplus Commonwealth Navy captain voidsuit! Slightly more comfortable and easier to move in than your average voidsuit."
-	
+
 	icon = 'icons/inventory/suit/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/suit/mob_vr.dmi'
 	icon_state = "void_command_bay"
@@ -235,13 +236,14 @@
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_SUIT_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_SUIT_ITEM
 	slowdown = 1.0
-	
+
 /obj/item/clothing/head/helmet/space/void/captain/alt
 	desc = "A surplus Commonwealth voidsuit helmet. Seems more fancy than what's usually found on the frontier."
-	
+
 	icon = 'icons/inventory/head/item_vr.dmi'
 	default_worn_icon = 'icons/inventory/head/mob_vr.dmi'
 	icon_state = "void_command_bay"
 	item_state = null
 	sprite_sheets = ALL_VR_SPRITE_SHEETS_HEAD_MOB
 	sprite_sheets_obj = ALL_VR_SPRITE_SHEETS_HEAD_ITEM
+	camera_networks = list(NETWORK_COMMAND)


### PR DESCRIPTION
Helmet cameras are an underused but really neat feature, so this just goes through and adds default networks to some default station voidsuit sets and their derivatives.

This doesn't change any other functions for them, and they remain an 'opt in' function that can be toggled off again at any time. I might poke at them later to see if I can make it remove them from the networks properly when they're toggled off.

Might also see about some custom camera helmets for the laserdome at some point too.

:cl:
tweak - added the (opt-in) helmet cameras for station voidsuit helmets to appropriate networks
/:cl: