### PR TITLE
Remove unused console

### DIFF
--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -257,10 +257,6 @@
 	name = "dorm seven holodeck control"
 	projection_area = /area/crew_quarters/sleep/Dorm_7/holo
 
-/obj/machinery/computer/HolodeckControl/holodorm/warship
-	name = "warship holodeck control"
-	projection_area = /area/mothership/holodeck/holo
-
 // Our map is small, if the supermatter is ejected lets not have it just blow up somewhere else
 /obj/machinery/power/supermatter/touch_map_edge()
 	qdel(src)


### PR DESCRIPTION
A ship was removed that used this console. This console references an area which no longer exists, which causes tether to fail to compile.

Removing the console makes tether compile again.