### PR TITLE
some RS ports

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded_vr.dm
+++ b/code/game/objects/items/weapons/material/twohanded_vr.dm
@@ -71,7 +71,7 @@
 		if(unique_parry_check(user, attacker, damage_source) && prob(parry_chance))
 			user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
 			playsound(src, 'sound/weapons/punchmiss.ogg', 50, 1)
-		return 1
+			return 1
 	return 0
 
 /obj/item/weapon/material/twohanded/staff/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -222,6 +222,7 @@
 		overheat()
 	else if (overheating > 0)
 		overheating--
+		update_icon() //Port RS PR #484
 
 /obj/machinery/power/port_gen/pacman/handleInactive()
 	var/cooling_temperature = 20
@@ -239,6 +240,7 @@
 
 	if(overheating)
 		overheating--
+		update_icon() //Port RS PR #484
 
 /obj/machinery/power/port_gen/pacman/proc/overheat()
 	overheating++

--- a/code/modules/power/port_gen_vr.dm
+++ b/code/modules/power/port_gen_vr.dm
@@ -7,6 +7,33 @@
 	power_gen = 50000 //watts
 	anchored = TRUE
 
+//Port Start, RS PR #484
+/obj/machinery/power/port_gen/pacman/super/potato/Destroy()
+	. = ..()
+	cut_overlays() // sanity checks
+	set_light(0)
+
+/obj/machinery/power/port_gen/pacman/super/potato/update_icon()
+	cut_overlays()
+	set_light(0)
+	//if there was an unexploded broken state, this is where it would go. + return
+	if(active && !overheating)
+		icon_state = "potatoon"
+		var/mutable_appearance/reactorglow = mutable_appearance(icon, "eggrad", alpha = 90) //v.faint glow for reasons. the reasons being it's producing radiation as per code
+		add_overlay(reactorglow)
+		set_light(l_range = 2, l_power = 2, l_color = "#A8B0F8")
+		return
+	else if(overheating)	//The warp core is overloading, Captain!
+		icon_state = "potatodanger"	//show that it's angry, even when it's off. something something subroutine. Visual feedback!
+		if(active)	//but only glow if it's also still on, since the reaction is ongoing.
+			var/mutable_appearance/reactorglow = mutable_appearance(icon, "eggrad", alpha = 190) //more intense glow, lightings
+			add_overlay(reactorglow)
+			set_light(l_range = 5, l_power = 4, l_color = "#A8B0F8")
+		return
+	else	//off and it isn't angry, so we just vibe as 'off'
+		icon_state = initial(icon_state)
+//Port Emd, RS PR #484
+
 // Circuits for the RTGs below
 /obj/item/weapon/circuitboard/machine/rtg
 	name = T_BOARD("radioisotope TEG")


### PR DESCRIPTION
Ports https://github.com/TS-Rogue-Star/Rogue-Star/pull/484
and https://github.com/TS-Rogue-Star/Rogue-Star/pull/519
from [RogueStar](https://github.com/TS-Rogue-Star/Rogue-Star)

🆑 Upstream (RS Port)
fix: staff having 100% block chance
add: talon reactor glow
/🆑 

Downstream: deconf the staff blocking