### PR TITLE
Mega Nukies Disallowed From Vacuum Flask

### DIFF
--- a/code/modules/food/food/lunch.dm
+++ b/code/modules/food/food/lunch.dm
@@ -121,7 +121,15 @@ var/list/lunchables_drink_reagents_ = list(/datum/reagent/drink/nothing,
                                            /datum/reagent/drink/dry_ramen,
                                            /datum/reagent/drink/hell_ramen,
                                            /datum/reagent/drink/hot_ramen,
-                                           /datum/reagent/drink/soda/nuka_cola)
+                                           /datum/reagent/drink/soda/nuka_cola,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_sight,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_heart,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_sleep,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_shock,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_fast,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_high,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_shrink,
+                                           /obj/item/weapon/reagent_containers/food/drinks/cans/nukie_mega_grow)
 
 
 // This default list is a bit different, it contains items we don't want


### PR DESCRIPTION
Removed Mega Nukies from the possible drinks that can start in a vacuum flask. I had simply forgot this was a thing when I made them, and they're supposed to be a tiny bit rare and also are a bit too powerful as a starting item.