### PR TITLE
fix belly sprite vis toggling

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -173,8 +173,6 @@
 
 	if(CE_DARKSIGHT in chem_effects) //Putting this near the beginning so it can be overwritten by equipment
 		compiled_vis += VIS_FULLBRIGHT
-	else
-		compiled_vis -= VIS_FULLBRIGHT
 
 	for(var/slot in slots)
 		var/obj/item/clothing/O = get_equipped_item(slot) //Change this type if you move the vision stuff to item or something.
@@ -200,8 +198,6 @@
 	//Vore Stomach addition start. This goes here.
 	if(stomach_vision)
 		compiled_vis += VIS_CH_STOMACH
-	else
-		compiled_vis -= VIS_CH_STOMACH
 	//Vore Stomach addition end
 
 	if(!compiled_vis.len && !vis_enabled.len)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -172,10 +172,8 @@
 	var/list/compiled_vis = list()
 
 	if(CE_DARKSIGHT in chem_effects) //Putting this near the beginning so it can be overwritten by equipment
-		plane_holder.set_vis(VIS_FULLBRIGHT,TRUE)
 		compiled_vis += VIS_FULLBRIGHT
 	else
-		plane_holder.set_vis(VIS_FULLBRIGHT,FALSE)
 		compiled_vis -= VIS_FULLBRIGHT
 
 	for(var/slot in slots)
@@ -200,11 +198,9 @@
 	//VOREStation Add End
 
 	//Vore Stomach addition start. This goes here.
-	if(stomach_vision && !(VIS_CH_STOMACH in vis_enabled))
-		plane_holder.set_vis(VIS_CH_STOMACH,TRUE)
+	if(stomach_vision)
 		compiled_vis += VIS_CH_STOMACH
-	else if(!stomach_vision && (VIS_CH_STOMACH in vis_enabled))
-		plane_holder.set_vis(VIS_CH_STOMACH,FALSE)
+	else
 		compiled_vis -= VIS_CH_STOMACH
 	//Vore Stomach addition end
 


### PR DESCRIPTION
Unlike with mobs, for humans, the entire list is recompiled on each call of the proc

🆑 Upstream
fix: fixed an issue which could lead to belly sprite vis toggling on carbon/human mobs
/🆑 