### PR TITLE
Hanner Concealment

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -356,7 +356,10 @@ var/global/list/PDA_Manifest = list()
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
 		G.fields["sex"]			= gender2text(H.gender)
-		G.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]" //VOREStation Edit
+		if(H.species.name == SPECIES_HANNER)
+			G.fields["species"] = "[H.custom_species ? "[H.custom_species]" : H.species.name]"
+		else
+			G.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]"
 		G.fields["home_system"]	= H.home_system
 		G.fields["birthplace"]	= H.birthplace
 		G.fields["citizenship"]	= H.citizenship
@@ -367,7 +370,10 @@ var/global/list/PDA_Manifest = list()
 
 		//Medical Record
 		var/datum/data/record/M = CreateMedicalRecord(H.real_name, id, hidden)
-		M.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]" //VOREStation Edit
+		if(H.species.name == SPECIES_HANNER)
+			M.fields["species"] = "[H.custom_species ? "[H.custom_species]" : H.species.name]"
+		else
+			M.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]"
 		M.fields["b_type"]		= H.b_type
 		M.fields["blood_reagent"]	= H.species.blood_reagents
 		M.fields["b_dna"]		= H.dna.unique_enzymes
@@ -381,7 +387,10 @@ var/global/list/PDA_Manifest = list()
 
 		//Security Record
 		var/datum/data/record/S = CreateSecurityRecord(H.real_name, id, hidden)
-		S.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]" //VOREStation Edit
+		if(H.species.name == SPECIES_HANNER)
+			S.fields["species"] = "[H.custom_species ? "[H.custom_species]" : H.species.name]"
+		else
+			S.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]"
 		if(H.get_FBP_type())
 			S.fields["brain_type"] = H.get_FBP_type()
 		else
@@ -407,7 +416,10 @@ var/global/list/PDA_Manifest = list()
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.SE // Used in respawning
 		L.fields["identity"]	= H.dna.UI // "
-		L.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]" //VOREStation Edit
+		if(H.species.name == SPECIES_HANNER)
+			L.fields["species"] = "[H.custom_species ? "[H.custom_species]" : H.species.name]"
+		else
+			L.fields["species"]		= "[H.custom_species ? "[H.custom_species] ([H.species.name])" : H.species.name]"
 		L.fields["home_system"]	= H.home_system
 		L.fields["birthplace"]	= H.birthplace
 		L.fields["citizenship"]	= H.citizenship

--- a/code/game/objects/items/weapons/id cards/station_ids.dm
+++ b/code/game/objects/items/weapons/id cards/station_ids.dm
@@ -74,7 +74,10 @@
 /mob/living/carbon/human/set_id_info(var/obj/item/weapon/card/id/id_card)
 	..()
 	id_card.age = age
-	id_card.species = "[custom_species ? "[custom_species] ([species.name])" : species.name]"
+	if(species.name == SPECIES_HANNER)
+		id_card.species = "[custom_species ? "[custom_species]" : species.name]"
+	else
+		id_card.species = "[custom_species ? "[custom_species] ([species.name])" : species.name]"
 	id_card.sex = capitalize(name_gender())
 
 /obj/item/weapon/card/id/tgui_data(mob/user)


### PR DESCRIPTION
Slightly inelegant, but this now conceals your status as a #16269 in your medical, security, and employment records if you set a custom species name. It does not hide it in the species directory.

You will currently still be outed by employment records as knowing glamourspeak, but I don't have the patience to fuck with lists right now. Also the number of jobs that actually have access to employment records is really small so it's not a huge issue probably.

:cl:
tweak: med/sec records and ids no longer out you as a hanner (useful for characters who are unaware of their own status)
/:cl: