### PR TITLE
Facility map fix

### DIFF
--- a/maps/redgate/facility.dmm
+++ b/maps/redgate/facility.dmm
@@ -6596,7 +6596,7 @@
 /area/redgate/facility/ne)
 "iWh" = (
 /obj/item/weapon/paper/crumpled/bloody{
-	info = "Report: The Canidfelanis specimens have take a sudden disliking to the lights in their study cell. It's becoming difficult to obser
+	info = "Report: The Canidfelanis specimens have take a sudden disliking to the lights in their study cell. It's becoming difficult to obser"
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;


### PR DESCRIPTION
Fixed an issue where some programmes could not open the facility redgate map due to an incomplete set of quotation marks.