### PR TITLE
Removed negative trait limit

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -279,7 +279,8 @@ var/global/list/valid_bloodreagents = list("default","iron","copper","phoron","s
 
 	for(var/T in pref.pos_traits + pref.neg_traits)
 		points_left -= traits_costs[T]
-		traits_left--
+		if(T in pref.pos_traits)
+			traits_left--
 	. += "<b>Traits Left:</b> [traits_left]<br>"
 	. += "<b>Points Left:</b> [points_left]<br>"
 	if(points_left < 0 || traits_left < 0 || (!pref.custom_species && pref.species == SPECIES_CUSTOM))

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -39,35 +39,35 @@
 			pass = FALSE
 			to_chat(src,"<span class='warning'>You have to name your custom species. Do this on the VORE tab in character setup.</span>")
 
-		//Check traits/costs
-		var/list/megalist = client.prefs.pos_traits + client.prefs.neu_traits + client.prefs.neg_traits
-		var/points_left = client.prefs.starting_trait_points
-		var/traits_left = client.prefs.max_traits
-		var/pref_synth = client.prefs.dirty_synth
-		var/pref_meat = client.prefs.gross_meatbag
-		for(var/datum/trait/T as anything in megalist)
-			var/cost = traits_costs[T]
+	//Check traits/costs
+	var/list/megalist = client.prefs.pos_traits + client.prefs.neu_traits + client.prefs.neg_traits
+	var/points_left = client.prefs.starting_trait_points
+	var/traits_left = client.prefs.max_traits
+	var/pref_synth = client.prefs.dirty_synth
+	var/pref_meat = client.prefs.gross_meatbag
+	for(var/datum/trait/T as anything in megalist)
+		var/cost = traits_costs[T]
 
-			if(cost)
-				traits_left--
+		if(T.category == TRAIT_TYPE_POSITIVE)
+			traits_left--
 
-			//A trait was removed from the game
-			if(isnull(cost))
-				pass = FALSE
-				to_chat(src,"<span class='warning'>Your custom species is not playable. One or more traits appear to have been removed from the game or renamed. Enter character setup to correct this.</span>")
-				break
-			else
-				points_left -= traits_costs[T]
-
-			var/take_flags = initial(T.can_take)
-			if((pref_synth && !(take_flags & SYNTHETICS)) || (pref_meat && !(take_flags & ORGANICS)))
-				pass = FALSE
-				to_chat(src, "<span class='warning'>Some of your traits are not usable by your character type (synthetic traits on organic, or vice versa).</span>")
-
-		//Went into negatives
-		if(points_left < 0 || traits_left < 0)
+		//A trait was removed from the game
+		if(isnull(cost))
 			pass = FALSE
-			to_chat(src,"<span class='warning'>Your custom species is not playable. Reconfigure your traits on the VORE tab.</span>")
+			to_chat(src,"<span class='warning'>Your species is not playable. One or more traits appear to have been removed from the game or renamed. Enter character setup to correct this.</span>")
+			break
+		else
+			points_left -= traits_costs[T]
+
+		var/take_flags = initial(T.can_take)
+		if((pref_synth && !(take_flags & SYNTHETICS)) || (pref_meat && !(take_flags & ORGANICS)))
+			pass = FALSE
+			to_chat(src, "<span class='warning'>Some of your traits are not usable by your character type (synthetic traits on organic, or vice versa).</span>")
+
+	//Went into negatives
+	if(points_left < 0 || traits_left < 0)
+		pass = FALSE
+		to_chat(src,"<span class='warning'>Your species is not playable. Reconfigure your traits on the VORE tab. Trait points: [points_left]. Traits left: [traits_left].</span>")
 
 	//Final popup notice
 	if (!pass)


### PR DESCRIPTION
This PR was made for staff discussion and should not be merged until staff agree on it.

Changed negative traits to no longer reduce the "traits left" count, allowing you to take as many as you would like. This allows people to potentially take up to five positive traits, provided that they take enough negative traits to gain the points.

Fixed non-custom species being able to completely ignore trait count and trait point limits.