### PR TITLE
Flying over water/snow does not slow

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -73,7 +73,7 @@
 			water_breath.adjust_gas(gasid, BREATH_MOLES) // They have no oxygen, but non-zero moles and temp
 			water_breath.temperature = above_air.temperature
 			return water_breath
-	if(L && L.is_bad_swimmer() && depth >= 2 && !L.buckled())
+	if(L && L.is_bad_swimmer() && depth >= 2 && !L.buckled() && !L.flying)
 		if(prob(10))
 			L.visible_message("<span class='notice'>[L] splashes wildly.</span>","<span class='warning'>You struggle to keep your head above the water!</span>")
 		if(L.can_breathe_water())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -147,7 +147,7 @@
 	if(!T)
 		return 0
 
-	if(T.movement_cost)
+	if(T.movement_cost && !flying) //VOREStation Add: If you are flying you are probably not affected by the terrain on the ground.
 		var/turf_move_cost = T.movement_cost
 		if(istype(T, /turf/simulated/floor/water))
 			if(species.water_movement)


### PR DESCRIPTION
Wow this was simpler than I thought. This PR allows people with winged flight (or otherwise a human mob that has flying=1) to fly over snow and water without incurring the effects of those turfs. They shouldn't get wet, get slowed, or proc traits like aquatic (movespeed equalizer) nor bad swimmer (hewp im dwowning).

Lava will still kill you, ice will still slipstun you, and other things that are not water/snow turfs will otherwise remain unaffected. You also still slip when flying. The limited scope is mostly for balance reasons since a 0 point positive with downsides (activating this will make every wall/desk/table/lamp/console etc a PvE hazard, fast af nutrition burn) should only have limited upsides (lets you be flying which is cool, activating this lets you ignore some things you are only mildly inconvenienced by without the trait). Maybe later I'll make "Superior Flight" that costs a couple of points and ditches most of the downsides (I am totally keeping the wall smacking tho, hitting windows is avian culture).

🆑
balance: Water and snow turfs will no longer impact human mobs with flying=1 
tweak: Bad Swimmer will not cause flying human mobs to start drowning when over deep water 
/:cl: