### PR TITLE
Xenoarch effects were editing the reference list

### DIFF
--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -11,11 +11,15 @@
 		AddComponent(/datum/component/artifact_master)
 		if(istype(src, /obj/item))
 			var/obj/item/I = src
-			LAZYINITLIST(I.origin_tech)
-			if(prob(50))
-				I.origin_tech[TECH_PRECURSOR] += 1
+			var/list/new_tech
+			if(I.origin_tech)
+				new_tech = origin_tech.Copy()
 			else
-				I.origin_tech[TECH_ARCANE] += 1
+				new_tech = list()
+			if(prob(50))
+				new_tech[TECH_PRECURSOR] += 1
+			else
+				new_tech[TECH_ARCANE] += 1
 			var/rand_tech = pick(\
 				TECH_MATERIAL,\
 				TECH_ENGINEERING,\
@@ -28,7 +32,8 @@
 				TECH_DATA,\
 				TECH_ILLEGAL\
 				)
-			LAZYSET(I.origin_tech, rand_tech, rand(4,7))
+			LAZYSET(new_tech, rand_tech, rand(4,7))
+			I.origin_tech = new_tech
 
 /datum/component/artifact_master
 	var/atom/holder

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -13,7 +13,7 @@
 			var/obj/item/I = src
 			var/list/new_tech
 			if(I.origin_tech)
-				new_tech = origin_tech.Copy()
+				new_tech = I.origin_tech.Copy()
 			else
 				new_tech = list()
 			if(prob(50))

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -687,9 +687,14 @@
 
 		if(talkative)
 			new_item.talking_atom = new(new_item)
-			LAZYINITLIST(new_item.origin_tech)
-			new_item.origin_tech[TECH_ARCANE] += 1
-			new_item.origin_tech[TECH_PRECURSOR] += 1
+			var/list/new_tech
+			if(new_item.origin_tech)
+				new_tech = new_item.origin_tech.Copy()
+			else
+				new_tech = list()
+			new_tech[TECH_ARCANE] += 1
+			new_tech[TECH_PRECURSOR] += 1
+			new_item.origin_tech = new_tech
 
 		if(become_anomalous)
 			new_item.become_anomalous()
@@ -702,9 +707,14 @@
 
 	else if(talkative)
 		src.talking_atom = new(src)
-		LAZYINITLIST(origin_tech)
-		origin_tech[TECH_ARCANE] += 1
-		origin_tech[TECH_PRECURSOR] += 1
+		var/list/new_tech
+		if(origin_tech)
+			new_tech = origin_tech.Copy()
+		else
+			new_tech = list()
+		new_tech[TECH_ARCANE] += 1
+		new_tech[TECH_PRECURSOR] += 1
+		origin_tech = new_tech
 
 	if(become_anomalous)
 		become_anomalous()


### PR DESCRIPTION
The xenoarch effects were editing the reference of the original tech list, adding the new parameters to all global objects!

🆑 Upstream
fix: xenoarch tech_level effects affecting all objects of the same type at once
/🆑 