### PR TITLE
Update electrical_storm.dm

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -60,8 +60,12 @@
 		return
 
 	// Decent chance to overload lighting circuit.
-	if(prob(3 * severity))
-		T.overload_lighting()
+	if(prob(8 * severity))	//over double the original chance (3), because it's now only a one-in-four to blow the lights out entirely
+		if(prob(75))	//flicker 'em
+			for(var/obj/machinery/light/L in T.area)
+				L.flicker(15)
+		else	//blast 'em!
+			T.overload_lighting()
 
 	// Relatively small chance to emag the apc as apc_damage event does.
 	if(prob(0.2 * severity))


### PR DESCRIPTION
Tweaked the electrical storm event to have a 75% chance to flicker all the lights in an area that it triggers on. This reduces the chance of a full lighting blowout, but the base chance to affect a given area has been almost tripled to offset that.

Probably kind of expensive perfwise because of lighting map updates but eh, storms don't fire very often so it should be OK?

This also affects the overmap version so flying through electrical storms will be kind of spooky without being quite such a huge pain in the ass!

:cl:
tweak: electrical storms have a high chance to flicker the lights instead of obliterating them
/:cl: