### PR TITLE
Required admin privileges restrictions

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -47,6 +47,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 //opens the ticket listings for one of the 3 states
 /datum/admin_help_tickets/proc/BrowseTickets(state)
+	if(!check_rights(R_ADMIN|R_SERVER)) //Prevents non-staff from opening the list of ahelp tickets
+		return
 	var/list/l2b
 	var/title
 	switch(state)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -169,7 +169,8 @@
 	// Admins with RLOOC displayed who weren't already in
 	for(var/client/admin in GLOB.admins)
 		if(!(admin in receivers) && admin.is_preference_enabled(/datum/client_preference/holder/show_rlooc))
-			r_receivers |= admin
+			if(check_rights(R_SERVER, FALSE, admin)) //Stop rLOOC showing for retired staff
+				r_receivers |= admin
 
 	msg = GLOB.is_valid_url.Replace(msg,"<span class='linkify'>$1</span>")
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -743,7 +743,8 @@
 						SS.stat_entry()
 
 			if(statpanel("Tickets"))
-				GLOB.ahelp_tickets.stat_entry()
+				if(check_rights(R_ADMIN|R_SERVER,FALSE)) //Prevents non-staff from opening the list of ahelp tickets
+					GLOB.ahelp_tickets.stat_entry()
 
 
 			if(length(GLOB.sdql2_queries))


### PR DESCRIPTION
Added a check to ranged LOOC to only broadcast them to active staff.

Added a check to the ahelp ticket panel to only allow active staff to view them.

Thank you a little birdy for pointing these out and a shadowy cat for helping me find the relevant bits.