### PR TITLE
Posibrain and drone intelligence surgery fixes

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -398,7 +398,11 @@ var/list/organ_cache = list()
 		rejecting = null
 
 	if(istype(owner))
-		var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
+		// VOREstation edit begin - Posibrains don't have blood reagents, so they crash this
+		var/datum/reagent/blood/organ_blood = null
+		if(reagents)
+			organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
+		// VOREstation edit end
 		if(!organ_blood || !organ_blood.data["blood_DNA"])
 			owner.vessel.trans_to(src, 5, 1, 1)
 
@@ -418,7 +422,11 @@ var/list/organ_cache = list()
 
 	if(!istype(target)) return
 
-	var/datum/reagent/blood/transplant_blood = locate(/datum/reagent/blood) in reagents.reagent_list
+	// VOREstation edit begin - Posibrains don't have blood reagents, so they crash this
+	var/datum/reagent/blood/transplant_blood = null
+	if(reagents)
+		transplant_blood = locate(/datum/reagent/blood) in reagents.reagent_list
+	// VOREstation edit end
 	transplant_data = list()
 	if(!transplant_blood)
 		transplant_data["species"] =    target?.species.name

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -485,7 +485,17 @@
 	"<span class='notice'>You have installed \the [tool] into [target]'s [affected.name].</span>")
 
 	var/obj/item/device/mmi/M = tool
-	var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
+	// VOREstation edit begin - Select the proper mmi holder subtype based on the brain inserted
+	var/obj/item/organ/internal/mmi_holder/holder = null
+	if(istype(M,/obj/item/device/mmi/digital/posibrain/nano))
+		holder = new /obj/item/organ/internal/mmi_holder/posibrain/nano(target, 1)
+	else if(istype(M,/obj/item/device/mmi/digital/posibrain))
+		holder = new /obj/item/organ/internal/mmi_holder/posibrain(target, 1)
+	else if(istype(M,/obj/item/device/mmi/digital/robot))
+		holder = new /obj/item/organ/internal/mmi_holder/robot(target, 1)
+	else
+		holder = new /obj/item/organ/internal/mmi_holder(target, 1) // Fallback to old behavior if organic MMI or if no subtype exists.
+	//VOREstation edit end
 	target.internal_organs_by_name["brain"] = holder
 	user.drop_from_inventory(tool)
 	tool.loc = holder


### PR DESCRIPTION
-Installing drone circuits/posibrains to a body no longer converts it to a meat brain
-Fixes runtimes with adding/removing synthetic brains

Downstream changelog
🆑 
fix: installing robobrains no longer converts the brain to MMI
fix: fixes brain surgery runtime from trying to find reagants in reagentless brains
/:cl: