### PR TITLE
fix alarm proc calls

### DIFF
--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/computer/station_alert/Initialize()
 	alarm_monitor = new monitor_type(src)
-	alarm_monitor.register_alarm(src, /atom/proc/update_icon)
+	alarm_monitor.register_alarm(src, "update_icon")
 	. = ..()
 
 /obj/machinery/computer/station_alert/Destroy()


### PR DESCRIPTION
🆑 Upstream
fix: fixes alarm proc calls failing
/🆑 

Reference: 
```
call(ProcRef)(Arguments)
call(Object,ProcName)(Arguments)
```

It is either to call it with only a path, or to call it with an object and the name. Not object and path!

https://github.com/VOREStation/VOREStation/blob/29e4444c4b4af21b7d7a62afaaa3fe3e0e28b5e2/code/modules/alarm/alarm_handler.dm#L106