### PR TITLE
prefs and scaling

### DIFF
--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -31,12 +31,7 @@
 	character.capture_crystal = pref.capture_crystal
 	//Vore Stomach Sprite Preference
 	character.stomach_vision = pref.stomach_vision
-	if((character && !istype(character,/mob/living/carbon/human/dummy)) && character.stomach_vision && !(VIS_CH_STOMACH in character.vis_enabled))
-		character.plane_holder.set_vis(VIS_CH_STOMACH,TRUE)
-		character.vis_enabled += VIS_CH_STOMACH
-	else if((character && !istype(character,/mob/living/carbon/human/dummy)) && !character.stomach_vision && (VIS_CH_STOMACH in character.vis_enabled))
-		character.plane_holder.set_vis(VIS_CH_STOMACH,FALSE)
-		character.vis_enabled -= VIS_CH_STOMACH
+	character.recalculate_vis()
 
 /datum/category_item/player_setup_item/vore/misc/sanitize_character()
 	pref.show_in_directory		= sanitize_integer(pref.show_in_directory, 0, 1, initial(pref.show_in_directory))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1417,6 +1417,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		vore_belly_image.layer = BODY_LAYER+VORE_BELLY_LAYER
 		overlays_standing[VORE_BELLY_LAYER] = vore_belly_image
 		vore_belly_image.plane = PLANE_CH_STOMACH //This one line of code. This ONE LINE OF CODE TOOK 6 HOURS TO FIGURE OUT. THANK YOU REDCAT.
+		vore_belly_image.appearance_flags = appearance_flags
 
 	apply_layer(VORE_BELLY_LAYER)
 
@@ -1449,6 +1450,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		vore_tail_image.layer = BODY_LAYER+VORE_TAIL_LAYER
 		overlays_standing[VORE_TAIL_LAYER] = vore_tail_image
 		vore_tail_image.plane = PLANE_CH_STOMACH //This one line of code. This ONE LINE OF CODE TOOK 6 HOURS TO FIGURE OUT. THANK YOU REDCAT.
+		vore_tail_image.appearance_flags = appearance_flags
 
 	apply_layer(VORE_TAIL_LAYER)
 


### PR DESCRIPTION
Close downstream, already done for us

transfers the mob's appearance flags to the new image...
uses the calculate_vis proc which is sanity checked for the pref loading to prevent early loading fails what could lead to corrupted saves due to failed pref loading.