### PR TITLE
Robot Mining ID

### DIFF
--- a/code/game/objects/items/weapons/id cards/cards.dm
+++ b/code/game/objects/items/weapons/id cards/cards.dm
@@ -268,3 +268,30 @@
 		reset_icon()
 		return
 	return
+
+/obj/item/weapon/card/id/cargo/miner/borg
+	var/mob/living/silicon/robot/R
+	var/last_robot_loc
+	name = "Robot Miner ID"
+
+/obj/item/weapon/card/id/cargo/miner/borg/Initialize()
+	. = ..()
+	R = loc.loc
+	registered_name = R.braintype
+	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(check_loc))
+
+/obj/item/weapon/card/id/cargo/miner/borg/proc/check_loc(atom/movable/mover, atom/old_loc, atom/new_loc)
+	if(old_loc == R || old_loc == R.module)
+		last_robot_loc = old_loc
+	if(!istype(loc, /obj/machinery) && loc != R && loc != R.module)
+		if(last_robot_loc)
+			forceMove(last_robot_loc)
+			last_robot_loc = null
+		else
+			forceMove(R)
+		if(loc == R)
+			hud_layerise()
+
+/obj/item/weapon/card/id/cargo/miner/borg/Destroy()
+	UnregisterSignal(src, COMSIG_OBSERVER_MOVED)
+	..()

--- a/code/modules/mining/machinery/machine_processing.dm
+++ b/code/modules/mining/machinery/machine_processing.dm
@@ -43,7 +43,7 @@
 	if(istype(I, /obj/item/weapon/card/id))
 		if(!powered())
 			return
-		if(!inserted_id && user.unEquip(I))
+		if(!inserted_id && (user.unEquip(I) || isrobot(user)))
 			I.forceMove(src)
 			inserted_id = I
 			SStgui.update_uis(src)
@@ -347,4 +347,3 @@
 #undef PROCESS_SMELT
 #undef PROCESS_COMPRESS
 #undef PROCESS_ALLOY
-

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -310,7 +310,7 @@
 	if(istype(I,/obj/item/weapon/card/id))
 		if(!powered())
 			return
-		else if(!inserted_id && (user.unEquip(I)  || isrobot(user)))
+		else if(!inserted_id && (user.unEquip(I) || isrobot(user)))
 			I.forceMove(src)
 			inserted_id = I
 			tgui_interact(user)

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -310,7 +310,7 @@
 	if(istype(I,/obj/item/weapon/card/id))
 		if(!powered())
 			return
-		else if(!inserted_id && user.unEquip(I))
+		else if(!inserted_id && (user.unEquip(I)  || isrobot(user)))
 			I.forceMove(src)
 			inserted_id = I
 			tgui_interact(user)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -679,6 +679,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	src.modules += new /obj/item/weapon/gripper/miner(src)
 	src.modules += new /obj/item/weapon/mining_scanner(src)
+	src.modules += new /obj/item/weapon/card/id/cargo/miner/borg(src)
 	src.emag += new /obj/item/weapon/kinetic_crusher/machete/dagger(src)
 
 	src.modules += new /obj/item/device/dogborg/sleeper/compactor/supply(src)


### PR DESCRIPTION
closes #16297

It's always been a hassle to get access to upgrades, this should make it easier for mining robots to access them as well as to claim their points.

🆑 Upstream
add: Mining id to mining / cargo robots
/🆑 