### PR TITLE
allows cyborg glass recyclers to refill lightreplacers

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -64,7 +64,7 @@
 		. += "It has [uses] lights remaining."
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "glass")
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == "glass" || istype(W, /obj/item/stack/material/cyborg/glass))
 		var/obj/item/stack/G = W
 		if(uses >= max_uses)
 			to_chat(user, "<span class='warning'>[src.name] is full.</span>")


### PR DESCRIPTION
It can be tedious to sit in the charger and wait for the light replacer to refill and the recycled glass so far couldn't be used, even so the unit can gather glass with the compactor.

🆑 Upstream
qol: Allows the cyborg glass recycler to refill the light replacer
/🆑 