### PR TITLE
Adds auto-transfer on absorb function, selective mode chance function, and applies both to succubi

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -70,7 +70,8 @@
 	var/new_fullness = 0
 	for(var/obj/belly/B as anything in vore_organs)
 		for(var/mob/living/M in B)
-			new_fullness += M.size_multiplier
+			if(!M.absorbed || B.count_absorbed_prey_for_sprite)
+				new_fullness += M.size_multiplier
 	new_fullness = new_fullness / size_multiplier //Divided by pred's size so a macro mob won't get macro belly from a regular prey.
 	new_fullness = new_fullness * belly_size_multiplier // Some mobs are small even at 100% size. Let's account for that.
 	new_fullness = round(new_fullness, 1) // Because intervals of 0.25 are going to make sprite artists cry.

--- a/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
@@ -47,7 +47,7 @@
 	vore_standing_too = 1
 	vore_ignores_undigestable = 0
 	vore_default_mode = DM_DRAIN // They just want to drain you!
-	vore_digest_chance = 25 // But don't you dare try to escape...
+	vore_digest_chance = 0 // But don't you dare try to escape...
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 
 /datum/say_list/succubus
@@ -65,9 +65,54 @@
 	B.digest_brute = 2
 	B.digest_burn = 2
 	B.digest_oxy = 1
-	B.digestchance = 25
+	B.selectchance = 25
+	B.digestchance = 0
 	B.absorbchance = 0
 	B.escapechance = 15
-	B.selective_preference = DM_DRAIN
+	B.selective_preference = DM_DIGEST
 	B.escape_stun = 5
+	B.transferlocation_absorb = "curves"
 
+	var/obj/belly/curves = new /obj/belly(src)
+	curves.immutable = TRUE
+	curves.name = "curves"
+	curves.desc = "Your entire being is cast adrift, no longer tight as it was in the succubus's gut but still inexorably bound, a sensation of warmth surrounding your entire being - it's pleasantly comfortable, relaxing even, as though lulling you, tempting you into simply allowing yourself to drift off. It's difficult to focus on yourself at all, any sense of your own position having abandoned you - instead, you can simply feel an odd, gentle sensation of being occasionally rubbed, stroked, squeezed, your captor eager to enjoy her prize. Even trying to move seems to elicit a satisfied chuckle, almost as though she knows that, at least on some level, some part of you wanted to give yourself to her - and she seemingly has little intention of giving you back."
+	curves.digest_mode = DM_HOLD // like, shes got you already, doesn't need to get you more
+	curves.mode_flags = DM_FLAG_FORCEPSAY
+	curves.escapable = TRUE // good luck
+	curves.escapechance = 40 // high chance of STARTING a successful escape attempt
+	curves.escapechance_absorbed = 5 // m i n e
+	curves.vore_verb = "soak"
+	curves.count_absorbed_prey_for_sprite = FALSE
+	curves.absorbed_struggle_messages_inside = list(
+		"You try and push free from %pred's %belly, but can't seem to will yourself to move.",
+		"Your fruitless mental struggles only cause %pred to chuckle lightly.",
+		"You can't make any progress freeing yourself from %pred's %belly.")
+	curves.escape_attempt_absorbed_messages_owner = list(
+		"%prey is attempting to free themselves from your %belly!")
+
+	curves.escape_attempt_absorbed_messages_prey = list(
+		"You try to force yourself out of %pred's %belly.",
+		"You strain and push, attempting to reach out of %pred's %belly.",
+		"You work up the will to try and force yourself free of %pred's clutches.")
+
+	curves.escape_absorbed_messages_owner = list(
+		"%prey forces themselves free of your %belly!")
+
+	curves.escape_absorbed_messages_prey = list(
+		"You finally manage to wrest yourself free from %pred's %belly, re-asserting your more usual form.",
+		"You heave and push, eventually spilling out from %pred's %belly, eliciting an amused smile from your former captor.")
+
+	curves.escape_absorbed_messages_outside = list(
+		"%prey suddenly forces themselves free of %pred's %belly!")
+
+	curves.escape_fail_absorbed_messages_owner = list(
+		"%prey's attempt to escape form your %belly has failed!")
+
+	curves.escape_fail_absorbed_messages_prey = list(
+		"Before you manage to reach freedom, you feel yourself getting dragged back into %pred's %belly!",
+		"%pred laughs lightly, simply pressing your wrigging form back into her %belly before you get anywhere.",
+		"%pred gently rubs a finger over her %belly, the gentle pressure breaking your concentration and sending you sinking back into her form.",
+		"Try as you might, you barely make an impression before %pred simply clenches with the most minimal effort, binding you back into her %belly.",
+		"Unfortunately, %pred seems to have absolutely no intention of letting you go, and your futile effort goes nowhere.",
+		"Strain as you might, you can't keep up the effort long enough before you sink back into %pred's %belly.")

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -32,6 +32,7 @@
 	var/immutable = FALSE					// Prevents this belly from being deleted
 	var/escapable = FALSE					// Belly can be resisted out of at any time
 	var/escapetime = 10 SECONDS				// Deciseconds, how long to escape this belly
+	var/selectchance = 0					// % Chance of stomach switching to selective mode if prey struggles
 	var/digestchance = 0					// % Chance of stomach beginning to digest if prey struggles
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.
@@ -47,6 +48,7 @@
 	var/shrink_grow_size = 1				// This horribly named variable determines the minimum/maximum size it will shrink/grow prey to.
 	var/transferlocation					// Location that the prey is released if they struggle and get dropped off.
 	var/transferlocation_secondary			// Secondary location that prey is released to.
+	var/transferlocation_absorb				// Location that prey is moved to if they get absorbed.
 	var/release_sound = "Splatter"			// Sound for letting someone out. Replaced from True/false
 	var/mode_flags = 0						// Stripping, numbing, etc.
 	var/fancy_vore = FALSE					// Using the new sounds?
@@ -219,6 +221,12 @@
 
 	var/list/absorb_chance_messages_prey = list(
 		"In response to your struggling, %pred's %belly begins to cling more tightly...")
+
+	var/list/select_chance_messages_owner = list(
+		"You feel your %belly beginning to become active!")
+
+	var/list/select_chance_messages_prey = list(
+		"In response to your struggling, %pred's %belly begins to get more active...")
 
 	var/list/digest_messages_owner = list(
 		"You feel %prey's body succumb to your digestive system, which breaks it apart into soft slurry.",
@@ -1156,7 +1164,6 @@
 			if(Mm.absorbed)
 				absorb_living(Mm)
 
-
 	if(absorbed_desc)
 		//Replace placeholder vars
 		var/formatted_abs_desc
@@ -1169,6 +1176,19 @@
 	owner.updateVRPanel()
 	if(isanimal(owner))
 		owner.update_icon()
+	// Finally, if they're to be sent to a special pudge belly, send them there
+	if(transferlocation_absorb)
+		var/obj/belly/dest_belly
+		for(var/obj/belly/B as anything in owner.vore_organs)
+			if(B.name == transferlocation_absorb)
+				dest_belly = B
+				break
+		if(!dest_belly)
+			to_chat(owner, "<span class='vwarning'>Something went wrong with your belly transfer settings. Your <b>[lowertext(name)]</b> has had its transfer location cleared as a precaution.</span>")
+			transferlocation_absorb = null
+			return
+
+		transfer_contents(M, dest_belly)
 
 // Handle a mob being unabsorbed
 /obj/belly/proc/unabsorb_living(mob/living/M)
@@ -1529,7 +1549,7 @@
 			digest_mode = DM_ABSORB
 			return
 
-		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
+		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Then, let's see if it should run the digest chance.
 			var/digest_chance_owner_message = pick(digest_chance_messages_owner)
 			var/digest_chance_prey_message = pick(digest_chance_messages_prey)
 
@@ -1552,6 +1572,28 @@
 			to_chat(owner, digest_chance_owner_message)
 			digest_mode = DM_DIGEST
 			return
+		else if(prob(selectchance) && digest_mode != DM_SELECT) //Finally, let's see if it should run the selective mode chance.
+			var/select_chance_owner_message = pick(select_chance_messages_owner)
+			var/select_chance_prey_message = pick(select_chance_messages_prey)
+
+			select_chance_owner_message = replacetext(select_chance_owner_message, "%pred", owner)
+			select_chance_owner_message = replacetext(select_chance_owner_message, "%prey", R)
+			select_chance_owner_message = replacetext(select_chance_owner_message, "%belly", lowertext(name))
+			select_chance_owner_message = replacetext(select_chance_owner_message, "%countprey", living_count)
+			select_chance_owner_message = replacetext(select_chance_owner_message, "%count", contents.len)
+
+			select_chance_prey_message = replacetext(select_chance_prey_message, "%pred", owner)
+			select_chance_prey_message = replacetext(select_chance_prey_message, "%prey", R)
+			select_chance_prey_message = replacetext(select_chance_prey_message, "%belly", lowertext(name))
+			select_chance_prey_message = replacetext(select_chance_prey_message, "%countprey", living_count)
+			select_chance_prey_message = replacetext(select_chance_prey_message, "%count", contents.len)
+
+			select_chance_owner_message = "<span class='vwarning'>[select_chance_owner_message]</span>"
+			select_chance_prey_message = "<span class='vwarning'>[select_chance_prey_message]</span>"
+
+			to_chat(R, select_chance_prey_message)
+			to_chat(owner, select_chance_owner_message)
+			digest_mode = DM_SELECT
 
 		else //Nothing interesting happened.
 			to_chat(R, struggle_user_message)


### PR DESCRIPTION
Adds an automatic transfer mode to automatically move prey to a new belly when they are absorbed - primarily so you can send them to bellies with different escape chances, overlays, and so forth to the main one.

Also adds selectchance alongside absorbchance and digestchance.

Replaces digestchance with selectchance on succubi (with selective mode preference set to digest) and gives them a belly for absorbed prey to be transferred to with high escapechance but low escapechance_absorbed along with some teasy messages 'cause let's face it if you end up in there and end up pudged then that means your preferences mean you want it and that's classic succubus stealing time.

Finally, made simplemobs able to use the "count absorbed prey for sprite" var so that they can, if desired, have their tums go flat again after claiming someone. Yes, succubi do this now too.

Selectchance (and its messages) and transferlocation_absorb are not currently on the vore panel because that's tgui and save files and I don't wanna touch those.