### PR TITLE
Fixes species blood color

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -738,6 +738,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			var/min_age = get_min_age()
 			var/max_age = get_max_age()
 			pref.age = max(min(pref.age, max_age), min_age)
+			pref.blood_color = setting_species.blood_color // VOREstation edit
 
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -307,7 +307,7 @@ var/global/list/valid_bloodreagents = list("default","iron","copper","phoron","s
 	. += "</ul>"
 
 	. += "<b>Blood Color: </b>" //People that want to use a certain species to have that species traits (xenochimera/promethean/spider) should be able to set their own blood color.
-	. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
+	. += "<a href='?src=\ref[src];blood_color=1'>Set Color <font color='[pref.blood_color]'>&#9899;</font></a>"
 	. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
 	. += "<b>Blood Reagent: </b>"	//Wanna be copper-based? Go ahead.
 	. += "<a href='?src=\ref[src];blood_reagents=1'>[pref.blood_reagents]</a><br>"

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -363,9 +363,11 @@ var/global/list/valid_bloodreagents = list("default","iron","copper","phoron","s
 		return TOPIC_REFRESH
 
 	else if(href_list["blood_reset"])
-		var/choice = tgui_alert(usr, "Reset blood color to human default (#A10808)?","Reset Blood Color",list("Reset","Cancel"))
+		var/datum/species/spec = GLOB.all_species[pref.species]
+		var/new_blood = spec.blood_color ? spec.blood_color : "#A10808"
+		var/choice = tgui_alert(usr, "Reset blood color to species default ([new_blood])?","Reset Blood Color",list("Reset","Cancel"))
 		if(choice == "Reset")
-			pref.blood_color = "#A10808"
+			pref.blood_color = new_blood
 		return TOPIC_REFRESH
 
 	else if(href_list["blood_reagents"])


### PR DESCRIPTION
Fixes species blood color, which is currently overridden by the default red blood. Selecting a species will now copy that species blood color, while the "reset" blood button now resets to the species' default.

This will not reset any blood colors currently in player save data, which must be manually reset if desired.

Downstream changelog:
:cl:
fix: Species blood color is used again
qol: Blood color reset button now uses the species' default
qol: Blood color button now has a colored dot
/:cl: