### PR TITLE
Make config.sql_enabled actually respected in all cases

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -584,6 +584,8 @@ var/failed_old_db_connections = 0
 	return 1
 
 /proc/setup_database_connection()
+	if(!config.sql_enabled)
+		return 0
 	if(failed_db_connections > FAILED_DB_CONNECTION_CUTOFF)	//If it failed to establish a connection more than 5 times in a row, don't bother attempting to conenct anymore.
 		return 0
 
@@ -628,6 +630,8 @@ var/failed_old_db_connections = 0
 
 //These two procs are for the old database, while it's being phased out. See the tgstation.sql file in the SQL folder for more information.
 /proc/setup_old_database_connection()
+	if(!config.sql_enabled)
+		return 0
 
 	if(failed_old_db_connections > FAILED_DB_CONNECTION_CUTOFF)	//If it failed to establish a connection more than 5 times in a row, don't bother attempting to conenct anymore.
 		return 0


### PR DESCRIPTION
setup_database_connection() and establish_db_connection() are called from some places in the code, ignoring the config option to not even try connecting to SQL. this is just fixing a minor annoyance for devs that don't run sql.