### PR TITLE
handle speechbubble for robots

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -970,6 +970,8 @@
 		return
 
 	cut_overlays()
+	add_overlay(active_thinking_indicator)
+	add_overlay(active_typing_indicator)
 
 	icon			= sprite_datum.sprite_icon
 	icon_state		= sprite_datum.sprite_icon_state


### PR DESCRIPTION
🆑 Upstream
fix: Speechbubble disappearing on robots
/🆑 

close downstream, already added for us.