### PR TITLE
Make tests actually run on all maps when SD is selected

### DIFF
--- a/tools/ci/compile_and_run.sh
+++ b/tools/ci/compile_and_run.sh
@@ -16,8 +16,8 @@ replace=${REPLACE}
 if grep -q '#include[[:space:]]\"maps\\tether\\tether.dm\"' $BASENAME.dme && $replace; then
   sed -i 's/#include[[:space:]]\"maps\\tether\\tether.dm\"/#include\ \"maps\\'${MAP}'\\'${MAP}'.dm\"/g' $BASENAME.dme
   replace=false
-elif grep -q '#include[[:space:]]\"maps\\stellardelight\\stellar_delight.dm\"' $BASENAME.dme && $replace; then
-  sed -i 's/#include[[:space:]]\"maps\\stellardelight\\stellar_delight.dm\"/#include\ \"maps\\'${MAP}'\\'${MAP}'.dm\"/g' $BASENAME.dme
+elif grep -q '#include[[:space:]]\"maps\\stellar_delight\\stellar_delight.dm\"' $BASENAME.dme && $replace; then
+  sed -i 's/#include[[:space:]]\"maps\\stellar_delight\\stellar_delight.dm\"/#include\ \"maps\\'${MAP}'\\'${MAP}'.dm\"/g' $BASENAME.dme
   replace=false
 elif grep -q '#include[[:space:]]\"maps\\groundbase\\groundbase.dm\"' $BASENAME.dme && $replace; then
   sed -i 's/#include[[:space:]]\"maps\\groundbase\\groundbase.dm\"/#include\ \"maps\\'${MAP}'\\'${MAP}'.dm\"/g' $BASENAME.dme


### PR DESCRIPTION
This typo made it so that whenever stellar delight is active, other maps aren't tested - leading to #16300 passing unit tests even though it broke tether.