### PR TITLE
Fix Charsetup Tail Layering

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -290,7 +290,7 @@ var/list/preferences_datums = list()
 	popup.open(FALSE) // Skip registring onclose on the browser pane
 	onclose(user, "preferences_window", src) // We want to register on the window itself
 
-/datum/preferences/proc/update_character_previews(mutable_appearance/MA)
+/datum/preferences/proc/update_character_previews(var/mob/living/carbon/human/mannequin)
 	if(!client)
 		return
 
@@ -319,8 +319,11 @@ var/list/preferences_datums = list()
 			O.pref = src
 			LAZYSET(char_render_holders, "[D]", O)
 			client.screen |= O
+		mannequin.set_dir(D)
+		mannequin.update_tail_showing()
+		mannequin.ImmediateOverlayUpdate()
+		var/mutable_appearance/MA = new(mannequin)
 		O.appearance = MA
-		O.dir = D
 		O.screen_loc = preview_screen_locs["[D]"]
 
 /datum/preferences/proc/show_character_previews()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -261,10 +261,8 @@
 	mannequin.update_transform() //VOREStation Edit to update size/shape stuff.
 	mannequin.toggle_tail(setting = animations_toggle)
 	mannequin.toggle_wing(setting = animations_toggle)
-	mannequin.update_tail_showing()
-	mannequin.ImmediateOverlayUpdate()
 
-	update_character_previews(new /mutable_appearance(mannequin))
+	update_character_previews(mannequin)
 
 /datum/preferences/proc/get_highest_job()
 	var/datum/job/highJob


### PR DESCRIPTION
Ports some charsetup display fixes from downstream. Credit to Verk for fixing this originally, I just dragged it over and made sure it worked.

:cl:
fix: fixed tails layering weirdly under the character on character setup
/:cl: