### PR TITLE
Temporarily disables sleeping on simple mobs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1334,6 +1334,11 @@
 /mob/living/verb/mob_sleep()
 	set name = "Sleep"
 	set category = "IC"
+
+	if(istype(src, /mob/living/simple_mob))
+		to_chat(src, SPAN_NOTICE("Sleeping is currently disabled on simple mobs due to a bug."))
+		return
+
 	if(!toggled_sleeping && alert(src, "Are you sure you wish to go to sleep? You will snooze until you use the Sleep verb again.", "Sleepy Time", "No", "Yes") == "No")
 		return
 	toggled_sleeping = !toggled_sleeping


### PR DESCRIPTION
Temporarily fixes https://github.com/VOREStation/VOREStation/issues/16077

Due to a bug that causes them to never wake up again, the previous attempt at fixing this caused death to stop working, so I'll leave it like this until a solution is found whilst leaving the option in for carbon mobs.

Not the most elegant solution but hopefully only temporary, seeing as simple mobs may be even more accessible to players soon.