### PR TITLE
allows to order more deuterium if needed

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -330,6 +330,13 @@
 	containertype = /obj/structure/closet/crate/einstein
 	contains = list(/obj/item/weapon/circuitboard/fusion_fuel_compressor)
 
+/datum/supply_pack/eng/deuterium
+	name = "Deuterium crate"
+	cost = 50
+	containername = "Deuterium crate"
+	containertype = /obj/structure/closet/crate/einstein
+	contains = list(/obj/fiftyspawner/deuterium)
+
 /datum/supply_pack/eng/tritium
 	name = "Tritium crate"
 	cost = 75


### PR DESCRIPTION
I've no clue why we can only order tritium and not the much safer variant to build RUSTs

🆑 Upstream
add: deuterium crates to cargo
/🆑 