### PR TITLE
allows to disable sliders again

### DIFF
--- a/tgui/packages/tgui/components/Slider.tsx
+++ b/tgui/packages/tgui/components/Slider.tsx
@@ -19,6 +19,8 @@ type Props = {
   /** Value itself, controls the position of the cursor. */
   value: number;
 } & Partial<{
+  /** Allows to disable the slider */
+  disabled: boolean;
   /** Animates the value if it was changed externally. */
   animated: boolean;
   /** Custom css */


### PR DESCRIPTION
No bundle needed as we only touch the props.

Allows to disable the slider element again.

can be closed downstream, already fixed for us.