### PR TITLE
Emergency Beacon Update

### DIFF
--- a/code/__defines/is_helpers.dm
+++ b/code/__defines/is_helpers.dm
@@ -63,6 +63,7 @@
 #define isopenspace(A)	istype(A, /turf/simulated/open)
 #define isspace(A)		istype(A, /turf/space)
 #define isopenturf(A)	istype(A, /turf/simulated/open) || istype(A, /turf/space)
+#define isnonsolidturf(A)	istype(A, /turf/simulated/open) || istype(A, /turf/space) || istype(A, /turf/simulated/floor/water) || istype(A, /turf/simulated/floor/lava)
 #define ismineralturf(A) istype(A, /turf/simulated/mineral)
 
 #define istaurtail(A)	istype(A, /datum/sprite_accessory/tail/taur)

--- a/code/__defines/is_helpers.dm
+++ b/code/__defines/is_helpers.dm
@@ -62,6 +62,7 @@
 //#define isturf(D)		istype(D, /turf)	//Built in
 #define isopenspace(A)	istype(A, /turf/simulated/open)
 #define isspace(A)		istype(A, /turf/space)
+#define isopenturf(A)	istype(A, /turf/simulated/open) || istype(A, /turf/space)
 #define ismineralturf(A) istype(A, /turf/simulated/mineral)
 
 #define istaurtail(A)	istype(A, /datum/sprite_accessory/tail/taur)

--- a/code/game/objects/items/devices/e_beacon.dm
+++ b/code/game/objects/items/devices/e_beacon.dm
@@ -14,33 +14,47 @@
 	gps_tag = "EMERGENCY BEACON"
 
 /obj/item/device/emergency_beacon/attack_self(mob/user)
+	var/T = user.loc
 	if(!beacon_active)
-		var/answer = tgui_alert(user, "Would you like to activate this personal emergency beacon?","\The [src]", list("Yes", "No"))
-		if(answer == "No")
+		if(!isturf(T))
+			to_chat(user,"<span class='warning'>You cannot activate the beacon when you are not on a turf!</span>")
 			return
-		else if(do_after(user, (5 SECONDS)))	//short delay, so they can still abort if they want to
-			user.visible_message("<span class='warning'>[user] activates \the [src]!</span>","<span class='warning'>You activate \the [src], spiking it into the ground!</span>")
-			beacon_active = TRUE
-			icon_state = "e_beacon_active"
-			user.drop_item()
-			anchored = TRUE
-			gps.tracking = TRUE
-			admin_chat_message(message = "'[user?.ckey || "Unknown"]' activated a personal emergency beacon", color = "#FF2222") //VOREStation Add
-			var/message = "This is an automated distress signal from a MIL-DTL-93352-compliant personal emergency beacon transmitting on [PUB_FREQ*0.1]kHz. \
-			This beacon was activated in '\the [get_area(src)]' at X[src.loc.x],Y[src.loc.y]. Due to the limited signal strength, no further information can be provided at this time. \
-			Per the Interplanetary Convention on Space SAR, those receiving this message must attempt rescue, \
-			or relay the message to those who can."
+		else if(isopenturf(T))
+			to_chat(user,"<span class='warning'>You cannot activate the beacon when you are not on solid ground!</span>")
+			return
+		else
+			var/answer = tgui_alert(user, "Would you like to activate this personal emergency beacon?","\The [src]", list("Yes", "No"))
+			if(answer == "No")
+				return
+			else if(do_after(user, (3 SECONDS)))	//short delay, so they can still abort if they want to
+				user.visible_message("<span class='warning'>[user] activates \the [src]!</span>","<span class='warning'>You activate \the [src], spiking it into the ground!</span>")
+				beacon_active = TRUE
+				icon_state = "e_beacon_active"
+				user.drop_item()
+				anchored = TRUE
+				gps.tracking = TRUE
+				admin_chat_message(message = "'[user?.ckey || "Unknown"]' activated a personal emergency beacon", color = "#FF2222")
+				var/message = "This is an automated distress signal from a MIL-DTL-93352-compliant personal emergency beacon transmitting on [PUB_FREQ*0.1]kHz. \
+				This beacon was activated in '\the [get_area(src)]' at X[src.loc.x], Y[src.loc.y]. Due to the limited signal strength, no further information can be provided at this time. \
+				Per the Interplanetary Convention on Space SAR, those receiving this message must attempt rescue, \
+				or relay the message to those who can."
 
-			if(!levels_for_distress)
-				levels_for_distress = list(1)
-			for(var/zlevel in levels_for_distress)
-				priority_announcement.Announce(message, new_title = "Automated Personal Distress Signal", new_sound = 'sound/AI/sos.ogg', zlevel = zlevel)
+				if(!levels_for_distress)
+					levels_for_distress = list(1)
+				for(var/zlevel in levels_for_distress)
+					priority_announcement.Announce(message, new_title = "Automated Personal Distress Signal", new_sound = 'sound/AI/sos.ogg', zlevel = zlevel)
 	else
 		to_chat(user,"\The [src] is already active, or is otherwise malfunctioning. There's nothing you can do but wait. And possibly pray.")
 
 /obj/item/device/emergency_beacon/attack_hand(mob/user)
 	if(beacon_active)
-		to_chat(user,"<span class='warning'>The beacon is already active and cannot be moved!")
+		to_chat(user,"<span class='warning'>The beacon is already active and cannot be moved!</span>")
 		return
 
 	. = ..()
+
+/obj/item/device/emergency_beacon/attackby(obj/item/weapon/W, mob/user)
+	if(W.is_wrench() && beacon_active)
+		gps.tracking = FALSE
+		user.visible_message("[user] disassembles \the [src].")
+		qdel(src)

--- a/code/game/objects/items/devices/e_beacon.dm
+++ b/code/game/objects/items/devices/e_beacon.dm
@@ -5,6 +5,13 @@
 	icon_state = "e_beacon_off"
 	var/beacon_active = FALSE
 	var/list/levels_for_distress
+	var/obj/item/device/gps/gps = null
+
+/obj/item/device/emergency_beacon/New()
+	gps = new/obj/item/device/gps/emergency_beacon(src)
+
+/obj/item/device/gps/emergency_beacon
+	gps_tag = "EMERGENCY BEACON"
 
 /obj/item/device/emergency_beacon/attack_self(mob/user)
 	if(!beacon_active)
@@ -12,9 +19,12 @@
 		if(answer == "No")
 			return
 		else if(do_after(user, (5 SECONDS)))	//short delay, so they can still abort if they want to
-			user.visible_message("<span class='warning'>[user] activates \the [src]!</span>","<span class='warning'>You activate \the [src]!</span>")
+			user.visible_message("<span class='warning'>[user] activates \the [src]!</span>","<span class='warning'>You activate \the [src], spiking it into the ground!</span>")
 			beacon_active = TRUE
 			icon_state = "e_beacon_active"
+			user.drop_item()
+			anchored = TRUE
+			gps.tracking = TRUE
 			admin_chat_message(message = "'[user?.ckey || "Unknown"]' activated a personal emergency beacon", color = "#FF2222") //VOREStation Add
 			var/message = "This is an automated distress signal from a MIL-DTL-93352-compliant personal emergency beacon transmitting on [PUB_FREQ*0.1]kHz. \
 			This beacon was activated in '\the [get_area(src)]' at X[src.loc.x],Y[src.loc.y]. Due to the limited signal strength, no further information can be provided at this time. \
@@ -27,3 +37,10 @@
 				priority_announcement.Announce(message, new_title = "Automated Personal Distress Signal", new_sound = 'sound/AI/sos.ogg', zlevel = zlevel)
 	else
 		to_chat(user,"\The [src] is already active, or is otherwise malfunctioning. There's nothing you can do but wait. And possibly pray.")
+
+/obj/item/device/emergency_beacon/attack_hand(mob/user)
+	if(beacon_active)
+		to_chat(user,"<span class='warning'>The beacon is already active and cannot be moved!")
+		return
+
+	. = ..()

--- a/code/game/objects/items/devices/e_beacon.dm
+++ b/code/game/objects/items/devices/e_beacon.dm
@@ -19,8 +19,8 @@
 		if(!isturf(T))
 			to_chat(user,"<span class='warning'>You cannot activate the beacon when you are not on a turf!</span>")
 			return
-		else if(isopenturf(T))
-			to_chat(user,"<span class='warning'>You cannot activate the beacon when you are not on solid ground!</span>")
+		else if(isnonsolidturf(T))
+			to_chat(user,"<span class='warning'>You cannot activate the beacon when you are not on sufficiently solid ground!</span>")
 			return
 		else
 			var/answer = tgui_alert(user, "Would you like to activate this personal emergency beacon?","\The [src]", list("Yes", "No"))

--- a/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
@@ -194,7 +194,7 @@
 		/obj/item/weapon/storage/backpack/parachute,
 		/obj/item/weapon/material/knife/tacknife/survival,
 		/obj/item/clothing/head/pilot_vr,
-		/obj/item/clothing/under/rank/pilot1,
+		/obj/item/clothing/under/rank/pilot1/no_webbing,
 		/obj/item/clothing/suit/storage/toggle/bomber/pilot,
 		/obj/item/clothing/shoes/boots/winter/explorer,
 		/obj/item/clothing/mask/gas/half,
@@ -211,7 +211,10 @@
 		/obj/item/device/radio,
 		/obj/item/device/gps/explorer,
 		/obj/item/weapon/gun/energy/gun/protector/pilotgun/locked,
-		/obj/item/clothing/gloves/watch/survival
+		/obj/item/clothing/gloves/watch/survival,
+		/obj/item/clothing/accessory/storage/webbing/pilot1,
+		/obj/item/clothing/accessory/storage/webbing/pilot2,
+		/obj/item/device/emergency_beacon
 		)
 
 /obj/structure/closet/secure_closet/pilot/Initialize()


### PR DESCRIPTION
Updating the personal emergency beacon with some new functionality. When activated, you now deploy it into your current tile and it becomes a fixture of that tile, transmitting an "emergency beacon" gps signal (much more useful than X/Y coords given in the message, though those are still given for now). You can't activate it if you're not on sufficiently solid ground though; mid air, floating in space, or neck deep in water are all bad terrain for beacons. Deployed beacons can be disassembled with a wrench.

Also adds an `isopenturf` and `isnonsolidturf` helpers; `isopenturf` checks if the turf is `space` or `simulated/open`, and `isnonsolidturf` checks both of those *and* `simulated/floor/water` and `simulated/floor/lava`, for the purposes of seeing if the ground is solid enough to plant a beacon in or not. Though the odds of anyone living long enough to plant a beacon in lava are fairly slim!

:cl:
tweak: emergency beacon behaviour tweaks; shorter activation, fixed deployment location, and integrated micro-gps
tweak: added emergency beacons to pilot lockers
tweak: deployed emergency beacons can be disassembled with a wrench
rscadd: added `isopenturf` helper, returns true if the checked turf is `space` or `simulated/open`
rscadd: added `isnonsolidturf` helper, returns true if the checked turf is `space`, `simulated/open`, `simulated/floor/water`, or `simulated/floor/lava`
/:cl: