### PR TITLE
Fixed potential runtimes smites and adds smite options

### DIFF
--- a/code/modules/admin/player_effects.dm
+++ b/code/modules/admin/player_effects.dm
@@ -66,7 +66,7 @@
 				to_chat(user,"[target] didn't have any breakable legs, sorry.")
 
 		if("bluespace_artillery")
-			bluespace_artillery(target,src)
+			bluespace_artillery(target,usr)
 
 		if("spont_combustion")
 			var/mob/living/carbon/human/Tar = target
@@ -187,13 +187,13 @@
 
 
 		if("redspace_abduct")
-			redspace_abduction(target, src)
+			redspace_abduction(target, usr)
 
 		if("autosave")
-			fake_autosave(target, src)
+			fake_autosave(target, usr)
 
 		if("autosave2")
-			fake_autosave(target, src, TRUE)
+			fake_autosave(target, usr, TRUE)
 
 		if("adspam")
 			if(target.client)

--- a/code/modules/admin/player_effects.dm
+++ b/code/modules/admin/player_effects.dm
@@ -453,6 +453,41 @@
 			else
 				Tar.Stasis(100000)
 
+		if("give_chem")
+			var/mob/living/carbon/human/Tar = target
+			if(!istype(Tar))
+				return
+			var/list/chem_list = typesof(/datum/reagent)
+			var/datum/reagent/chemical = tgui_input_list(user, "Which chemical would you like to add?", "Chemicals", chem_list)
+
+			if(!chemical)
+				return
+
+			var/chem = chemical.id
+
+			var/amount = tgui_input_number(user, "How much of the chemical would you like to add?", "Amount", 5)
+			if(!amount)
+				return
+
+			var/location = tgui_alert(user, "Where do you want to add the chemical?", "Location", list("Blood", "Stomach", "Skin", "Cancel"))
+
+			if(!location || location == "Cancel")
+				return
+			if(location == "Blood")
+				Tar.bloodstr.add_reagent(chem, amount)
+			if(location == "Stomach")
+				Tar.ingested.add_reagent(chem, amount)
+			if(location == "Skin")
+				Tar.touching.add_reagent(chem, amount)
+
+		if("purge")
+			var/mob/living/carbon/Tar = target
+			if(!istype(Tar))
+				return
+			Tar.bloodstr.clear_reagents()
+			Tar.ingested.clear_reagents()
+			Tar.touching.clear_reagents()
+
 		////////ABILITIES//////////////
 
 		if("vent_crawl")

--- a/code/modules/admin/player_effects.dm
+++ b/code/modules/admin/player_effects.dm
@@ -757,6 +757,12 @@
 			if(tgui_alert(usr, "Make mob wake up? This is needed for carbon mobs.", "Wake mob?", list("Yes", "No")) == "Yes")
 				L.AdjustSleeping(-100)
 
+		if("cloaking")
+			if(target.cloaked)
+				target.uncloak()
+			else if(!target.cloaked)
+				target.cloak()
+
 
 		////////FIXES//////////////
 

--- a/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlAdmin.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlAdmin.tsx
@@ -42,6 +42,9 @@ export const ControlAdmin = (props) => {
       <Button fluid onClick={() => act('orbit')}>
         Make Marked Datum Orbit
       </Button>
+      <Button fluid onClick={() => act('cloaking')}>
+        Force Cloaking or Uncloaking
+      </Button>
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlMedical.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlMedical.tsx
@@ -33,6 +33,12 @@ export const ControlMedical = (props) => {
       <Button fluid onClick={() => act('stasis')}>
         Toggle Stasis
       </Button>
+      <Button fluid onClick={() => act('give_chem')}>
+        Give Reagent
+      </Button>
+      <Button fluid onClick={() => act('purge')}>
+        Purge Reagents
+      </Button>
     </Section>
   );
 };


### PR DESCRIPTION
Fixed potential runtimes smites by replacing the datum with the user in proc calls.

Added three new options under the player medical effects. One to purge all reagents from a character. Another to add any amount of any reagent to their blood, skin or stomach. A final one to force a mob to cloak or uncloak.