### PR TITLE
Fix for bait toy

### DIFF
--- a/code/game/objects/items/toys/toys_vr.dm
+++ b/code/game/objects/items/toys/toys_vr.dm
@@ -1163,6 +1163,9 @@
 
 /obj/item/weapon/toy/monster_bait/afterattack(var/atom/A, var/mob/user)
 	var/mob/living/simple_mob/M = A
+	if(M.z != user.z || get_dist(user,M) > 1)
+		to_chat(user, "<span class='notice'>You need to stand right next to \the [M] to bait it.</span>")
+		return
 	if(!istype(M))
 		return
 	if(!M.vore_active)


### PR DESCRIPTION
Fixed the monster bait toy so that it can only be used on mobs immediately next to you, preventing them from telekinetically shoving you over.