### PR TITLE
Allow harm-intent disabling AI holograms

### DIFF
--- a/code/modules/vore/eating/silicon_vr.dm
+++ b/code/modules/vore/eating/silicon_vr.dm
@@ -100,3 +100,16 @@
 
 		if(master.ooc_notes)
 			. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[master];ooc_notes=1'>\[View\]</a> - <a href='?src=\ref[master];print_ooc_notes_to_chat=1'>\[Print\]</a>"
+
+// Allow dissipating ai holograms by attacking them
+/obj/effect/overlay/aiholo/attack_hand(mob/living/user)
+	if(user.a_intent == I_HURT)
+		to_chat(user, span_attack("You dissipate [src]."))
+		master?.holo?.clear_holo(master)
+	return ..()
+
+/obj/effect/overlay/aiholo/attackby(obj/item/I, mob/user)
+	if(user.a_intent == I_HURT)
+		to_chat(user, span_attack("You dissipate [src] with [I]."))
+		master?.holo?.clear_holo(master)
+	return ..()


### PR DESCRIPTION
If you harm intent click on an AI hologram with an empty hand or any item, it'll now dissipate it and kick them out of the hologram.

![https://i.tigercat2000.net/2024/09/dreamseeker_YkuSmUrqir.gif](https://i.tigercat2000.net/2024/09/dreamseeker_YkuSmUrqir.gif)
![https://i.tigercat2000.net/2024/09/dreamseeker_PRC046M6ra.png](https://i.tigercat2000.net/2024/09/dreamseeker_PRC046M6ra.png)

:cl:
add: You can now dissipate AI holograms by attacking them.
/:cl: