### PR TITLE
Add spacebar throwing to hotkey mode

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1205,6 +1205,18 @@
 	if(src.throw_icon && !issilicon(src)) // Silicon use this for something else. Do not overwrite their HUD icon
 		src.throw_icon.icon_state = "act_throw_on"
 
+/mob/verb/spacebar_throw_on()
+	set name = ".throwon"
+	set hidden = TRUE
+	set instant = TRUE
+	throw_mode_on()
+
+/mob/verb/spacebar_throw_off()
+	set name = ".throwoff"
+	set hidden = TRUE
+	set instant = TRUE
+	throw_mode_off()
+
 /mob/proc/isSynthetic()
 	return 0
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -792,6 +792,12 @@ macro "hotkeymode"
 	elem
 		name = "CTRL+SHIFT+SUBTRACT"
 		command = "planedown"
+	elem
+		name = "Space"
+		command = ".throwon"
+	elem
+		name = "Space+UP"
+		command = ".throwoff"
 
 macro "borgmacro"
 	elem


### PR DESCRIPTION
![https://i.tigercat2000.net/2024/09/dreamseeker_tOiMNtP8V2.gif](https://i.tigercat2000.net/2024/09/dreamseeker_tOiMNtP8V2.gif)

As in title, this allows you to hold spacebar to throw items when in hotkey mode.

:cl:
add: You can now hold spacebar to throw items.
/:cl: