### PR TITLE
Ship Transponder Flip

### DIFF
--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -20,7 +20,7 @@
 
 	unknown_name = "unknown ship"
 	unknown_state = "ship"
-	known = FALSE // Ships start 'unknown' on the map and require scanning
+	known = TRUE // Ships start known by default because most of them should be transmitting ID codes at all times
 
 	var/vessel_mass = 10000             //tonnes, arbitrary number, affects acceleration provided by engines
 	var/vessel_size = SHIP_SIZE_LARGE	//arbitrary number, affects how likely are we to evade meteors

--- a/maps/offmap_vr/om_ships/geckos.dm
+++ b/maps/offmap_vr/om_ships/geckos.dm
@@ -24,7 +24,7 @@
 	annihilate = TRUE
 
 // The shuttle's area(s)
-/area/shuttle/gecko_sh	
+/area/shuttle/gecko_sh
 	name = "\improper Gecko Stationhopper"
 	icon_state = "green"
 	requires_power = 1
@@ -42,7 +42,7 @@
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/gecko_cr	
+/area/shuttle/gecko_cr
 	name = "\improper Gecko Cargo Hauler Bay"
 	icon_state = "green"
 	requires_power = 1
@@ -60,7 +60,7 @@
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/gecko_cr_wreck	
+/area/shuttle/gecko_cr_wreck
 	name = "\improper Wrecked Gecko Cargo Hauler Bay"
 	icon_state = "green"
 	requires_power = 1
@@ -174,3 +174,4 @@
 	vessel_mass = 6500
 	vessel_size = SHIP_SIZE_LARGE
 	shuttle = "Wrecked Gecko Cargo Hauler"
+	known = FALSE

--- a/maps/offmap_vr/om_ships/mackerels.dm
+++ b/maps/offmap_vr/om_ships/mackerels.dm
@@ -39,43 +39,43 @@
 	annihilate = TRUE
 
 // The shuttle's area(s)
-/area/shuttle/mackerel_sh	
+/area/shuttle/mackerel_sh
 	name = "\improper Mackerel Stationhopper"
 	icon_state = "green"
 	requires_power = 1
 	has_gravity = 0
-	
-/area/shuttle/mackerel_lc	
+
+/area/shuttle/mackerel_lc
 	name = "\improper Mackerel Light Cargo"
 	icon_state = "green"
 	requires_power = 1
 	has_gravity = 0
-	
-/area/shuttle/mackerel_hc	
+
+/area/shuttle/mackerel_hc
 	name = "\improper Mackerel Heavy Cargo"
 	icon_state = "green"
 	requires_power = 1
 	has_gravity = 0
-	
-/area/shuttle/mackerel_hc_skel	
+
+/area/shuttle/mackerel_hc_skel
 	name = "\improper Mackerel Heavy Cargo Spartan"
 	icon_state = "green"
 	requires_power = 1
 	has_gravity = 0
-	
+
 /area/shuttle/mackerel_hc_skel_cockpit
 	name = "\improper Mackerel Heavy Cargo Cockpit"
 	icon_state = "purple"
 	requires_power = 1
 	has_gravity = 0
-	
+
 /area/shuttle/mackerel_hc_skel_eng
 	name = "\improper Mackerel Heavy Cargo Engineering"
 	icon_state = "yellow"
 	requires_power = 1
 	has_gravity = 0
-	
-/area/shuttle/mackerel_lc_wreck	
+
+/area/shuttle/mackerel_lc_wreck
 	name = "\improper Wrecked Mackerel Light Cargo"
 	icon_state = "green"
 	requires_power = 1
@@ -239,3 +239,4 @@
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "Mackerel Light Cargo II"
+	known = FALSE

--- a/maps/offmap_vr/om_ships/mercship.dm
+++ b/maps/offmap_vr/om_ships/mercship.dm
@@ -74,6 +74,7 @@
 	vessel_size = SHIP_SIZE_SMALL
 	initial_generic_waypoints = list("carrier_fore", "carrier_aft", "carrier_port", "carrier_starboard", "base_dock")
 	initial_restricted_waypoints = list("Carrier's Ship's Boat" = list("omship_spawn_mercboat"))
+	known = FALSE
 
 	unowned_areas = list(/area/shuttle/mercboat)
 

--- a/maps/offmap_vr/om_ships/salamander.dm
+++ b/maps/offmap_vr/om_ships/salamander.dm
@@ -18,7 +18,7 @@
 	annihilate = TRUE
 
 // The shuttle's area(s)
-/area/shuttle/salamander	
+/area/shuttle/salamander
 	name = "\improper Salamander Cabin"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray"
@@ -39,35 +39,35 @@
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_q1	
+/area/shuttle/salamander_q1
 	name = "\improper Salamander Quarters 1"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray-p"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_q2	
+/area/shuttle/salamander_q2
 	name = "\improper Salamander Quarters 2"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray-s"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_galley	
+/area/shuttle/salamander_galley
 	name = "\improper Salamander Galley"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "dark-s"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_head	
+/area/shuttle/salamander_head
 	name = "\improper Salamander Head"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "dark-p"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_wreck	
+/area/shuttle/salamander_wreck
 	name = "\improper Wrecked Salamander Cabin"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray"
@@ -88,28 +88,28 @@
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_wreck_q1	
+/area/shuttle/salamander_wreck_q1
 	name = "\improper Wrecked Salamander Quarters 1"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray-p"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_wreck_q2	
+/area/shuttle/salamander_wreck_q2
 	name = "\improper Wrecked Salamander Quarters 2"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "gray-s"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_wreck_galley	
+/area/shuttle/salamander_wreck_galley
 	name = "\improper Wrecked Salamander Galley"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "dark-s"
 	requires_power = 1
 	has_gravity = 0
 
-/area/shuttle/salamander_wreck_head	
+/area/shuttle/salamander_wreck_head
 	name = "\improper Wrecked Salamander Head"
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "dark-p"
@@ -187,6 +187,7 @@
 	vessel_size = SHIP_SIZE_LARGE
 	fore_dir = EAST
 	shuttle = "Salamander Wreckage"
+	known = FALSE
 
 /obj/item/weapon/paper/unity_notice
 	name = "hastily-scrawled missive"

--- a/maps/offmap_vr/om_ships/sdf_corvettes.dm
+++ b/maps/offmap_vr/om_ships/sdf_corvettes.dm
@@ -129,6 +129,7 @@
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "SDF Corvette Wreck"
+	known = FALSE
 
 /obj/effect/overmap/visitable/ship/landable/sdf_cutter
 	name = "SDF Cutter"


### PR DESCRIPTION
Most ships now have their transponders enabled by default (read: they no longer require scanning to reveal their name on the overmap) because of things like ***space traffic regulations***. Wrecks and certain offmap ships start with their transponders disabled though (there isn't a way to turn them on or off manually right now, but maybe someone can figure that out).

:cl:
tweak: most ships start as known, except for wrecks and the mercenary manta
/:cl: