### PR TITLE
Convert NanoMap to TSX and fix a bunch of bugs

### DIFF
--- a/tgui/packages/tgui/styles/components/NanoMap.scss
+++ b/tgui/packages/tgui/styles/components/NanoMap.scss
@@ -16,7 +16,7 @@ $color-background: rgba(0, 0, 0, 0.33) !default;
   z-index: 20;
   background-color: $color-background;
   position: absolute;
-  top: 30px;
+  top: 40px;
   left: 0;
   padding: 0.5rem;
   width: 30%;


### PR DESCRIPTION
You can now zoom in and out using W/S and Up Arrow/Down Arrow

The map offsets when zooming should be much more accurate

Tooltips on map markers actually work again

Also fixed a bug where the atmospherics control in specific liked to start scrolling the whole map element.

https://github.com/user-attachments/assets/c78f980f-edff-492b-ad7d-683f88ca8fce

:cl:
fix: NanoMap components (air alarm computer, crew monitor) have been much improved.
fix: You can now use W/S and Up Arrow/Down Arrow to zoom on a NanoMap.
fix: NanoMap zooming should be centered more correctly.
fix: Tooltips show up when hovering over icons in a NanoMap.
fix: The Atmospherics Control interface occasionally started to scroll weirdly in map ivew.
/:cl: