### PR TITLE
move alert icon call to it's own proc

### DIFF
--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/computer/station_alert/Initialize()
 	alarm_monitor = new monitor_type(src)
-	alarm_monitor.register_alarm(src, "update_icon")
+	alarm_monitor.register_alarm(src, "update_console_icon")
 	. = ..()
 
 /obj/machinery/computer/station_alert/Destroy()
@@ -44,11 +44,13 @@
 /obj/machinery/computer/station_alert/tgui_interact(mob/user)
 	alarm_monitor.tgui_interact(user)
 
-/obj/machinery/computer/station_alert/update_icon()
+/obj/machinery/computer/station_alert/proc/update_console_icon()
 	if(!(stat & (BROKEN|NOPOWER)))
+		var/last_icon = icon_screen
 		var/list/alarms = alarm_monitor ? alarm_monitor.major_alarms() : list()
 		if(alarms.len)
 			icon_screen = "alert:2"
 		else
 			icon_screen = initial(icon_screen)
-	..()
+		if(last_icon != icon_screen)
+			update_icon()


### PR DESCRIPTION
Don't call update icon, unless we actually change the state

🆑 Upstream
fix: alert console calling the sound proc over and over
/🆑 

fixes #16304