### PR TITLE
August 2024 various fixes

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -43,6 +43,13 @@
 
 	else if(LAZYLEN(prizes))
 		var/prizeselect = pickweight(prizes)
+		//VOREstation edit - Randomized map objects were put in loot piles, so handle them...
+		if(istype(prizeselect,/obj/random))
+			var/obj/random/randy = prizeselect
+			var/new_I = randy.spawn_item()
+			qdel(prizeselect)
+			prizeselect = new_I // swap it
+		//VOREstation edit end
 		new prizeselect(src.loc)
 
 		if(istype(prizeselect, /obj/item/clothing/suit/syndicatefake)) //Helmet is part of the suit

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -132,6 +132,19 @@ Buildable meters
 	src.set_dir(turn(src.dir, 270))
 	fixdir()
 
+//VOREstation edit: counter-clockwise rotation
+/obj/item/pipe/verb/rotate_counterclockwise()
+	set category = "Object"
+	set name = "Rotate Pipe Counter-Clockwise"
+	set src in view(1)
+
+	if ( usr.stat || usr.restrained() || !usr.canmove )
+		return
+
+	src.set_dir(turn(src.dir, 90))
+	fixdir()
+//VOREstation edit end
+
 // Don't let pulling a pipe straighten it out.
 /obj/item/pipe/binary/bendable/Move()
 	var/old_bent = !IS_CARDINAL(dir)

--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -170,12 +170,18 @@
 			M.client.perspective = EYE_PERSPECTIVE
 			M.client.eye = src
 		M.loc = src
-		update_use_power(USE_POWER_ACTIVE)
+		// update_use_power(USE_POWER_ACTIVE) //VOREstation edit: borer VR crash fix
 		occupant = M
 
 		update_icon()
 
-		enter_vr()
+		//VOREstation edit - crashes borers
+		if(!M.has_brain_worms())
+			update_use_power(USE_POWER_ACTIVE)
+			enter_vr()
+		else
+			to_chat(user, "<span class='warning'>\The [src] rejects [M] with a sharp beep.</span>")
+		//VOREstation edit end
 	return
 
 /obj/machinery/vr_sleeper/proc/go_out(var/forced = TRUE)
@@ -261,4 +267,3 @@
 
 	else
 		occupant.enter_vr(avatar)
-

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -49,7 +49,13 @@ var/global/list/image/splatter_cache=list()
 					if (B.blood_DNA)
 						blood_DNA |= B.blood_DNA.Copy()
 					qdel(B)
-	addtimer(CALLBACK(src, PROC_REF(dry)), DRYING_TIME * (amount+1))
+
+//VOREstation edit - Moved timer call to Init, and made it not call on mapload
+/obj/effect/decal/cleanable/blood/Initialize(var/mapload, var/_age)
+	. = ..()
+	if(!mapload)
+		addtimer(CALLBACK(src, PROC_REF(dry)), DRYING_TIME * (amount+1))
+//VOREstation edit end
 
 /obj/effect/decal/cleanable/blood/update_icon()
 	if(basecolor == "rainbow") basecolor = get_random_colour(1)

--- a/code/game/objects/items/contraband_vr.dm
+++ b/code/game/objects/items/contraband_vr.dm
@@ -7,90 +7,97 @@
 	w_class = ITEMSIZE_HUGE
 
 /obj/item/stolenpackage/attack_self(mob/user as mob)
-		// Another way of doing this. Commented out because the other method is better for this application.
-		/*var/spawn_chance = rand(1,100)
-		switch(spawn_chance)
-			if(0 to 49)
-				new /obj/random/gun/guarenteed(usr.loc)
-				to_chat(usr, "You got a thing!")
-			if(50 to 99)
-				new /obj/item/weapon/bikehorn/rubberducky(usr.loc)
-				new /obj/item/weapon/bikehorn(usr.loc)
-				to_chat(usr, "You got two things!")
-			if(100)
-				to_chat(usr, "The box contained nothing!")
-				return
-		*/
-		var/loot = pick(/obj/effect/landmark/costume,
-						/obj/item/clothing/glasses/thermal,
-						/obj/item/clothing/gloves/combat,
-						/obj/item/clothing/head/bearpelt,
-						/obj/item/clothing/mask/balaclava,
-						/obj/item/clothing/mask/horsehead,
-						/obj/item/clothing/mask/muzzle,
-						/obj/item/clothing/suit/armor/heavy,
-						/obj/item/clothing/suit/armor/laserproof,
-						/obj/item/clothing/suit/armor/vest,
-						/obj/item/device/chameleon,
-						/obj/item/device/pda/clown,
-						/obj/item/device/pda/mime,
-						/obj/item/device/pda/syndicate,
-						/obj/item/mecha_parts/chassis/phazon,
-						/obj/item/mecha_parts/part/phazon_head,
-						/obj/item/mecha_parts/part/phazon_left_arm,
-						/obj/item/mecha_parts/part/phazon_left_leg,
-						/obj/item/mecha_parts/part/phazon_right_arm,
-						/obj/item/mecha_parts/part/phazon_right_leg,
-						/obj/item/mecha_parts/part/phazon_torso,
-						/obj/item/weapon/circuitboard/mecha/phazon/targeting,
-						/obj/item/weapon/circuitboard/mecha/phazon/peripherals,
-						/obj/item/weapon/circuitboard/mecha/phazon/main,
-						/obj/item/device/bodysnatcher,
-						/obj/item/weapon/bluespace_harpoon,
-						/obj/item/clothing/accessory/permit/gun,
-						/obj/item/device/perfect_tele,
-						/obj/item/device/sleevemate,
-						/obj/item/weapon/disk/nifsoft/compliance,
-						/obj/item/weapon/implanter/compliance,
-						/obj/item/seeds/ambrosiadeusseed,
-						/obj/item/seeds/ambrosiavulgarisseed,
-						/obj/item/seeds/libertymycelium,
-						/obj/fiftyspawner/platinum,
-						/obj/item/toy/nanotrasenballoon,
-						/obj/item/toy/syndicateballoon,
-						/obj/item/weapon/aiModule/syndicate,
-						/obj/item/weapon/book/manual/engineering_hacking,
-						/obj/item/weapon/card/emag,
-						/obj/item/weapon/card/emag_broken,
-						/obj/item/weapon/card/id/syndicate,
-						/obj/item/poster,
-						/obj/item/weapon/disposable_teleporter,
-						/obj/item/weapon/grenade/flashbang/clusterbang,
-						/obj/item/weapon/grenade/flashbang/clusterbang,
-						/obj/item/weapon/grenade/spawnergrenade/spesscarp,
-						/obj/item/weapon/melee/energy/sword,
-						/obj/item/weapon/melee/telebaton,
-						/obj/item/weapon/pen/reagent/paralysis,
-						/obj/item/weapon/pickaxe/diamonddrill,
-						/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine,
-						/obj/item/weapon/reagent_containers/food/snacks/carpmeat,
-						/obj/item/weapon/reagent_containers/food/snacks/clownstears,
-						/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
-						/obj/item/weapon/reagent_containers/glass/beaker/neurotoxin,
-						/obj/item/weapon/rig/combat,
-						/obj/item/weapon/shield/energy,
-						/obj/item/weapon/stamp/centcomm,
-						/obj/item/weapon/stamp/solgov,
-						/obj/item/weapon/storage/fancy/cigar/havana,
-						/obj/item/xenos_claw,
-						/obj/random/contraband,
-						/obj/random/contraband,
-						/obj/random/contraband,
-						/obj/random/contraband,
-						/obj/random/weapon/guarenteed)
-		new loot(usr.loc)
-		to_chat(user, "You unwrap the package.")
-		qdel(src)
+	// Another way of doing this. Commented out because the other method is better for this application.
+	/*var/spawn_chance = rand(1,100)
+	switch(spawn_chance)
+		if(0 to 49)
+			new /obj/random/gun/guarenteed(usr.loc)
+			to_chat(usr, "You got a thing!")
+		if(50 to 99)
+			new /obj/item/weapon/bikehorn/rubberducky(usr.loc)
+			new /obj/item/weapon/bikehorn(usr.loc)
+			to_chat(usr, "You got two things!")
+		if(100)
+			to_chat(usr, "The box contained nothing!")
+			return
+	*/
+	var/loot = pick(/obj/effect/landmark/costume,
+					/obj/item/clothing/glasses/thermal,
+					/obj/item/clothing/gloves/combat,
+					/obj/item/clothing/head/bearpelt,
+					/obj/item/clothing/mask/balaclava,
+					/obj/item/clothing/mask/horsehead,
+					/obj/item/clothing/mask/muzzle,
+					/obj/item/clothing/suit/armor/heavy,
+					/obj/item/clothing/suit/armor/laserproof,
+					/obj/item/clothing/suit/armor/vest,
+					/obj/item/device/chameleon,
+					/obj/item/device/pda/clown,
+					/obj/item/device/pda/mime,
+					/obj/item/device/pda/syndicate,
+					/obj/item/mecha_parts/chassis/phazon,
+					/obj/item/mecha_parts/part/phazon_head,
+					/obj/item/mecha_parts/part/phazon_left_arm,
+					/obj/item/mecha_parts/part/phazon_left_leg,
+					/obj/item/mecha_parts/part/phazon_right_arm,
+					/obj/item/mecha_parts/part/phazon_right_leg,
+					/obj/item/mecha_parts/part/phazon_torso,
+					/obj/item/weapon/circuitboard/mecha/phazon/targeting,
+					/obj/item/weapon/circuitboard/mecha/phazon/peripherals,
+					/obj/item/weapon/circuitboard/mecha/phazon/main,
+					/obj/item/device/bodysnatcher,
+					/obj/item/weapon/bluespace_harpoon,
+					/obj/item/clothing/accessory/permit/gun,
+					/obj/item/device/perfect_tele,
+					/obj/item/device/sleevemate,
+					/obj/item/weapon/disk/nifsoft/compliance,
+					/obj/item/weapon/implanter/compliance,
+					/obj/item/seeds/ambrosiadeusseed,
+					/obj/item/seeds/ambrosiavulgarisseed,
+					/obj/item/seeds/libertymycelium,
+					/obj/fiftyspawner/platinum,
+					/obj/item/toy/nanotrasenballoon,
+					/obj/item/toy/syndicateballoon,
+					/obj/item/weapon/aiModule/syndicate,
+					/obj/item/weapon/book/manual/engineering_hacking,
+					/obj/item/weapon/card/emag,
+					/obj/item/weapon/card/emag_broken,
+					/obj/item/weapon/card/id/syndicate,
+					/obj/item/poster,
+					/obj/item/weapon/disposable_teleporter,
+					/obj/item/weapon/grenade/flashbang/clusterbang,
+					/obj/item/weapon/grenade/flashbang/clusterbang,
+					/obj/item/weapon/grenade/spawnergrenade/spesscarp,
+					/obj/item/weapon/melee/energy/sword,
+					/obj/item/weapon/melee/telebaton,
+					/obj/item/weapon/pen/reagent/paralysis,
+					/obj/item/weapon/pickaxe/diamonddrill,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine,
+					/obj/item/weapon/reagent_containers/food/snacks/carpmeat,
+					/obj/item/weapon/reagent_containers/food/snacks/clownstears,
+					/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
+					/obj/item/weapon/reagent_containers/glass/beaker/neurotoxin,
+					/obj/item/weapon/rig/combat,
+					/obj/item/weapon/shield/energy,
+					/obj/item/weapon/stamp/centcomm,
+					/obj/item/weapon/stamp/solgov,
+					/obj/item/weapon/storage/fancy/cigar/havana,
+					/obj/item/xenos_claw,
+					/obj/random/contraband,
+					/obj/random/contraband,
+					/obj/random/contraband,
+					/obj/random/contraband,
+					/obj/random/weapon/guarenteed)
+	//VOREstation edit - Randomized map objects were put in loot piles, so handle them...
+	if(istype(loot,/obj/random))
+		var/obj/random/randy = loot
+		var/new_I = randy.spawn_item()
+		qdel(loot)
+		loot = new_I // swap it
+	//VOREstation edit end
+	new loot(usr.loc)
+	to_chat(user, "You unwrap the package.")
+	qdel(src)
 
 /obj/item/weapon/miscdisc
 	name = "strange artefact"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -97,6 +97,8 @@
 			return
 		if(W.loc != user) // This should stop mounted modules ending up outside the module.
 			return
+		if(istype(W, /obj/item/weapon/grab)) //VOREstation edit: we don't want to drop grabs into the crate
+			return
 		user.drop_item()
 		if(W)
 			W.forceMove(src.loc)

--- a/code/game/objects/structures/gravemarker.dm
+++ b/code/game/objects/structures/gravemarker.dm
@@ -127,3 +127,22 @@
 
 	src.set_dir(turn(src.dir, 270))
 	return
+
+//VOREstation edit: counter-clockwise rotation
+/obj/structure/gravemarker/verb/rotate_counterclockwise()
+	set name = "Rotate Grave Marker Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if(anchored)
+		return
+
+	if(!usr || !isturf(usr.loc))
+		return
+	if(usr.stat || usr.restrained())
+		return
+	if(ismouse(usr) || (isobserver(usr) && !config.ghost_interaction))
+		return
+
+	src.set_dir(turn(src.dir, 90))
+	return

--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -93,6 +93,14 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 			else // Welp.
 				loot = produce_common_item()
 
+			//VOREstation edit - Randomized map objects were put in loot piles, so handle them...
+			if(istype(loot,/obj/random))
+				var/obj/random/randy = loot
+				var/new_I = randy.spawn_item()
+				qdel(loot)
+				loot = new_I // swap it
+			//VOREstation edit end
+
 			if(loot)
 				searched_by |= user.ckey
 				loot.forceMove(get_turf(src))

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -158,6 +158,14 @@
 				else if(luck <= chance_alpha+chance_beta+chance_gamma)
 					I = produce_gamma_item()
 
+				//VOREstation edit - Randomized map objects were put in loot piles, so handle them...
+				if(istype(I,/obj/random))
+					var/obj/random/randy = I
+					var/new_I = randy.spawn_item()
+					qdel(I)
+					I = new_I // swap it
+				//VOREstation edit end
+
 				//We either have an item to hand over or we don't, at this point!
 				if(I)
 					searchedby += user.ckey

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -290,6 +290,27 @@
 	update_icon()
 	return
 
+//VOREstation edit: counter-clockwise rotation
+/obj/structure/windoor_assembly/verb/rotate_counterclockwise()
+	set name = "Rotate Windoor Assembly Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored)
+		to_chat(usr,"It is fastened to the floor; therefore, you can't rotate it!")
+		return 0
+	if(src.state != "01")
+		update_nearby_tiles(need_rebuild=1) //Compel updates before
+
+	src.set_dir(turn(src.dir, 90))
+
+	if(src.state != "01")
+		update_nearby_tiles(need_rebuild=1)
+
+	update_icon()
+	return
+//VOREstation edit end
+
 //Flips the windoor assembly, determines whather the door opens to the left or the right
 /obj/structure/windoor_assembly/verb/flip()
 	set name = "Flip Windoor Assembly"

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -139,6 +139,15 @@
 
 	set_dir(turn(dir, 270))
 
+//VOREstation edit: counter-clockwise rotation
+/obj/item/device/assembly/infra/verb/rotate_counterclockwise()
+	set name = "Rotate Infrared Laser Counter-Clockwise"
+	set category = "Object"
+	set src in usr
+
+	set_dir(turn(dir, 90))
+//VOREstation edit end
+
 /***************************IBeam*********************************/
 
 /obj/effect/beam/i_beam

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -684,6 +684,23 @@ GLOBAL_LIST_EMPTY(vending_products)
 	src.set_dir(turn(src.dir, 270))
 	return 1
 
+//VOREstation edit: counter-clockwise rotation
+/obj/machinery/vending/verb/rotate_counterclockwise()
+	set name = "Rotate Vending Machine Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.can_rotate == 0)
+		to_chat(usr, "<span class='warning'>\The [src] cannot be rotated.</span>")
+		return 0
+
+	if (src.anchored || usr:stat)
+		to_chat(usr, "<span class='filter_notice'>It is bolted down!</span>")
+		return 0
+	src.set_dir(turn(src.dir, 90))
+	return 1
+//VOREstation edit end
+
 /obj/machinery/vending/verb/check_logs()
 	set name = "Check Vending Logs"
 	set category = "Object"

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -17,7 +17,7 @@
 		return
 
 	else // They're outside and hopefully on a planet.
-		if(!(T.z in SSplanets.z_to_planet) || !(SSplanets.z_to_planet[T.z]))
+		if(T.z <= 0 || SSplanets.z_to_planet.len < T.z || !(SSplanets.z_to_planet[T.z])) //VOREstation edit - removed broken in list check; use length limit instead.
 			to_chat(usr, span("warning", "You appear to be outside, but not on a planet... Something is wrong."))
 			return
 		var/datum/planet/P = SSplanets.z_to_planet[T.z]
@@ -62,4 +62,3 @@
 					to_chat(usr, "[P.moon_name] is not visible. It must be a new moon.")
 				else
 					to_chat(usr, "[P.moon_name] appears to currently be a [P.moon_phase].")
-

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -505,3 +505,18 @@
 
 	src.set_dir(turn(src.dir, 270))
 	return 1
+
+//VOREstation edit: counter-clockwise rotation
+/obj/machinery/mining/brace/verb/rotate_counterclockwise()
+	set name = "Rotate Brace Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if(usr.stat) return
+
+	if (src.anchored)
+		to_chat(usr, "It is anchored in place!")
+		return 0
+
+	src.set_dir(turn(src.dir, 90))
+	return 1

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -43,9 +43,9 @@
 
 /mob/living/bot/New()
 	..()
-	update_icons()
+	//update_icons() //VOREstation edit: moved to Init
 
-	default_language = GLOB.all_languages[LANGUAGE_GALCOM]
+	//default_language = GLOB.all_languages[LANGUAGE_GALCOM] //VOREstation edit: moved to Init
 
 	botcard = new /obj/item/weapon/card/id(src)
 	botcard.access = botcard_access.Copy()
@@ -62,6 +62,8 @@
 	. = ..()
 	if(on)
 		turn_on() // Update lights and other stuff
+	update_icons() //VOREstation edit - overlay runtime fix
+	default_language = GLOB.all_languages[LANGUAGE_GALCOM] //VOREstation edit - runtime fix
 
 /mob/living/bot/Life()
 	..()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -340,6 +340,11 @@
 /obj/mecha/can_fall()
 	return TRUE
 
+// VOREstation edit - Falling vehicles.
+/obj/vehicle/can_fall()
+	return TRUE
+// VOREstation edit end
+
 /obj/item/pipe/can_fall()
 	. = ..()
 

--- a/code/modules/power/lighting_vr.dm
+++ b/code/modules/power/lighting_vr.dm
@@ -85,6 +85,16 @@
 
     src.set_dir(turn(src.dir, 270))
 
+/obj/machinery/light_construct/floortube/verb/rotate_counterclockwise()
+    set name = "Rotate Fixture Counter-Clockwise"
+    set category = "Object"
+    set src in view(1)
+
+    if (usr.stat || usr.restrained() || anchored)
+        return
+
+    src.set_dir(turn(src.dir, 90))
+
 /obj/machinery/light_construct/floortube/update_icon()
 	switch(stage)
 		if(1)
@@ -260,4 +270,3 @@
 /obj/machinery/light/broken/small/Initialize()
 	. = ..()
 	broken()
-

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/cell_loaded.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/cell_loaded.dm
@@ -14,7 +14,7 @@
 
 	caliber = "nsfw"
 
-	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 6, TECH_MAGNETS = 4)
+	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 6, TECH_MAGNET = 4)
 
 	fire_sound = 'sound/weapons/Taser.ogg'
 
@@ -65,8 +65,8 @@
 	chambered = new_batt
 	update_charge()
 	update_icon()
-	var/mob/living/M = loc // TGMC Ammo HUD 
-	if(istype(M)) // TGMC Ammo HUD 
+	var/mob/living/M = loc // TGMC Ammo HUD
+	if(istype(M)) // TGMC Ammo HUD
 		M?.hud_used.update_ammo_hud(M, src)
 
 /obj/item/weapon/gun/projectile/cell_loaded/attack_self(mob/user)
@@ -143,7 +143,7 @@
 	desc = "A microbattery holder for a cell-based variable weapon."
 	icon = 'icons/obj/ammo_vr.dmi'
 	icon_state = "cell_mag"
-	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_MAGNETS = 3)
+	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_MAGNET = 3)
 	caliber = "nsfw"
 	ammo_type = /obj/item/ammo_casing/microbattery
 	initial_ammo = 0
@@ -284,7 +284,7 @@
 	new /obj/item/ammo_casing/microbattery/medical/stabilize2(src)
 	new /obj/item/ammo_casing/microbattery/medical/haste(src)
 	new /obj/item/ammo_casing/microbattery/medical/resist(src)
-	
+
 // TGMC Ammo HUD: Custom handling for cell-loaded weaponry.
 /*
 /obj/item/weapon/gun/projectile/cell_loaded/get_ammo_type()
@@ -299,7 +299,7 @@
 		return 0 // We're not chambered, so we have 0 rounds loaded.
 
 	var/obj/item/ammo_casing/microbattery/batt = chambered
-	
+
 	var/shots
 	if(ammo_magazine) // Check how much ammo we have
 		for(var/obj/item/ammo_casing/microbattery/bullet as anything in ammo_magazine.stored_ammo)

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/ml3m_cells.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/ml3m_cells.dm
@@ -4,7 +4,7 @@
 	desc = "A miniature nanite fabricator for a medigun."
 	catalogue_data = list(/datum/category_item/catalogue/information/organization/vey_med)
 	icon_state = "ml3m_batt"
-	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 1, TECH_MAGNETS = 2)
+	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 1, TECH_MAGNET = 2)
 
 /obj/item/projectile/beam/medical_cell
 	name = "\improper healing beam"

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
@@ -19,7 +19,7 @@
 	description_antag = ""
 	allowed_magazines = list(/obj/item/ammo_magazine/cell_mag/combat/prototype)
 
-	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 4, TECH_MAGNETS = 3)
+	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 4, TECH_MAGNET = 3)
 
 
 // The Magazine //
@@ -39,7 +39,7 @@
 	max_ammo = 2
 	x_offset = 6
 	catalogue_data = null
-	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNETS = 2)
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 2)
 
 
 // The Pack //

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
@@ -3,7 +3,7 @@
 	name = "\'NSFW\' microbattery - UNKNOWN"
 	desc = "A miniature battery for an energy weapon."
 	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
-	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 1, TECH_MAGNETS = 2)
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 1, TECH_MAGNET = 2)
 
 /obj/item/ammo_casing/microbattery/combat/lethal
 	name = "\'NSFW\' microbattery - LETHAL"

--- a/code/modules/reagents/machinery/dispenser/dispenser2.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser2.dm
@@ -42,6 +42,19 @@
 	src.set_dir(turn(src.dir, 270))
 	return 1
 
+//VOREstation edit: counter-clockwise rotation
+/obj/machinery/chemical_dispenser/verb/rotate_counterclockwise()
+	set name = "Rotate Dispenser Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored || usr:stat)
+		to_chat(usr, "It is fastened down!")
+		return 0
+	src.set_dir(turn(src.dir, 90))
+	return 1
+//VOREstation edit end
+
 /obj/machinery/chemical_dispenser/proc/add_cartridge(obj/item/weapon/reagent_containers/chem_disp_cartridge/C, mob/user)
 	if(!istype(C))
 		if(user)

--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -359,6 +359,19 @@
 	src.set_dir(turn(src.dir, 270))
 	return 1
 
+//VOREstation edit: counter-clockwise rotation
+/obj/structure/reagent_dispensers/water_cooler/verb/rotate_counterclockwise()
+	set name = "Rotate Cooler Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored || usr:stat)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	src.set_dir(turn(src.dir, 90))
+	return 1
+//VOREstation edit end
+
 /obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.has_tool_quality(TOOL_WRENCH))
 		src.add_fingerprint(user)
@@ -522,4 +535,3 @@
 /obj/structure/reagent_dispensers/bloodbarrel/Initialize()
 	. = ..()
 	reagents.add_reagent("blood", 1000, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"="O-","resistances"=null,"trace_chem"=null))
-

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -136,6 +136,23 @@
 	src.set_dir(turn(src.dir, 270))
 	update()
 
+//VOREstation edit: counter-clockwise rotation
+/obj/structure/disposalconstruct/verb/rotate_counterclockwise()
+	set category = "Object"
+	set name = "Rotate Pipe Counter-Clockwise"
+	set src in view(1)
+
+	if(usr.stat)
+		return
+
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		return
+
+	src.set_dir(turn(src.dir, 90))
+	update()
+//VOREstation edit end
+
 /obj/structure/disposalconstruct/verb/flip()
 	set category = "Object"
 	set name = "Flip Pipe"

--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -146,3 +146,16 @@
 
 	src.set_dir(turn(src.dir, 270))
 	return
+
+//VOREstation edit: counter-clockwise rotation
+/obj/machinery/shield_capacitor/verb/rotate_counterclockwise()
+	set name = "Rotate Capacitor Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored)
+		to_chat(usr, "It is fastened to the floor!")
+		return
+
+	src.set_dir(turn(src.dir, 90))
+	return

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -38,6 +38,8 @@
 		unattach()
 
 /obj/vehicle/train/Bump(atom/Obstacle)
+	if(istype(Obstacle,/obj/structure/stairs)) // VOREstation edit - Stair support for towing vehicles
+		return ..()
 	if(!istype(Obstacle, /atom/movable))
 		return
 	var/atom/movable/A = Obstacle

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -70,16 +70,20 @@
 		riding_datum.handle_vehicle_offsets() // So the person in back goes to the front.
 
 /obj/vehicle/Move(var/newloc, var/direction, var/movetime)
-	if(world.time < l_move_time + move_delay) //This AND the riding datum move speed limit?
+	// VOREstation edit - Zmoving for falling
+	var/turf/newturf = newloc
+	var/zmove = (newturf && z != newturf.z)
+
+	if(!zmove && world.time < l_move_time + move_delay) //This AND the riding datum move speed limit? // VOREstation edit end
 		return
 
-	if(mechanical && on && powered && cell.charge < charge_use)
+	if(!zmove && mechanical && on && powered && cell.charge < charge_use) // VOREstation edit - zmove doesn't run this
 		turn_off()
 		return
 
 	. = ..()
 
-	if(mechanical && on && powered)
+	if(!zmove && mechanical && on && powered) // VOREstation edit - zmove doesn't run this
 		cell.use(charge_use)
 
 	//Dummy loads do not have to be moved as they are just an overlay

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -56,8 +56,10 @@
 
 /obj/item/weapon/virusdish/attackby(var/obj/item/weapon/W as obj,var/mob/living/carbon/user as mob)
 	if(istype(W,/obj/item/weapon/hand_labeler) || istype(W,/obj/item/weapon/reagent_containers/syringe))
-		return
-	..()
+		//VOREstation edit - Actually functional virus dishes
+		// Originally this returns, THEN calls ..() instead of returning the value of ..()
+		return ..()
+		//VOREstation edit end
 	if(prob(50))
 		to_chat(user, "<span class='danger'>\The [src] shatters!</span>")
 		if(virus2.infectionchance > 0)

--- a/code/modules/vore/eating/stumblevore_vr.dm
+++ b/code/modules/vore/eating/stumblevore_vr.dm
@@ -14,14 +14,14 @@
 /mob/living/Bump(atom/movable/AM)
 	//. = ..()
 	if(istype(AM, /mob/living))
-		if(((confused || is_blind()) && stat == CONSCIOUS && prob(50) && m_intent=="run") || flying && flight_vore)
+		if(buckled != AM && (((confused || is_blind()) && stat == CONSCIOUS && prob(50) && m_intent=="run") || flying && flight_vore))
 			AM.stumble_into(src)
 	return ..()
 // Because flips toggle density
 /mob/living/Crossed(var/atom/movable/AM)
 	if(istype(AM, /mob/living) && isturf(loc) && AM != src)
 		var/mob/living/AMV = AM
-		if(((AMV.confused || AMV.is_blind()) && AMV.stat == CONSCIOUS && prob(50) && AMV.m_intent=="run") || AMV.flying && AMV.flight_vore)
+		if(AMV.buckled != src && (((AMV.confused || AMV.is_blind()) && AMV.stat == CONSCIOUS && prob(50) && AMV.m_intent=="run") || AMV.flying && AMV.flight_vore))
 			stumble_into(AMV)
 	..()
 

--- a/code/modules/vore/smoleworld/smoleworld_vr.dm
+++ b/code/modules/vore/smoleworld/smoleworld_vr.dm
@@ -132,6 +132,14 @@
 		return
 	src.set_dir(turn(src.dir, 270))
 
+/obj/structure/smoletrack/verb/rotate_counterclockwise()
+	set name = "Rotate Road Counter-Clockwise"
+	set category = "Object"
+	set src in oview(1)
+	if(ismouse(usr) || (isobserver(usr) && !config.ghost_interaction))
+		return
+	src.set_dir(turn(src.dir, 90))
+
 //color roads
 /obj/structure/smoletrack/verb/colorpieces()
 	set name = "Use Color Pieces"


### PR DESCRIPTION
Ports various bug fixes and QoL from a private downstream:

-Patches random objects in lootpiles which were intended for mapspawn only. The temporary item spawner should no longer linger after spawning its loot. 
-Adds counter-clockwise rotation to many objects.
-Prevents cortical borers from crashing VR pods.
     ^DOWNSTREAM NOTE: this change must be added to modular_chomp/.../vr_console.dm
-Tweaks blood to not proc dry timers on mapload, preventing the generation of numerous 0 tick callbacks.
-Prevents storing grabs in crates.
-Fixes look up verb when outdoors.
-Lets vehicles obey gravity and fall through open space.
-Lets the cargo tug use stairs in exchange for injury to the rider.
-Fixes med/sec bot runtimes.
-Fixes TECH_MAGNETS incorrect define.
     ^DOWNSTREAM NOTE: ml3m_cells.dm was replaced with nerd_cells.dm which must be manually fixed.
-Fixes damage/stumblevore procing every step when riding taurs/borgs while confused.
-Fixed item interaction with virus dishes.

Fixes #14108 

Downstream changelog:
:cl:
fix: random loot spawners delete properly
qol: adds counter-clockwise rotation to pipes, grave markers, windoors, infrared assemblies, vending machines, drill braces, floor tubes, chemical dispensers, water coolers, disposal pipes, shield capacitors, and micro roads
fix: prevents cortical borers from crashing VR pods
qol: removes 0 tick blood dry timers from maploaded blood
fix: prevents storing grabs in crates
fix: fixes look-up verb when outdoors
add: vehicles obey gravity
add: cargo tug can dangerously traverse stairs
fix: fixes incorrect "TECH_MAGNETS" defines
fix: fixes med/sec bot runtimes
fix: fixes injury/stumblevore proccing every step when buckled to borgs or taurs
fix: fixes item interactions with virus dishes
/:cl: