### PR TITLE
textbox not respecting value changes

### DIFF
--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -79,14 +79,21 @@ export const createMessage = (payload) => ({
   ...payload,
 });
 
-export const serializeMessage = (message, archive = false) => ({
-  type: message.type,
-  text: message.text,
-  html: archive ? message.node.outerHTML : message.html,
-  times: message.times,
-  createdAt: message.createdAt,
-  roundId: message.roundId,
-});
+export const serializeMessage = (message, archive = false) => {
+  let archiveM = '';
+  if (archive) {
+    archiveM = message.node.outerHTML.replace(/(?:\r\n|\r|\n)/g, '<br>');
+    alert(message.node.outerHTML);
+  }
+  return {
+    type: message.type,
+    text: message.text,
+    html: archive ? archiveM : message.html,
+    times: message.times,
+    createdAt: message.createdAt,
+    roundId: message.roundId,
+  };
+};
 
 export const isSameMessage = (a, b) =>
   (typeof a.text === 'string' && a.text === b.text) ||

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -83,7 +83,6 @@ export const serializeMessage = (message, archive = false) => {
   let archiveM = '';
   if (archive) {
     archiveM = message.node.outerHTML.replace(/(?:\r\n|\r|\n)/g, '<br>');
-    alert(message.node.outerHTML);
   }
   return {
     type: message.type,

--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -162,11 +162,11 @@ export function Input(props: Props) {
 
   useEffect(() => {
     const input = inputRef.current;
-    if (!input) return;
+    if (!input || editing) return;
 
     const newValue = toInputValue(value);
 
-    if (input.value !== newValue && !editing) input.value = newValue;
+    if (input.value !== newValue) input.value = newValue;
   });
 
   return (

--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -140,10 +140,6 @@ export function Input(props: Props) {
     const input = inputRef.current;
     if (!input) return;
 
-    const newValue = toInputValue(value);
-
-    if (input.value !== newValue) input.value = newValue;
-
     if (!autoFocus && !autoSelect) return;
 
     setTimeout(() => {
@@ -154,6 +150,14 @@ export function Input(props: Props) {
       }
     }, 1);
   }, []);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const newValue = toInputValue(value);
+    if (input.value !== newValue) input.value = newValue;
+  });
 
   return (
     <Box

--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -126,7 +126,6 @@ export function Input(props: Props) {
         event.currentTarget.blur();
         onChange?.(event, event.currentTarget.value);
       }
-      editing = false;
 
       return;
     }

--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -102,11 +102,8 @@ export function Input(props: Props) {
   // The ref to the input field
   const inputRef = useRef<HTMLInputElement>(null);
 
-  let editing = false;
-
   function handleInput(event: SyntheticEvent<HTMLInputElement>) {
     if (!onInput) return;
-    editing = true;
 
     const value = event.currentTarget?.value;
 
@@ -151,7 +148,6 @@ export function Input(props: Props) {
 
     setTimeout(() => {
       input.focus();
-      editing = true;
 
       if (autoSelect) {
         input.select();
@@ -161,7 +157,11 @@ export function Input(props: Props) {
 
   useEffect(() => {
     const input = inputRef.current;
-    if (!input || editing) return;
+    if (!input) return;
+
+    if (document.activeElement === input) {
+      return;
+    }
 
     const newValue = toInputValue(value);
 

--- a/tgui/packages/tgui/components/Input.tsx
+++ b/tgui/packages/tgui/components/Input.tsx
@@ -102,8 +102,11 @@ export function Input(props: Props) {
   // The ref to the input field
   const inputRef = useRef<HTMLInputElement>(null);
 
+  let editing = false;
+
   function handleInput(event: SyntheticEvent<HTMLInputElement>) {
     if (!onInput) return;
+    editing = true;
 
     const value = event.currentTarget?.value;
 
@@ -123,6 +126,7 @@ export function Input(props: Props) {
         event.currentTarget.blur();
         onChange?.(event, event.currentTarget.value);
       }
+      editing = false;
 
       return;
     }
@@ -140,10 +144,15 @@ export function Input(props: Props) {
     const input = inputRef.current;
     if (!input) return;
 
+    const newValue = toInputValue(value);
+
+    if (input.value !== newValue) input.value = newValue;
+
     if (!autoFocus && !autoSelect) return;
 
     setTimeout(() => {
       input.focus();
+      editing = true;
 
       if (autoSelect) {
         input.select();
@@ -156,7 +165,8 @@ export function Input(props: Props) {
     if (!input) return;
 
     const newValue = toInputValue(value);
-    if (input.value !== newValue) input.value = newValue;
+
+    if (input.value !== newValue && !editing) input.value = newValue;
   });
 
   return (


### PR DESCRIPTION
🆑 Upstream
fix: textinput not updating on value changes
qol: archive now preserves newlines
/🆑 

Brings back the editing state and rerenders the textbox once it's no longer edited. This once more allows the value to update on state changes.

fixes #16239