### PR TITLE
edits some no_vore usage

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -563,9 +563,7 @@
 	return ..()
 
 /mob/living/bot/Logout()
-	no_vore = TRUE // ROBOT VORE
 	release_vore_contents()
-	init_vore() // ROBOT VORE
 	verbs -= /mob/proc/insidePanel
 	no_vore = TRUE
 	devourable = FALSE

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -82,8 +82,8 @@
 
 /mob/living/init_vore()
 	if(no_vore)
-		return
-	..()
+		return FALSE
+	return ..()
 
 //
 // Hide vore organs in contents

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -45,7 +45,7 @@
 /hook/living_new/proc/vore_setup(mob/living/M)
 	//Tries to load prefs if a client is present otherwise gives freebie stomach
 	spawn(2 SECONDS)
-		if(M)
+		if(!QDELETED(M))
 			M.init_vore()
 
 	//return TRUE to hook-caller

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -52,6 +52,9 @@
 	return TRUE
 
 /mob/proc/init_vore()
+	if(no_vore)
+		return FALSE
+
 	//Something else made organs, meanwhile.
 	if(LAZYLEN(vore_organs))
 		return TRUE

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -52,9 +52,6 @@
 	return TRUE
 
 /mob/proc/init_vore()
-	if(no_vore)
-		return FALSE
-
 	//Something else made organs, meanwhile.
 	if(LAZYLEN(vore_organs))
 		return TRUE
@@ -82,6 +79,11 @@
 			if(istype(H.species,/datum/species/monkey))
 				allow_spontaneous_tf = TRUE
 		return TRUE
+
+/mob/living/init_vore()
+	if(no_vore)
+		return
+	..()
 
 //
 // Hide vore organs in contents


### PR DESCRIPTION
makes no sense to init on no_vore or to re init on bots on logout when they are not meant to have vore without clients.

🆑 Upstream
code: removes some unnecessary lines and returns the init_vore proc on no_vore
/🆑 