### PR TITLE
we load it from a file, that path might no longer exist

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -151,8 +151,12 @@ GLOBAL_DATUM_INIT(gear_tweak_free_matrix_recolor, /datum/gear_tweak/matrix_recol
 			continue
 		else
 			path = 	contents[metadata[i]]
-		if(path)
-			new path(I)
+		if(!path)
+			var/mob/user = ismob(I.loc) ? I.loc : I.loc.loc
+			if(istype(user))
+				to_chat(user, span_warning("The content \"[metadata[i]]\" from \"[I]\" does no longer exist and has not been loaded. Please replace it in the character setup."))
+			continue
+		new path(I)
 
 /*
 * Ragent adjustment

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -152,7 +152,7 @@ GLOBAL_DATUM_INIT(gear_tweak_free_matrix_recolor, /datum/gear_tweak/matrix_recol
 		else
 			path = 	contents[metadata[i]]
 		if(!path)
-			var/mob/user = ismob(I.loc) ? I.loc : I.loc.loc
+			var/mob/user = ismob(I.loc) ? I.loc : I.loc?.loc
 			if(istype(user))
 				to_chat(user, span_warning("The content \"[metadata[i]]\" from \"[I]\" does no longer exist and has not been loaded. Please replace it in the character setup."))
 			continue

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -151,7 +151,8 @@ GLOBAL_DATUM_INIT(gear_tweak_free_matrix_recolor, /datum/gear_tweak/matrix_recol
 			continue
 		else
 			path = 	contents[metadata[i]]
-		new path(I)
+		if(path)
+			new path(I)
 
 /*
 * Ragent adjustment


### PR DESCRIPTION
🆑 Upstream
fix: runtime with lunchboxes if the contents since saving had been changed.
/🆑 