### PR TITLE
prevent blood overlays from stacking up

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -89,6 +89,7 @@ var/global/list/image/splatter_cache=list()
 		if(istype(S))
 			S.blood_color = basecolor
 			S.track_blood = max(amount,S.track_blood)
+			S.update_icon() // Cut previous overlays
 			if(!S.blood_overlay)
 				S.generate_blood_overlay()
 			if(!S.blood_DNA)


### PR DESCRIPTION
We call update icon beforehand now, to make sure the previous one is removed before we just add overlay over overlay on them...

🆑 Upstream
fix: blood overlays stacking all over
/🆑 