### PR TITLE
Adds 3 second delay to amputations

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -192,7 +192,14 @@
 	if(isnull(selected_surgery)) //They clicked 'cancel'
 		return 1
 	selected_surgery = available_surgeries[selected_surgery] //Sets the name they selected to be the datum.
-
+	// VOREstation edit start
+	if(istype(selected_surgery,/datum/surgery_step/generic/amputate))
+		var/obj/item/organ/external/affected = M.get_organ(zone)
+		to_chat(user, "<span class='danger'>You are preparing to amputate \the [M]'s [affected.name]!</span>")
+		if(!do_after(user, 3 SECONDS, M))
+			to_chat(user, "<span class='warning'>You reconsider performing an amputation...</span>")
+			return 0
+	// VOREstation edit end
 	M.op_stage.in_progress += zone
 	selected_surgery.begin_step(user, M, zone, src)		//start on it
 	var/success = TRUE


### PR DESCRIPTION
So your intern has a brief chance to reconsider cutting the patient's head off during NIF surgery.

Downstream changelog
🆑
qol: Adds 3 second delay to amputation so you can cancel without damage
/:cl: