### PR TITLE
Add examine_block to mob examine

### DIFF
--- a/code/__defines/chat.dm
+++ b/code/__defines/chat.dm
@@ -34,3 +34,6 @@
 #define MESSAGE_TYPE_ADMINLOG "adminlog"
 #define MESSAGE_TYPE_ATTACKLOG "attacklog"
 #define MESSAGE_TYPE_DEBUG "debug"
+
+/// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
+#define examine_block(str) ("<div class='examine_block'>" + str + "</div>")

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -112,7 +112,10 @@
 	var/list/results = A.examine(src)
 	if(!results || !results.len)
 		results = list("You were unable to examine that. Tell a developer!")
-	to_chat(src, "<span class='infoplain'>[jointext(results, "<br>")]</span>")
+	var/final_string = "<span class='infoplain'>[jointext(results, "<br>")]</span>"
+	if(ismob(A)) // mob descriptions matter more than others
+		final_string = examine_block(final_string)
+	to_chat(src, final_string)
 	update_examine_panel(A)
 
 /mob/proc/update_examine_panel(var/atom/A)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -101,7 +101,7 @@
 		else if(species.name != "Human")
 			name_ender = ", <b><font color='[species.get_flesh_colour(src)]'>\a [species.get_examine_name()]!</font></b>[species.get_additional_examine_text(src)]"
 
-	var/list/msg = list("<span class='info'>*---------*","This is [icon2html(src, user.client)] <EM>[src.name]</EM>[name_ender]")
+	var/list/msg = list("<span class='info'>","This is [icon2html(src, user.client)] <EM>[src.name]</EM>[name_ender]")
 
 	//uniform
 	if(w_uniform && !(skip_gear & EXAMINE_SKIPJUMPSUIT) && w_uniform.show_examine)
@@ -440,7 +440,7 @@
 		msg += "OOC Notes: <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[src];print_ooc_notes_to_chat=1'>\[Print\]</a>"
 	msg += "<a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>"
 	// VOREStation End
-	msg += "*---------*</span>"
+	msg += "</span>"
 	if(applying_pressure)
 		msg += applying_pressure
 

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -28,11 +28,11 @@
 		if(deployed_shell)
 			. += "The wireless networking light is blinking."
 
-	. += "*---------*"
-	
+	. += ""
+
 	if(hardware && (hardware.owner == src))
 		. += hardware.get_examine_desc()
-	
+
 	user.showLaws(src)
 
 /mob/proc/showLaws(var/mob/living/silicon/S)

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -6,12 +6,12 @@
 			if(!src.client)	. += "It appears to be in stand-by mode." //afk
 		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
-	
+
 	// VOREStation Edit: Start
 	. += attempt_vr(src,"examine_bellies",args) //VOREStation Edit
 	if(print_flavor_text()) . += "\n[print_flavor_text()]\n"
 	// VOREStation Edit: End
-	. += "*---------*"
+	. += ""
 	if (pose)
 		if(!findtext(pose, regex("\[.?!]$"))) // Will be zero if the last character is not a member of [.?!]
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -34,7 +34,7 @@
 	. += attempt_vr(src,"examine_bellies_borg",args) //VOREStation Edit
 	// VOREStation Edit: End
 
-	. += "*---------*"
+	. += ""
 
 	if(print_flavor_text()) . += "<br>[print_flavor_text()]"
 


### PR DESCRIPTION
It looks like this:

![https://i.tigercat2000.net/2024/09/dreamseeker_xxtd6ekguH.png](https://i.tigercat2000.net/2024/09/dreamseeker_xxtd6ekguH.png)
![https://i.tigercat2000.net/2024/09/dreamseeker_FyrF2TGFiC.png](https://i.tigercat2000.net/2024/09/dreamseeker_FyrF2TGFiC.png)

:cl:
add: Examining a mob now puts their description in a box. It's pretty.
/:cl: