### PR TITLE
Give the AI back most of their shell options (not research)

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -139,7 +139,8 @@ var/list/emergency_module_types = list(
 )
 // List of modules available to AI shells
 var/list/shell_module_types = list(
-	"Standard", "Service", "Clerical"
+	"Standard", "Engineering", "Surgeon", "Crisis",
+	"Miner", "Janitor", "Service", "Clerical", "Research"
 )
 // List of whitelisted modules
 var/list/whitelisted_module_types = list(

--- a/code/global.dm
+++ b/code/global.dm
@@ -140,7 +140,7 @@ var/list/emergency_module_types = list(
 // List of modules available to AI shells
 var/list/shell_module_types = list(
 	"Standard", "Engineering", "Surgeon", "Crisis",
-	"Miner", "Janitor", "Service", "Clerical", "Research"
+	"Miner", "Janitor", "Service", "Clerical", "Security"
 )
 // List of whitelisted modules
 var/list/whitelisted_module_types = list(


### PR DESCRIPTION
![https://i.tigercat2000.net/2024/10/dreamseeker_pEO11ns1dM.png](https://i.tigercat2000.net/2024/10/dreamseeker_pEO11ns1dM.png)

Changes AI shell selection from `Standard`, `Service`, `Clerical` to 
`Standard`, `Engineering`, `Surgeon`, `Crisis`, `Miner`, `Janitor`, `Service`, `Clerical`, and `Research`.