### PR TITLE
slots are saved on load

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -485,9 +485,11 @@ var/list/preferences_datums = list()
 		error("Player picked [choice] slot to load, but that wasn't one we sent.")
 		return
 
+	load_preferences()
 	load_character(slotnum)
 	attempt_vr(user.client?.prefs_vr,"load_vore","") //VOREStation Edit
 	sanitize_preferences()
+	save_preferences()
 	ShowChoices(user)
 
 /datum/preferences/proc/open_copy_dialog(mob/user)


### PR DESCRIPTION
~~Something to look into first, @ShadowLarkens~~
Checked, works.

When we load a character, we reload the prefs, then once the slot has updated, we save it again.