### PR TITLE
Revert Throw Notifs

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -19,7 +19,6 @@
 	S["obfuscate_key"]			>> pref.obfuscate_key
 	S["obfuscate_job"]			>> pref.obfuscate_job
 	S["chat_timestamp"]			>> pref.chat_timestamp
-	S["throwmode_loud"]			>> pref.throwmode_loud
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]				<< pref.UI_style
@@ -38,7 +37,6 @@
 	S["obfuscate_key"]			<< pref.obfuscate_key
 	S["obfuscate_job"]			<< pref.obfuscate_job
 	S["chat_timestamp"]			<< pref.chat_timestamp
-	S["throwmode_loud"]			<< pref.throwmode_loud
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style			= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
@@ -57,7 +55,6 @@
 	pref.obfuscate_key		= sanitize_integer(pref.obfuscate_key, 0, 1, initial(pref.obfuscate_key))
 	pref.obfuscate_job		= sanitize_integer(pref.obfuscate_job, 0, 1, initial(pref.obfuscate_job))
 	pref.chat_timestamp		= sanitize_integer(pref.chat_timestamp, 0, 1, initial(pref.chat_timestamp))
-	pref.throwmode_loud		= sanitize_integer(pref.throwmode_loud, 0, 1, initial(pref.throwmode_loud))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. = "<b>UI Style:</b> <a href='?src=\ref[src];select_style=1'><b>[pref.UI_style]</b></a><br>"
@@ -76,7 +73,6 @@
 	. += "<b>Obfuscate Ckey:</b> <a href='?src=\ref[src];obfuscate_key=1'><b>[(pref.obfuscate_key) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	. += "<b>Obfuscate Job:</b> <a href='?src=\ref[src];obfuscate_job=1'><b>[(pref.obfuscate_job) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	. += "<b>Chat Timestamps:</b> <a href='?src=\ref[src];chat_timestamps=1'><b>[(pref.chat_timestamp) ? "Enabled" : "Disabled (default)"]</b></a><br>"
-	. += "<b>Throw Mode Messages:</b> <a href='?src=\ref[src];throwmode_loudness=1'><b>[(pref.throwmode_loud) ? "Loud" : "Quiet (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b>"
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -168,10 +164,6 @@
 
 	else if(href_list["chat_timestamps"])
 		pref.chat_timestamp = !pref.chat_timestamp
-		return TOPIC_REFRESH
-
-	else if(href_list["throwmode_loudness"])
-		pref.throwmode_loud = !pref.throwmode_loud
 		return TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -32,7 +32,6 @@ var/list/preferences_datums = list()
 	var/obfuscate_key = FALSE
 	var/obfuscate_job = FALSE
 	var/chat_timestamp = FALSE
-	var/throwmode_loud = FALSE
 
 	//character preferences
 	var/real_name						//our character's name

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -389,16 +389,6 @@
 
 	to_chat(src, span_notice("You have toggled chat timestamps: [prefs.chat_timestamp ? "ON" : "OFF"]."))
 
-/client/verb/toggle_throwmode_messages()
-	set name = "Toggle Throw Mode Messages"
-	set category = "Preferences"
-	set desc = "Toggles whether or not activating throw mode (hotkey: R) will announce you're preparing to throw your current handheld item, or catch an incoming item if your hand is empty."
-
-	prefs.throwmode_loud = !prefs.throwmode_loud	//There is no preference datum for tgui input lock, nor for any TGUI prefs.
-	SScharacter_setup.queue_preferences_save(prefs)
-
-	to_chat(src, span_notice("You have toggled throw mode messages: [prefs.throwmode_loud ? "ON" : "OFF"]."))
-
 /client/verb/toggle_status_indicators()
 	set name = "Toggle Status Indicators"
 	set category = "Preferences"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1196,20 +1196,11 @@
 
 /mob/proc/throw_mode_off()
 	src.in_throw_mode = 0
-	if(client)
-		if(a_intent == I_HELP || client.prefs.throwmode_loud)
-			src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
 	if(src.throw_icon && !issilicon(src)) //in case we don't have the HUD and we use the hotkey. Silicon use this for something else. Do not overwrite their HUD icon
 		src.throw_icon.icon_state = "act_throw_off"
 
 /mob/proc/throw_mode_on()
 	src.in_throw_mode = 1
-	if(client)
-		if(a_intent == I_HELP || client.prefs.throwmode_loud)
-			if(src.get_active_hand())
-				src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
-			else
-				src.visible_message("<span class='warning'>[src] looks ready to catch anything thrown at them!</span>","<span class='notice'>You get ready to catch anything thrown at you.</span>")
 	if(src.throw_icon && !issilicon(src)) // Silicon use this for something else. Do not overwrite their HUD icon
 		src.throw_icon.icon_state = "act_throw_on"
 


### PR DESCRIPTION
In hindsight, these ( #15405 ) were not such a great idea. I'm surprised no-one ripped them out sooner.

Perhaps there's room for some other kind of indicator for easily reading a character's body language/etc. down the line, but it needs more refinement and workshopping than this approach.

:cl:
rscdel: removed text notifs when prepping to throw/catch stuff
/:cl: