### PR TITLE
Adjusts stationside first aid spawns

### DIFF
--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -244,7 +244,7 @@
 	return pick(prob(10);/obj/item/weapon/storage/firstaid/regular,
 				prob(8);/obj/item/weapon/storage/firstaid/toxin,
 				prob(8);/obj/item/weapon/storage/firstaid/o2,
-				prob(6);/obj/item/weapon/storage/firstaid/adv,
+				prob(4);/obj/item/weapon/storage/firstaid/adv, //VOREStation Edit: 6 to 4
 				prob(8);/obj/item/weapon/storage/firstaid/fire,
 				prob(1);/obj/item/device/denecrotizer/medical, //VOREStation Add,
 				prob(1);/obj/item/weapon/storage/firstaid/combat)

--- a/code/game/objects/random/mob_vr.dm
+++ b/code/game/objects/random/mob_vr.dm
@@ -210,11 +210,12 @@
 	icon_state = "firstaid"
 
 /obj/random/tetheraid/item_to_spawn()
-	return pick(prob(4);/obj/item/weapon/storage/firstaid/regular,
-				prob(3);/obj/item/weapon/storage/firstaid/toxin,
-				prob(3);/obj/item/weapon/storage/firstaid/o2,
-				prob(2);/obj/item/weapon/storage/firstaid/adv,
-				prob(3);/obj/item/weapon/storage/firstaid/fire)
+	return pick(prob(10);/obj/item/weapon/storage/firstaid/regular,
+				prob(8);/obj/item/weapon/storage/firstaid/toxin,
+				prob(8);/obj/item/weapon/storage/firstaid/o2,
+				prob(5);/obj/item/weapon/storage/firstaid/adv,
+				prob(8);/obj/item/weapon/storage/firstaid/fire,
+				prob(1);/obj/item/device/denecrotizer/medical)
 
 //Override from maintenance.dm to prevent combat kits from spawning in Tether maintenance
 /obj/random/maintenance/item_to_spawn()

--- a/code/modules/economy/vending_machines_vr.dm
+++ b/code/modules/economy/vending_machines_vr.dm
@@ -24,6 +24,18 @@
 					/obj/item/clothing/glasses/omnihud/med = 4, /obj/item/device/glasses_kit = 1,  /obj/item/weapon/storage/quickdraw/syringe_case = 4)
 	..()
 
+/obj/machinery/vending/wallmed1/New()
+	products += list(/obj/item/bodybag/cryobag = 2)
+	..()
+
+/obj/machinery/vending/wallmed2/New()
+	products += list(/obj/item/bodybag/cryobag = 3)
+	..()
+
+/obj/machinery/vending/wallmed1/public/New()
+	products += list(/obj/item/bodybag/cryobag = 4)
+	..()
+
 // Food Machines (for event/away maps)
 
 //I want this not just as part of the zoo. ;v

--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -3719,7 +3719,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance/research,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/random/maintenance/engineering,
 /obj/random/soap,
 /obj/effect/decal/cleanable/dirt,
@@ -7836,7 +7836,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
@@ -9855,7 +9855,7 @@
 /area/offmap/aerostat/inside/xenoarch)
 "Lg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/random/maintenance/research,
 /obj/structure/sign/painting/public{
 	pixel_x = -30
@@ -10388,7 +10388,7 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/item/weapon/storage/firstaid,
 /obj/structure/cable{
 	icon_state = "1-2"

--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -898,7 +898,7 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/structure/closet/crate/xion //XION SUIT
 			),
 			prob(10);list(
-				/obj/random/firstaid,
+				/obj/random/tetheraid,
 				/obj/random/medical,
 				/obj/random/medical,
 				/obj/random/medical,
@@ -907,10 +907,10 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/structure/closet/crate/freezer/veymed //VM GRABBAG
 			),
 			prob(10);list(
-				/obj/random/firstaid,
-				/obj/random/firstaid,
-				/obj/random/firstaid,
-				/obj/random/firstaid,
+				/obj/random/tetheraid,
+				/obj/random/tetheraid,
+				/obj/random/tetheraid,
+				/obj/random/tetheraid,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/structure/closet/crate/freezer/veymed //VM FAKS
@@ -931,7 +931,7 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/structure/closet/crate/xion //XION SUPPLY
 			),
 			prob(10);list(
-				/obj/random/firstaid,
+				/obj/random/tetheraid,
 				/obj/random/medical,
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/pillbottle,

--- a/maps/redgate/cybercity.dmm
+++ b/maps/redgate/cybercity.dmm
@@ -4172,7 +4172,7 @@
 /area/redgate/city/waterworks)
 "fEr" = (
 /obj/structure/table/glass,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/city/hospital)
 "fEG" = (
@@ -17937,7 +17937,7 @@
 /obj/random/medical/pillbottle,
 /obj/random/medical/pillbottle,
 /obj/random/medical/pillbottle,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/city/hospital)
 "xwF" = (
@@ -18193,8 +18193,8 @@
 /area/redgate/city/gym)
 "xUz" = (
 /obj/structure/table/rack,
-/obj/random/tetheraid,
-/obj/random/tetheraid,
+/obj/random/firstaid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/redgate/city/hospital)
 "xVb" = (

--- a/maps/redgate/facility.dmm
+++ b/maps/redgate/facility.dmm
@@ -698,7 +698,7 @@
 "bgg" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloor,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/ne)
 "bil" = (
@@ -9751,7 +9751,7 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/wood/alt,
 /area/redgate/facility/office7)
 "nJx" = (
@@ -12444,7 +12444,7 @@
 	},
 /obj/item/clothing/shoes/slippers,
 /obj/item/clothing/under/pants/black,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/office6)
 "rDk" = (
@@ -13359,7 +13359,7 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/random/medical/pillbottle,
 /obj/random/medical/pillbottle,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/office7)
 "sSG" = (
@@ -15443,7 +15443,7 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/medbay)
 "vMh" = (

--- a/maps/redgate/jungle_underground.dmm
+++ b/maps/redgate/jungle_underground.dmm
@@ -3169,7 +3169,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/redgate/jungle/facilitynw)
 "MA" = (
-/obj/random/tetheraid,
+/obj/random/firstaid,
 /turf/simulated/floor,
 /area/redgate/jungle/facilityne)
 "MD" = (

--- a/maps/redgate/train_upper.dmm
+++ b/maps/redgate/train_upper.dmm
@@ -710,9 +710,9 @@
 /area/redgate/train/dining)
 "lp" = (
 /obj/structure/closet/walllocker_double/medical/east,
-/obj/random/tetheraid,
-/obj/random/tetheraid,
-/obj/random/tetheraid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
 /obj/item/clothing/gloves/sterile/nitrile,
 /obj/item/clothing/gloves/sterile/nitrile,
 /obj/item/weapon/storage/belt/medical,

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -1194,7 +1194,7 @@
 /area/maintenance/stellardelight/deck3/starboardcent)
 "ed" = (
 /obj/structure/closet,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/portaft)
 "eg" = (
@@ -4709,7 +4709,7 @@
 /area/stellardelight/deck3/exterior)
 "qM" = (
 /obj/structure/table/steel,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/foreportrooma)
 "qN" = (
@@ -6516,7 +6516,7 @@
 /area/stellardelight/deck3/starboarddock)
 "xE" = (
 /obj/structure/closet,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/random/maintenance,
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,


### PR DESCRIPTION
Stationside/Talonside first aid kit spawns should not have combat first aid kits

- Swaps stationside first aid kit spawns on Talon, Stellar Delight, and the V2 Outpost to Tetheraid spawns
- Redgates consistently use the firstaid spawners rather than tetheraid
- Adds the medical denecrotizer as a possibility to tetheraid spawners
- Public wallmeds now have access to some stasis bags