### PR TITLE
preemptively remove empty strings from bad formatting

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -941,6 +941,10 @@
 		raw_list = splittext(html_encode(raw_text), delim)
 	else
 		raw_list = list(raw_text)
+	for(var/i = 1, i <= raw_list.len, i++)
+		if(!raw_list[i].len)
+			raw_list.Cut(i, i + 1)
+			i--
 	if(raw_list.len > 10)
 		raw_list.Cut(11)
 		log_debug("[owner] tried to set [lowertext(name)] with 11+ messages")

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -942,7 +942,7 @@
 	else
 		raw_list = list(raw_text)
 	for(var/i = 1, i <= raw_list.len, i++)
-		if(!raw_list[i].len)
+		if(!length(raw_list[i]))
 			raw_list.Cut(i, i + 1)
 			i--
 	if(raw_list.len > 10)


### PR DESCRIPTION
🆑 Upstream
qol: preemptively drop empty strings from the belly text sanity in case someone accidentally entered /n/n/n/n
/🆑 