### PR TITLE
lightens the slowdown from chemistry bags

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -426,7 +426,7 @@
 	desc = "A bag for storing pills, patches, and bottles."
 	max_storage_space = 200
 	w_class = ITEMSIZE_LARGE
-	slowdown = 3
+	slowdown = 1 //you probably shouldn't be running with chemicals
 	can_hold = list(/obj/item/reagent_containers/pill,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/glass/bottle)
 
 // -----------------------------


### PR DESCRIPTION
PR awaiting staff commentary or approval to revert a past PR that makes chemistry bags super slow to lug around. I reverted it back to slowdown = 1 but if this results in janky behavior I can also just remove the slowdown.

afaik the original reason for increasing the slowdown was due to undesirable player behavior but I'm pretty confident the culture has shifted all around to make this no longer necessary and kinda just weird. The engi is zooming by pulling a full shield generator meanwhile an empty chem bag is slowing you down to a brisk crawl.

🆑
balance: changes chemistry bag slowdown to 1 from 3 
/🆑