### PR TITLE
Mini Hacktool Expansion

### DIFF
--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -91,6 +91,14 @@
 					/obj/item/clothing/mask/gas/voice,
 					/obj/item/weapon/makeover
 					),
+			list( //the hacker,
+					/obj/item/weapon/gun/projectile/silenced,
+					/obj/item/weapon/gun/energy/ionrifle/pistol,
+					/obj/item/clothing/glasses/thermal/syndi,
+					/obj/item/ammo_magazine/m45/ap,
+					/obj/item/weapon/material/knife/tacknife/combatknife,
+					/obj/item/device/multitool/hacktool
+					),
 			list( //the professional,
 					/obj/item/weapon/gun/projectile/silenced,
 					/obj/item/weapon/gun/energy/ionrifle/pistol,


### PR DESCRIPTION
Slightly expands the hacktool accessibility and functionality by adding a new set of goodies to the contraband NULL crate and allowing it to hack both locked crates and lockers. Hacking crates and lockers takes half as long as doors, and they don't have security level modifiers.

Hopefully more functions and accessibility will come Soon:tm: - possibly a slightly adjusted hacktool as a rare maint loot spawn, perhaps? Gotta mull things over.

:cl:
tweak: hacktools can now be found in a new NULL contraband crate set
tweak: hacktools can now hack secure crates and lockers open (but not relock them)
/:cl: