### PR TITLE
Spacewhale LZs

### DIFF
--- a/maps/om_adventure/grasscave.dm
+++ b/maps/om_adventure/grasscave.dm
@@ -20,12 +20,20 @@
 
 
 /obj/effect/shuttle_landmark/premade/om_adventure/grasscave/center
-	name = "Anomaly - Center"
+	name = "Anomaly - Center Alpha"
 	landmark_tag = "om-grasscave-center"
 
+/obj/effect/shuttle_landmark/premade/om_adventure/grasscave/center_alt
+	name = "Anomaly - Center Beta"
+	landmark_tag = "om-grasscave-center2"
+
 /obj/effect/shuttle_landmark/premade/om_adventure/grasscave/southeast
-	name = "Anomaly - Southeast"
+	name = "Anomaly - Southeast Alpha"
 	landmark_tag = "om-grasscave-southeast"
+
+/obj/effect/shuttle_landmark/premade/om_adventure/grasscave/southeast_alt
+	name = "Anomaly - Southeast Beta"
+	landmark_tag = "om-grasscave-southeast2"
 
 
 /area/om_adventure/grasscave
@@ -46,7 +54,7 @@
 /area/om_adventure/grasscave/rocks
 
 /obj/effect/overmap/visitable/simplemob/spacewhale/grasscave
-	initial_generic_waypoints = list("om-grasscave-center", "om-grasscave-southeast")
+	initial_generic_waypoints = list("om-grasscave-center", "om-grasscave-center2", "om-grasscave-southeast", "om-grasscave-southeast2")
 
 /turf/simulated/mineral/omadventure/make_ore(var/rare_ore)
 	if(mineral)

--- a/maps/om_adventure/grasscave.dmm
+++ b/maps/om_adventure/grasscave.dmm
@@ -6,6 +6,10 @@
 "c" = (
 /turf/simulated/floor/outdoors/grass/forest,
 /area/om_adventure/grasscave/unexplored)
+"e" = (
+/obj/effect/shuttle_landmark/premade/om_adventure/grasscave/center_alt,
+/turf/simulated/floor/outdoors/grass/forest,
+/area/om_adventure/grasscave/explored)
 "n" = (
 /obj/effect/shuttle_landmark/premade/om_adventure/grasscave/southeast,
 /turf/simulated/floor/outdoors/grass/forest,
@@ -25,6 +29,10 @@
 /area/om_adventure/grasscave/explored)
 "C" = (
 /turf/unsimulated/wall/dark,
+/area/om_adventure/grasscave)
+"I" = (
+/obj/effect/shuttle_landmark/premade/om_adventure/grasscave/southeast_alt,
+/turf/simulated/floor/outdoors/grass/forest,
 /area/om_adventure/grasscave)
 "N" = (
 /turf/simulated/floor/outdoors/grass/forest,
@@ -9907,7 +9915,7 @@ u
 u
 u
 u
-u
+e
 u
 u
 u
@@ -12793,7 +12801,7 @@ N
 N
 N
 N
-N
+I
 N
 N
 N


### PR DESCRIPTION
Adds two more LZ markers to the spacewhale for ease of landing certain left-dock shuttles on them. The zones are still quite tight, but they're at least workable.

:cl:
rscadd: two variant landing markers on the space whale, to make landing at the existing landing zones easier
/:cl: