### PR TITLE
Vore Messages

### DIFF
--- a/code/modules/vore/eating/belly_messages.dm
+++ b/code/modules/vore/eating/belly_messages.dm
@@ -1,0 +1,507 @@
+/obj/belly
+	// Don't forget to watch your commas at the end of each line if you change these.
+	var/list/struggle_messages_outside = list(
+		"%pred's %belly wobbles with a squirming meal.",
+		"%pred's %belly jostles with movement.",
+		"%pred's %belly briefly swells outward as someone pushes from inside.",
+		"%pred's %belly fidgets with a trapped victim.",
+		"%pred's %belly jiggles with motion from inside.",
+		"%pred's %belly sloshes around.",
+		"%pred's %belly gushes softly.",
+		"%pred's %belly lets out a wet squelch.")
+
+	var/list/struggle_messages_inside = list(
+		"Your useless squirming only causes %pred's slimy %belly to squelch over your body.",
+		"Your struggles only cause %pred's %belly to gush softly around you.",
+		"Your movement only causes %pred's %belly to slosh around you.",
+		"Your motion causes %pred's %belly to jiggle.",
+		"You fidget around inside of %pred's %belly.",
+		"You shove against the walls of %pred's %belly, making it briefly swell outward.",
+		"You jostle %pred's %belly with movement.",
+		"You squirm inside of %pred's %belly, making it wobble around.")
+
+	var/list/absorbed_struggle_messages_outside = list(
+		"%pred's %belly wobbles, seemingly on its own.",
+		"%pred's %belly jiggles without apparent cause.",
+		"%pred's %belly seems to shake for a second without an obvious reason.")
+
+	var/list/absorbed_struggle_messages_inside = list(
+		"You try and resist %pred's %belly, but only cause it to jiggle slightly.",
+		"Your fruitless mental struggles only shift %pred's %belly a tiny bit.",
+		"You can't make any progress freeing yourself from %pred's %belly.")
+
+	var/list/escape_attempt_messages_owner = list(
+		"%prey is attempting to free themselves from your %belly!")
+
+	var/list/escape_attempt_messages_prey = list(
+		"You start to climb out of %pred's %belly.")
+
+	var/list/escape_messages_owner = list(
+		"%prey climbs out of your %belly!")
+
+	var/list/escape_messages_prey = list(
+		"You climb out of %pred's %belly.")
+
+	var/list/escape_messages_outside = list(
+		"%prey climbs out of %pred's %belly!")
+
+	var/list/escape_item_messages_owner = list(
+		"%item suddenly slips out of your %belly!")
+
+	var/list/escape_item_messages_prey = list(
+		"Your struggles successfully cause %pred to squeeze your %item out of their %belly.")
+
+	var/list/escape_item_messages_outside = list(
+		"%item suddenly slips out of %pred's %belly!")
+
+	var/list/escape_fail_messages_owner = list(
+		"%prey's attempt to escape from your %belly has failed!")
+
+	var/list/escape_fail_messages_prey = list(
+		"Your attempt to escape %pred's %belly has failed!")
+
+	var/list/escape_attempt_absorbed_messages_owner = list(
+		"%prey is attempting to free themselves from your %belly!")
+
+	var/list/escape_attempt_absorbed_messages_prey = list(
+		"You try to force yourself out of %pred's %belly.")
+
+	var/list/escape_absorbed_messages_owner = list(
+		"%prey forces themselves free of your %belly!")
+
+	var/list/escape_absorbed_messages_prey = list(
+		"You manage to free yourself from %pred's %belly.")
+
+	var/list/escape_absorbed_messages_outside = list(
+		"%prey climbs out of %pred's %belly!")
+
+	var/list/escape_fail_absorbed_messages_owner = list(
+		"%prey's attempt to escape form your %belly has failed!")
+
+	var/list/escape_fail_absorbed_messages_prey = list(
+		"Before you manage to reach freedom, you feel yourself getting dragged back into %pred's %belly!")
+
+	var/list/primary_transfer_messages_owner = list(
+		"%prey slid into your %dest due to their struggling inside your %belly!")
+
+	var/list/primary_transfer_messages_prey = list(
+		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
+
+	var/list/secondary_transfer_messages_owner = list(
+		"%prey slid into your %dest due to their struggling inside your %belly!")
+
+	var/list/secondary_transfer_messages_prey = list(
+		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
+
+	var/list/digest_chance_messages_owner = list(
+		"You feel your %belly beginning to become active!")
+
+	var/list/digest_chance_messages_prey = list(
+		"In response to your struggling, %pred's %belly begins to get more active...")
+
+	var/list/absorb_chance_messages_owner = list(
+		"You feel your %belly start to cling onto its contents...")
+
+	var/list/absorb_chance_messages_prey = list(
+		"In response to your struggling, %pred's %belly begins to cling more tightly...")
+
+	var/list/select_chance_messages_owner = list(
+		"You feel your %belly beginning to become active!")
+
+	var/list/select_chance_messages_prey = list(
+		"In response to your struggling, %pred's %belly begins to get more active...")
+
+	var/list/digest_messages_owner = list(
+		"You feel %prey's body succumb to your digestive system, which breaks it apart into soft slurry.",
+		"You hear a lewd glorp as your %belly muscles grind %prey into a warm pulp.",
+		"Your %belly lets out a rumble as it melts %prey into sludge.",
+		"You feel a soft gurgle as %prey's body loses form in your %belly. They're nothing but a soft mass of churning slop now.",
+		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your thighs.",
+		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your rump.",
+		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your belly.",
+		"Your %belly groans as %prey falls apart into a thick soup. You can feel their remains soon flowing deeper into your body to be absorbed.",
+		"Your %belly kneads on every fiber of %prey, softening them down into mush to fuel your next hunt.",
+		"Your %belly churns %prey down into a hot slush. You can feel the nutrients coursing through your digestive track with a series of long, wet glorps.")
+
+	var/list/digest_messages_prey = list(
+		"Your body succumbs to %pred's digestive system, which breaks you apart into soft slurry.",
+		"%pred's %belly lets out a lewd glorp as their muscles grind you into a warm pulp.",
+		"%pred's %belly lets out a rumble as it melts you into sludge.",
+		"%pred feels a soft gurgle as your body loses form in their %belly. You're nothing but a soft mass of churning slop now.",
+		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's thighs.",
+		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's rump.",
+		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's belly.",
+		"%pred's %belly groans as you fall apart into a thick soup. Your remains soon flow deeper into %pred's body to be absorbed.",
+		"%pred's %belly kneads on every fiber of your body, softening you down into mush to fuel their next hunt.",
+		"%pred's %belly churns you down into a hot slush. Your nutrient-rich remains course through their digestive track with a series of long, wet glorps.")
+
+	var/list/absorb_messages_owner = list(
+		"You feel %prey becoming part of you.")
+
+	var/list/absorb_messages_prey = list(
+		"You feel yourself becoming part of %pred's %belly!")
+
+	var/list/unabsorb_messages_owner = list(
+		"You feel %prey reform into a recognizable state again.")
+
+	var/list/unabsorb_messages_prey = list(
+		"You are released from being part of %pred's %belly.")
+
+	var/list/examine_messages = list(
+		"They have something solid in their %belly!",
+		"It looks like they have something in their %belly!")
+
+	var/list/examine_messages_absorbed = list(
+		"Their body looks somewhat larger than usual around the area of their %belly.",
+		"Their %belly looks larger than usual.")
+
+GLOBAL_LIST_INIT(vore_words_goo, list("muck","goo","sludge","slime","mire","ectoplasm","quagmire","glop","jelly","ooze","slush","mush","quicksand"))//%goo
+GLOBAL_LIST_INIT(vore_words_hbellynoises, list("gurgle","gloorp","squelch","gloosh","squish","groan","grrrrrrn","sloooooOrp","slooosh","grrrbles","worbles"))//%happybelly
+GLOBAL_LIST_INIT(vore_words_fat, list("love handles","fat","pudge","plumpness","squish","chunk","meat","softness","blubber","flab","paunch","hip dip","mass","dough","chub","marshmellowy goodness","girth","fluff","thickness","jello","adipose "))//%fat
+GLOBAL_LIST_INIT(vore_words_grip, list("grip","grasp","clutch","hold"))//%grip
+GLOBAL_LIST_INIT(vore_words_cozyholdingwords, list("soft","cozy","comfortable","gentle","snug","safe","restful","snuggly","intimate","secure"))//%cozy
+GLOBAL_LIST_INIT(vore_words_angry, list("hated","unsafe","angry"))//%angry
+GLOBAL_LIST_INIT(vore_words_acid, list("acid","burbling goo","angry slop","chime","devouring liquid","slop","liquid","goo","mush","boiling liquid","hot oil"))//%acid
+GLOBAL_LIST_INIT(vore_words_snackname, list("snack","lunch","meat","calories","food","meal","dinner","chow","future pudge","fuel"))//%snack
+GLOBAL_LIST_INIT(vore_words_hot, list("sweltering","hot","boiling","sizzling","burning","steaming","firey"))//%hot
+GLOBAL_LIST_INIT(vore_words_snake, list("snake","serpent","reptilian","noodle","snek","noperope","throattube","armless mouth"))//%snake
+
+/// Replaces a bunch of format strings with relevant messages.
+/// `prey` may be a string or a specific prey ref.
+/obj/belly/proc/belly_format_string(message, prey, use_absorbed_count = FALSE, item = null, dest = null, use_first_only = FALSE)
+	if(islist(message))
+		. = "[pick(message)]"
+	else
+		. = "[message]"
+
+	. = replacetext(., "%belly", lowertext(name))
+	. = replacetext(., "%pred", owner)
+	. = replacetext(., "%prey", prey)
+
+	var/total_prey_count = 0
+	var/all_object_and_prey_count = LAZYLEN(contents)
+	var/ghost_count = 0
+	var/absorbed_count = 0
+	for(var/mob/M in contents)
+		total_prey_count++
+
+		if(isobserver(M))
+			all_object_and_prey_count--
+			ghost_count++
+
+		if(isliving(M))
+			var/mob/living/L = M
+			if(L.absorbed)
+				absorbed_count++
+
+	. = replacetext(., "%countpreytotal", total_prey_count)
+	. = replacetext(., "%countpreyabsorbed", absorbed_count)
+	. = replacetext(., "%countprey", use_absorbed_count ? absorbed_count : total_prey_count)
+	. = replacetext(., "%countghosts", ghost_count)
+	. = replacetext(., "%count", all_object_and_prey_count)
+
+	if(!isnull(item))
+		. = replacetext(., "%item", item)
+	if(!isnull(dest))
+		. = replacetext(., "%dest", dest)
+
+	// Belly messages
+	. = replacetext(., "%goo", use_first_only ? GLOB.vore_words_goo[1] : pick(GLOB.vore_words_goo))
+	. = replacetext(., "%happybelly", use_first_only ? GLOB.vore_words_hbellynoises[1] : pick(GLOB.vore_words_hbellynoises))
+	. = replacetext(., "%fat", use_first_only ? GLOB.vore_words_fat[1] : pick(GLOB.vore_words_fat))
+	. = replacetext(., "%grip", use_first_only ? GLOB.vore_words_grip[1] : pick(GLOB.vore_words_grip))
+	. = replacetext(., "%cozy", use_first_only ? GLOB.vore_words_cozyholdingwords[1] : pick(GLOB.vore_words_cozyholdingwords))
+	. = replacetext(., "%angry", use_first_only ? GLOB.vore_words_angry[1] : pick(GLOB.vore_words_angry))
+	. = replacetext(., "%acid", use_first_only ? GLOB.vore_words_acid[1] : pick(GLOB.vore_words_acid))
+	. = replacetext(., "%snack", use_first_only ? GLOB.vore_words_snackname[1] : pick(GLOB.vore_words_snackname))
+	. = replacetext(., "%hot", use_first_only ? GLOB.vore_words_hot[1] : pick(GLOB.vore_words_hot))
+	. = replacetext(., "%snake", use_first_only ? GLOB.vore_words_snake[1] : pick(GLOB.vore_words_snake))
+
+// Get the line that should show up in Examine message if the owner of this belly
+// is examined.   By making this a proc, we not only take advantage of polymorphism,
+// but can easily make the message vary based on how many people are inside, etc.
+// Returns a string which shoul be appended to the Examine output.
+/obj/belly/proc/get_examine_msg()
+	if(!(contents.len) || !(examine_messages.len))
+		return ""
+
+	var/raw_message = pick(examine_messages)
+	var/total_bulge = 0
+
+	var/list/vore_contents = list()
+	for(var/G in contents)
+		if(!isobserver(G))
+			vore_contents += G //Exclude any ghosts from %prey
+
+	for(var/mob/living/P in contents)
+		if(!P.absorbed) //This is required first, in case there's a person absorbed and not absorbed in a stomach.
+			total_bulge += P.size_multiplier
+
+	if(total_bulge < bulge_size || bulge_size == 0)
+		return ""
+
+	return(span_red("<i>[belly_format_string(raw_message, english_list(vore_contents))]</i>"))
+
+/obj/belly/proc/get_examine_msg_absorbed()
+	if(!(contents.len) || !(examine_messages_absorbed.len) || !display_absorbed_examine)
+		return ""
+
+	var/raw_message = pick(examine_messages_absorbed)
+
+	var/absorbed_count = 0
+	var/list/absorbed_victims = list()
+	for(var/mob/living/L in contents)
+		if(L.absorbed)
+			absorbed_victims += L
+			absorbed_count++
+
+	if(!absorbed_count)
+		return ""
+
+	return(span_red("<i>[belly_format_string(raw_message, english_list(absorbed_victims), use_absorbed_count = TRUE)]</i>"))
+
+// The next function gets the messages set on the belly, in human-readable format.
+// This is useful in customization boxes and such. The delimiter right now is \n\n so
+// in message boxes, this looks nice and is easily delimited.
+/obj/belly/proc/get_messages(type, delim = "\n\n")
+	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
+
+	var/list/raw_messages
+	switch(type)
+		if("smo")
+			raw_messages = struggle_messages_outside
+		if("smi")
+			raw_messages = struggle_messages_inside
+		if("asmo")
+			raw_messages = absorbed_struggle_messages_outside
+		if("asmi")
+			raw_messages = absorbed_struggle_messages_inside
+		if("escao")
+			raw_messages = escape_attempt_messages_owner
+		if("escap")
+			raw_messages = escape_attempt_messages_prey
+		if("esco")
+			raw_messages = escape_messages_owner
+		if("escp")
+			raw_messages = escape_messages_prey
+		if("escout")
+			raw_messages = escape_messages_outside
+		if("escio")
+			raw_messages = escape_item_messages_owner
+		if("escip")
+			raw_messages = escape_item_messages_prey
+		if("esciout")
+			raw_messages = escape_item_messages_outside
+		if("escfo")
+			raw_messages = escape_fail_messages_owner
+		if("escfp")
+			raw_messages = escape_fail_messages_prey
+		if("aescao")
+			raw_messages = escape_attempt_absorbed_messages_owner
+		if("aescap")
+			raw_messages = escape_attempt_absorbed_messages_prey
+		if("aesco")
+			raw_messages = escape_absorbed_messages_owner
+		if("aescp")
+			raw_messages = escape_absorbed_messages_prey
+		if("aescout")
+			raw_messages = escape_absorbed_messages_outside
+		if("aescfo")
+			raw_messages = escape_fail_absorbed_messages_owner
+		if("aescfp")
+			raw_messages = escape_fail_absorbed_messages_prey
+		if("trnspo")
+			raw_messages = primary_transfer_messages_owner
+		if("trnspp")
+			raw_messages = primary_transfer_messages_prey
+		if("trnsso")
+			raw_messages = secondary_transfer_messages_owner
+		if("trnssp")
+			raw_messages = secondary_transfer_messages_prey
+		if("stmodo")
+			raw_messages = digest_chance_messages_owner
+		if("stmodp")
+			raw_messages = digest_chance_messages_prey
+		if("stmoao")
+			raw_messages = absorb_chance_messages_owner
+		if("stmoap")
+			raw_messages = absorb_chance_messages_prey
+		if("dmo")
+			raw_messages = digest_messages_owner
+		if("dmp")
+			raw_messages = digest_messages_prey
+		if("em")
+			raw_messages = examine_messages
+		if("ema")
+			raw_messages = examine_messages_absorbed
+		if("amo")
+			raw_messages = absorb_messages_owner
+		if("amp")
+			raw_messages = absorb_messages_prey
+		if("uamo")
+			raw_messages = unabsorb_messages_owner
+		if("uamp")
+			raw_messages = unabsorb_messages_prey
+		if("im_digest")
+			raw_messages = emote_lists[DM_DIGEST]
+		if("im_hold")
+			raw_messages = emote_lists[DM_HOLD]
+		if("im_holdabsorbed")
+			raw_messages = emote_lists[DM_HOLD_ABSORBED]
+		if("im_absorb")
+			raw_messages = emote_lists[DM_ABSORB]
+		if("im_heal")
+			raw_messages = emote_lists[DM_HEAL]
+		if("im_drain")
+			raw_messages = emote_lists[DM_DRAIN]
+		if("im_steal")
+			raw_messages = emote_lists[DM_SIZE_STEAL]
+		if("im_egg")
+			raw_messages = emote_lists[DM_EGG]
+		if("im_shrink")
+			raw_messages = emote_lists[DM_SHRINK]
+		if("im_grow")
+			raw_messages = emote_lists[DM_GROW]
+		if("im_unabsorb")
+			raw_messages = emote_lists[DM_UNABSORB]
+	var/messages = null
+	if(raw_messages)
+		messages = raw_messages.Join(delim)
+	return messages
+
+// The next function sets the messages on the belly, from human-readable var
+// replacement strings and linebreaks as delimiters (two \n\n by default).
+// They also sanitize the messages.
+// Give them a limit for each type...
+/obj/belly/proc/set_messages(raw_text, type, delim = "\n\n", limit)
+	if(!limit)
+		CRASH("[src] set message called without limit!")
+	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
+
+	var/list/raw_list
+
+	if(findtext(raw_text, delim))
+		raw_list = splittext(html_encode(raw_text), delim)
+	else
+		raw_list = list(raw_text)
+	for(var/i = 1, i <= raw_list.len, i++)
+		if(!length(raw_list[i]))
+			raw_list.Cut(i, i + 1)
+			i--
+	if(raw_list.len > 10)
+		raw_list.Cut(11)
+		log_debug("[owner] tried to set [lowertext(name)] with 11+ messages")
+
+	var/realIndex = 0
+	for(var/i = 1, i <= raw_list.len, i++)
+		realIndex++
+		raw_list[i] = readd_quotes(raw_list[i])
+		//Also fix % sign for var replacement
+		raw_list[i] = replacetext(raw_list[i],"&#37;","%")
+		if(length(raw_list[i]) > limit || length(raw_list[i]) < 10)
+			to_chat(owner, span_warning("One of the message for [lowertext(name)] exceeded the limit of [limit] characters or has been below the lower limit of 10 characters and has been removed. Actual length: [length(raw_list[i])]"))
+			//Reflect message to the player so that they don't just lose it
+			to_chat(owner, span_warning("Message [realIndex]: [raw_list[i]]"))
+			log_debug("[owner] tried to set [lowertext(name)] [type] message with >[limit] or <10 characters")
+			raw_list.Cut(i, i + 1)
+			i--
+
+	ASSERT(raw_list.len <= 10) //Sanity
+
+	switch(type)
+		if("smo")
+			struggle_messages_outside = raw_list
+		if("smi")
+			struggle_messages_inside = raw_list
+		if("asmo")
+			absorbed_struggle_messages_outside = raw_list
+		if("asmi")
+			absorbed_struggle_messages_inside = raw_list
+		if("escao")
+			escape_attempt_messages_owner = raw_list
+		if("escap")
+			escape_attempt_messages_prey = raw_list
+		if("esco")
+			escape_messages_owner = raw_list
+		if("escp")
+			escape_messages_prey = raw_list
+		if("escout")
+			escape_messages_outside = raw_list
+		if("escio")
+			escape_item_messages_owner = raw_list
+		if("escip")
+			escape_item_messages_prey = raw_list
+		if("esciout")
+			escape_item_messages_outside = raw_list
+		if("escfo")
+			escape_fail_messages_owner = raw_list
+		if("escfp")
+			escape_fail_messages_prey = raw_list
+		if("aescao")
+			escape_attempt_absorbed_messages_owner = raw_list
+		if("aescap")
+			escape_attempt_absorbed_messages_prey = raw_list
+		if("aesco")
+			escape_absorbed_messages_owner = raw_list
+		if("aescp")
+			escape_absorbed_messages_prey = raw_list
+		if("aescout")
+			escape_absorbed_messages_outside = raw_list
+		if("aescfo")
+			escape_fail_absorbed_messages_owner = raw_list
+		if("aescfp")
+			escape_fail_absorbed_messages_prey = raw_list
+		if("trnspo")
+			primary_transfer_messages_owner = raw_list
+		if("trnspp")
+			primary_transfer_messages_prey = raw_list
+		if("trnsso")
+			secondary_transfer_messages_owner = raw_list
+		if("trnssp")
+			secondary_transfer_messages_prey = raw_list
+		if("stmodo")
+			digest_chance_messages_owner = raw_list
+		if("stmodp")
+			digest_chance_messages_prey = raw_list
+		if("stmoao")
+			absorb_chance_messages_owner = raw_list
+		if("stmoap")
+			absorb_chance_messages_prey = raw_list
+		if("dmo")
+			digest_messages_owner = raw_list
+		if("dmp")
+			digest_messages_prey = raw_list
+		if("amo")
+			absorb_messages_owner = raw_list
+		if("amp")
+			absorb_messages_prey = raw_list
+		if("uamo")
+			unabsorb_messages_owner = raw_list
+		if("uamp")
+			unabsorb_messages_prey = raw_list
+		if("em")
+			examine_messages = raw_list
+		if("ema")
+			examine_messages_absorbed = raw_list
+		if("im_digest")
+			emote_lists[DM_DIGEST] = raw_list
+		if("im_hold")
+			emote_lists[DM_HOLD] = raw_list
+		if("im_holdabsorbed")
+			emote_lists[DM_HOLD_ABSORBED] = raw_list
+		if("im_absorb")
+			emote_lists[DM_ABSORB] = raw_list
+		if("im_heal")
+			emote_lists[DM_HEAL] = raw_list
+		if("im_drain")
+			emote_lists[DM_DRAIN] = raw_list
+		if("im_steal")
+			emote_lists[DM_SIZE_STEAL] = raw_list
+		if("im_egg")
+			emote_lists[DM_EGG] = raw_list
+		if("im_shrink")
+			emote_lists[DM_SHRINK] = raw_list
+		if("im_grow")
+			emote_lists[DM_GROW] = raw_list
+		if("im_unabsorb")
+			emote_lists[DM_UNABSORB] = raw_list

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -116,162 +116,6 @@
 	var/tmp/recent_sound = FALSE				// Prevent audio spam
 	var/tmp/drainmode = DR_NORMAL				// Simply drains the prey then does nothing.
 
-	// Don't forget to watch your commas at the end of each line if you change these.
-	var/list/struggle_messages_outside = list(
-		"%pred's %belly wobbles with a squirming meal.",
-		"%pred's %belly jostles with movement.",
-		"%pred's %belly briefly swells outward as someone pushes from inside.",
-		"%pred's %belly fidgets with a trapped victim.",
-		"%pred's %belly jiggles with motion from inside.",
-		"%pred's %belly sloshes around.",
-		"%pred's %belly gushes softly.",
-		"%pred's %belly lets out a wet squelch.")
-
-	var/list/struggle_messages_inside = list(
-		"Your useless squirming only causes %pred's slimy %belly to squelch over your body.",
-		"Your struggles only cause %pred's %belly to gush softly around you.",
-		"Your movement only causes %pred's %belly to slosh around you.",
-		"Your motion causes %pred's %belly to jiggle.",
-		"You fidget around inside of %pred's %belly.",
-		"You shove against the walls of %pred's %belly, making it briefly swell outward.",
-		"You jostle %pred's %belly with movement.",
-		"You squirm inside of %pred's %belly, making it wobble around.")
-
-	var/list/absorbed_struggle_messages_outside = list(
-		"%pred's %belly wobbles, seemingly on its own.",
-		"%pred's %belly jiggles without apparent cause.",
-		"%pred's %belly seems to shake for a second without an obvious reason.")
-
-	var/list/absorbed_struggle_messages_inside = list(
-		"You try and resist %pred's %belly, but only cause it to jiggle slightly.",
-		"Your fruitless mental struggles only shift %pred's %belly a tiny bit.",
-		"You can't make any progress freeing yourself from %pred's %belly.")
-
-	var/list/escape_attempt_messages_owner = list(
-		"%prey is attempting to free themselves from your %belly!")
-
-	var/list/escape_attempt_messages_prey = list(
-		"You start to climb out of %pred's %belly.")
-
-	var/list/escape_messages_owner = list(
-		"%prey climbs out of your %belly!")
-
-	var/list/escape_messages_prey = list(
-		"You climb out of %pred's %belly.")
-
-	var/list/escape_messages_outside = list(
-		"%prey climbs out of %pred's %belly!")
-
-	var/list/escape_item_messages_owner = list(
-		"%item suddenly slips out of your %belly!")
-
-	var/list/escape_item_messages_prey = list(
-		"Your struggles successfully cause %pred to squeeze your %item out of their %belly.")
-
-	var/list/escape_item_messages_outside = list(
-		"%item suddenly slips out of %pred's %belly!")
-
-	var/list/escape_fail_messages_owner = list(
-		"%prey's attempt to escape from your %belly has failed!")
-
-	var/list/escape_fail_messages_prey = list(
-		"Your attempt to escape %pred's %belly has failed!")
-
-	var/list/escape_attempt_absorbed_messages_owner = list(
-		"%prey is attempting to free themselves from your %belly!")
-
-	var/list/escape_attempt_absorbed_messages_prey = list(
-		"You try to force yourself out of %pred's %belly.")
-
-	var/list/escape_absorbed_messages_owner = list(
-		"%prey forces themselves free of your %belly!")
-
-	var/list/escape_absorbed_messages_prey = list(
-		"You manage to free yourself from %pred's %belly.")
-
-	var/list/escape_absorbed_messages_outside = list(
-		"%prey climbs out of %pred's %belly!")
-
-	var/list/escape_fail_absorbed_messages_owner = list(
-		"%prey's attempt to escape form your %belly has failed!")
-
-	var/list/escape_fail_absorbed_messages_prey = list(
-		"Before you manage to reach freedom, you feel yourself getting dragged back into %pred's %belly!")
-
-	var/list/primary_transfer_messages_owner = list(
-		"%prey slid into your %dest due to their struggling inside your %belly!")
-
-	var/list/primary_transfer_messages_prey = list(
-		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
-
-	var/list/secondary_transfer_messages_owner = list(
-		"%prey slid into your %dest due to their struggling inside your %belly!")
-
-	var/list/secondary_transfer_messages_prey = list(
-		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
-
-	var/list/digest_chance_messages_owner = list(
-		"You feel your %belly beginning to become active!")
-
-	var/list/digest_chance_messages_prey = list(
-		"In response to your struggling, %pred's %belly begins to get more active...")
-
-	var/list/absorb_chance_messages_owner = list(
-		"You feel your %belly start to cling onto its contents...")
-
-	var/list/absorb_chance_messages_prey = list(
-		"In response to your struggling, %pred's %belly begins to cling more tightly...")
-
-	var/list/select_chance_messages_owner = list(
-		"You feel your %belly beginning to become active!")
-
-	var/list/select_chance_messages_prey = list(
-		"In response to your struggling, %pred's %belly begins to get more active...")
-
-	var/list/digest_messages_owner = list(
-		"You feel %prey's body succumb to your digestive system, which breaks it apart into soft slurry.",
-		"You hear a lewd glorp as your %belly muscles grind %prey into a warm pulp.",
-		"Your %belly lets out a rumble as it melts %prey into sludge.",
-		"You feel a soft gurgle as %prey's body loses form in your %belly. They're nothing but a soft mass of churning slop now.",
-		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your thighs.",
-		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your rump.",
-		"Your %belly begins gushing %prey's remains through your system, adding some extra weight to your belly.",
-		"Your %belly groans as %prey falls apart into a thick soup. You can feel their remains soon flowing deeper into your body to be absorbed.",
-		"Your %belly kneads on every fiber of %prey, softening them down into mush to fuel your next hunt.",
-		"Your %belly churns %prey down into a hot slush. You can feel the nutrients coursing through your digestive track with a series of long, wet glorps.")
-
-	var/list/digest_messages_prey = list(
-		"Your body succumbs to %pred's digestive system, which breaks you apart into soft slurry.",
-		"%pred's %belly lets out a lewd glorp as their muscles grind you into a warm pulp.",
-		"%pred's %belly lets out a rumble as it melts you into sludge.",
-		"%pred feels a soft gurgle as your body loses form in their %belly. You're nothing but a soft mass of churning slop now.",
-		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's thighs.",
-		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's rump.",
-		"%pred's %belly begins gushing your remains through their system, adding some extra weight to %pred's belly.",
-		"%pred's %belly groans as you fall apart into a thick soup. Your remains soon flow deeper into %pred's body to be absorbed.",
-		"%pred's %belly kneads on every fiber of your body, softening you down into mush to fuel their next hunt.",
-		"%pred's %belly churns you down into a hot slush. Your nutrient-rich remains course through their digestive track with a series of long, wet glorps.")
-
-	var/list/absorb_messages_owner = list(
-		"You feel %prey becoming part of you.")
-
-	var/list/absorb_messages_prey = list(
-		"You feel yourself becoming part of %pred's %belly!")
-
-	var/list/unabsorb_messages_owner = list(
-		"You feel %prey reform into a recognizable state again.")
-
-	var/list/unabsorb_messages_prey = list(
-		"You are released from being part of %pred's %belly.")
-
-	var/list/examine_messages = list(
-		"They have something solid in their %belly!",
-		"It looks like they have something in their %belly!")
-
-	var/list/examine_messages_absorbed = list(
-		"Their body looks somewhat larger than usual around the area of their %belly.",
-		"Their %belly looks larger than usual.")
-
 	var/item_digest_mode = IM_DIGEST_FOOD	// Current item-related mode from item_digest_modes
 	var/contaminates = FALSE					// Whether the belly will contaminate stuff
 	var/contamination_flavor = "Generic"	// Determines descriptions of contaminated items
@@ -422,11 +266,7 @@
 	if(istype(thing, /mob/observer)) //Ports CHOMPStation PR#3072
 		if(desc) //Ports CHOMPStation PR#4772
 			//Allow ghosts see where they are if they're still getting squished along inside.
-			var/formatted_desc
-			formatted_desc = replacetext(desc, "%belly", lowertext(name)) //replace with this belly's name
-			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
-			formatted_desc = replacetext(formatted_desc, "%prey", thing) //replace with whatever mob entered into this belly
-			to_chat(thing, span_vnotice("<B>[formatted_desc]</B>"))
+			to_chat(thing, span_vnotice("<B>[belly_format_string(desc, thing)]</B>"))
 
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
@@ -459,11 +299,7 @@
 		//Was there a description text? If so, it's time to format it!
 		if(raw_desc)
 			//Replace placeholder vars
-			var/formatted_desc
-			formatted_desc = replacetext(raw_desc, "%belly", lowertext(name)) //replace with this belly's name
-			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
-			formatted_desc = replacetext(formatted_desc, "%prey", M) //replace with whatever mob entered into this belly
-			to_chat(M, span_vnotice("<B>[formatted_desc]</B>"))
+			to_chat(M, span_vnotice("<B>[belly_format_string(raw_desc, M)]</B>"))
 
 		var/taste
 		if(can_taste && (taste = M.get_taste_message(FALSE)))
@@ -753,318 +589,6 @@
 		if(owner.mind)
 			owner.mind.vore_prey_eaten++
 
-// Get the line that should show up in Examine message if the owner of this belly
-// is examined.   By making this a proc, we not only take advantage of polymorphism,
-// but can easily make the message vary based on how many people are inside, etc.
-// Returns a string which shoul be appended to the Examine output.
-/obj/belly/proc/get_examine_msg()
-	if(!(contents.len) || !(examine_messages.len))
-		return ""
-
-	var/formatted_message
-	var/raw_message = pick(examine_messages)
-	var/total_bulge = 0
-
-	var/living_count = 0
-	for(var/mob/living/L in contents)
-		living_count++
-
-	var/count_total = contents.len
-	for(var/mob/observer/C in contents)
-		count_total-- //Exclude any ghosts from %count
-
-	var/list/vore_contents = list()
-	for(var/G in contents)
-		if(!isobserver(G))
-			vore_contents += G //Exclude any ghosts from %prey
-
-	for(var/mob/living/P in contents)
-		if(!P.absorbed) //This is required first, in case there's a person absorbed and not absorbed in a stomach.
-			total_bulge += P.size_multiplier
-
-	if(total_bulge < bulge_size || bulge_size == 0)
-		return ""
-
-	formatted_message = replacetext(raw_message, "%belly", lowertext(name))
-	formatted_message = replacetext(formatted_message, "%pred", owner)
-	formatted_message = replacetext(formatted_message, "%prey", english_list(vore_contents))
-	formatted_message = replacetext(formatted_message, "%countprey", living_count)
-	formatted_message = replacetext(formatted_message, "%count", count_total)
-
-	return(span_red("<i>[formatted_message]</i>"))
-
-/obj/belly/proc/get_examine_msg_absorbed()
-	if(!(contents.len) || !(examine_messages_absorbed.len) || !display_absorbed_examine)
-		return ""
-
-	var/formatted_message
-	var/raw_message = pick(examine_messages_absorbed)
-
-	var/absorbed_count = 0
-	var/list/absorbed_victims = list()
-	for(var/mob/living/L in contents)
-		if(L.absorbed)
-			absorbed_victims += L
-			absorbed_count++
-
-	if(!absorbed_count)
-		return ""
-
-	formatted_message = replacetext(raw_message, "%belly", lowertext(name))
-	formatted_message = replacetext(formatted_message, "%pred", owner)
-	formatted_message = replacetext(formatted_message, "%prey", english_list(absorbed_victims))
-	formatted_message = replacetext(formatted_message, "%countprey", absorbed_count)
-
-	return(span_red("<i>[formatted_message]</i>"))
-
-// The next function gets the messages set on the belly, in human-readable format.
-// This is useful in customization boxes and such. The delimiter right now is \n\n so
-// in message boxes, this looks nice and is easily delimited.
-/obj/belly/proc/get_messages(type, delim = "\n\n")
-	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
-
-	var/list/raw_messages
-	switch(type)
-		if("smo")
-			raw_messages = struggle_messages_outside
-		if("smi")
-			raw_messages = struggle_messages_inside
-		if("asmo")
-			raw_messages = absorbed_struggle_messages_outside
-		if("asmi")
-			raw_messages = absorbed_struggle_messages_inside
-		if("escao")
-			raw_messages = escape_attempt_messages_owner
-		if("escap")
-			raw_messages = escape_attempt_messages_prey
-		if("esco")
-			raw_messages = escape_messages_owner
-		if("escp")
-			raw_messages = escape_messages_prey
-		if("escout")
-			raw_messages = escape_messages_outside
-		if("escio")
-			raw_messages = escape_item_messages_owner
-		if("escip")
-			raw_messages = escape_item_messages_prey
-		if("esciout")
-			raw_messages = escape_item_messages_outside
-		if("escfo")
-			raw_messages = escape_fail_messages_owner
-		if("escfp")
-			raw_messages = escape_fail_messages_prey
-		if("aescao")
-			raw_messages = escape_attempt_absorbed_messages_owner
-		if("aescap")
-			raw_messages = escape_attempt_absorbed_messages_prey
-		if("aesco")
-			raw_messages = escape_absorbed_messages_owner
-		if("aescp")
-			raw_messages = escape_absorbed_messages_prey
-		if("aescout")
-			raw_messages = escape_absorbed_messages_outside
-		if("aescfo")
-			raw_messages = escape_fail_absorbed_messages_owner
-		if("aescfp")
-			raw_messages = escape_fail_absorbed_messages_prey
-		if("trnspo")
-			raw_messages = primary_transfer_messages_owner
-		if("trnspp")
-			raw_messages = primary_transfer_messages_prey
-		if("trnsso")
-			raw_messages = secondary_transfer_messages_owner
-		if("trnssp")
-			raw_messages = secondary_transfer_messages_prey
-		if("stmodo")
-			raw_messages = digest_chance_messages_owner
-		if("stmodp")
-			raw_messages = digest_chance_messages_prey
-		if("stmoao")
-			raw_messages = absorb_chance_messages_owner
-		if("stmoap")
-			raw_messages = absorb_chance_messages_prey
-		if("dmo")
-			raw_messages = digest_messages_owner
-		if("dmp")
-			raw_messages = digest_messages_prey
-		if("em")
-			raw_messages = examine_messages
-		if("ema")
-			raw_messages = examine_messages_absorbed
-		if("amo")
-			raw_messages = absorb_messages_owner
-		if("amp")
-			raw_messages = absorb_messages_prey
-		if("uamo")
-			raw_messages = unabsorb_messages_owner
-		if("uamp")
-			raw_messages = unabsorb_messages_prey
-		if("im_digest")
-			raw_messages = emote_lists[DM_DIGEST]
-		if("im_hold")
-			raw_messages = emote_lists[DM_HOLD]
-		if("im_holdabsorbed")
-			raw_messages = emote_lists[DM_HOLD_ABSORBED]
-		if("im_absorb")
-			raw_messages = emote_lists[DM_ABSORB]
-		if("im_heal")
-			raw_messages = emote_lists[DM_HEAL]
-		if("im_drain")
-			raw_messages = emote_lists[DM_DRAIN]
-		if("im_steal")
-			raw_messages = emote_lists[DM_SIZE_STEAL]
-		if("im_egg")
-			raw_messages = emote_lists[DM_EGG]
-		if("im_shrink")
-			raw_messages = emote_lists[DM_SHRINK]
-		if("im_grow")
-			raw_messages = emote_lists[DM_GROW]
-		if("im_unabsorb")
-			raw_messages = emote_lists[DM_UNABSORB]
-	var/messages = null
-	if(raw_messages)
-		messages = raw_messages.Join(delim)
-	return messages
-
-// The next function sets the messages on the belly, from human-readable var
-// replacement strings and linebreaks as delimiters (two \n\n by default).
-// They also sanitize the messages.
-// Give them a limit for each type...
-/obj/belly/proc/set_messages(raw_text, type, delim = "\n\n", limit)
-	if(!limit)
-		CRASH("[src] set message called without limit!")
-	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
-
-	var/list/raw_list
-
-	if(findtext(raw_text, delim))
-		raw_list = splittext(html_encode(raw_text), delim)
-	else
-		raw_list = list(raw_text)
-	for(var/i = 1, i <= raw_list.len, i++)
-		if(!length(raw_list[i]))
-			raw_list.Cut(i, i + 1)
-			i--
-	if(raw_list.len > 10)
-		raw_list.Cut(11)
-		log_debug("[owner] tried to set [lowertext(name)] with 11+ messages")
-
-	var/realIndex = 0
-	for(var/i = 1, i <= raw_list.len, i++)
-		realIndex++
-		raw_list[i] = readd_quotes(raw_list[i])
-		//Also fix % sign for var replacement
-		raw_list[i] = replacetext(raw_list[i],"&#37;","%")
-		if(length(raw_list[i]) > limit || length(raw_list[i]) < 10)
-			to_chat(owner, span_warning("One of the message for [lowertext(name)] exceeded the limit of [limit] characters or has been below the lower limit of 10 characters and has been removed. Actual length: [length(raw_list[i])]"))
-			//Reflect message to the player so that they don't just lose it
-			to_chat(owner, span_warning("Message [realIndex]: [raw_list[i]]"))
-			log_debug("[owner] tried to set [lowertext(name)] [type] message with >[limit] or <10 characters")
-			raw_list.Cut(i, i + 1)
-			i--
-
-	ASSERT(raw_list.len <= 10) //Sanity
-
-	switch(type)
-		if("smo")
-			struggle_messages_outside = raw_list
-		if("smi")
-			struggle_messages_inside = raw_list
-		if("asmo")
-			absorbed_struggle_messages_outside = raw_list
-		if("asmi")
-			absorbed_struggle_messages_inside = raw_list
-		if("escao")
-			escape_attempt_messages_owner = raw_list
-		if("escap")
-			escape_attempt_messages_prey = raw_list
-		if("esco")
-			escape_messages_owner = raw_list
-		if("escp")
-			escape_messages_prey = raw_list
-		if("escout")
-			escape_messages_outside = raw_list
-		if("escio")
-			escape_item_messages_owner = raw_list
-		if("escip")
-			escape_item_messages_prey = raw_list
-		if("esciout")
-			escape_item_messages_outside = raw_list
-		if("escfo")
-			escape_fail_messages_owner = raw_list
-		if("escfp")
-			escape_fail_messages_prey = raw_list
-		if("aescao")
-			escape_attempt_absorbed_messages_owner = raw_list
-		if("aescap")
-			escape_attempt_absorbed_messages_prey = raw_list
-		if("aesco")
-			escape_absorbed_messages_owner = raw_list
-		if("aescp")
-			escape_absorbed_messages_prey = raw_list
-		if("aescout")
-			escape_absorbed_messages_outside = raw_list
-		if("aescfo")
-			escape_fail_absorbed_messages_owner = raw_list
-		if("aescfp")
-			escape_fail_absorbed_messages_prey = raw_list
-		if("trnspo")
-			primary_transfer_messages_owner = raw_list
-		if("trnspp")
-			primary_transfer_messages_prey = raw_list
-		if("trnsso")
-			secondary_transfer_messages_owner = raw_list
-		if("trnssp")
-			secondary_transfer_messages_prey = raw_list
-		if("stmodo")
-			digest_chance_messages_owner = raw_list
-		if("stmodp")
-			digest_chance_messages_prey = raw_list
-		if("stmoao")
-			absorb_chance_messages_owner = raw_list
-		if("stmoap")
-			absorb_chance_messages_prey = raw_list
-		if("dmo")
-			digest_messages_owner = raw_list
-		if("dmp")
-			digest_messages_prey = raw_list
-		if("amo")
-			absorb_messages_owner = raw_list
-		if("amp")
-			absorb_messages_prey = raw_list
-		if("uamo")
-			unabsorb_messages_owner = raw_list
-		if("uamp")
-			unabsorb_messages_prey = raw_list
-		if("em")
-			examine_messages = raw_list
-		if("ema")
-			examine_messages_absorbed = raw_list
-		if("im_digest")
-			emote_lists[DM_DIGEST] = raw_list
-		if("im_hold")
-			emote_lists[DM_HOLD] = raw_list
-		if("im_holdabsorbed")
-			emote_lists[DM_HOLD_ABSORBED] = raw_list
-		if("im_absorb")
-			emote_lists[DM_ABSORB] = raw_list
-		if("im_heal")
-			emote_lists[DM_HEAL] = raw_list
-		if("im_drain")
-			emote_lists[DM_DRAIN] = raw_list
-		if("im_steal")
-			emote_lists[DM_SIZE_STEAL] = raw_list
-		if("im_egg")
-			emote_lists[DM_EGG] = raw_list
-		if("im_shrink")
-			emote_lists[DM_SHRINK] = raw_list
-		if("im_grow")
-			emote_lists[DM_GROW] = raw_list
-		if("im_unabsorb")
-			emote_lists[DM_UNABSORB] = raw_list
-
-	return
-
 // Handle the death of a mob via digestion.
 // Called from the process_Life() methods of bellies that digest prey.
 // Default implementation calls M.death() and removes from internal contents.
@@ -1117,33 +641,13 @@
 
 // Handle a mob being absorbed
 /obj/belly/proc/absorb_living(mob/living/M)
-	var/absorb_alert_owner = pick(absorb_messages_owner)
-	var/absorb_alert_prey = pick(absorb_messages_prey)
-
-	var/absorbed_count = 0
-	for(var/mob/living/L in contents)
-		if(L.absorbed)
-			absorbed_count++
-
-	//Replace placeholder vars
-	absorb_alert_owner = replacetext(absorb_alert_owner, "%pred", owner)
-	absorb_alert_owner = replacetext(absorb_alert_owner, "%prey", M)
-	absorb_alert_owner = replacetext(absorb_alert_owner, "%belly", lowertext(name))
-	absorb_alert_owner = replacetext(absorb_alert_owner, "%countprey", absorbed_count)
-
-	absorb_alert_prey = replacetext(absorb_alert_prey, "%pred", owner)
-	absorb_alert_prey = replacetext(absorb_alert_prey, "%prey", M)
-	absorb_alert_prey = replacetext(absorb_alert_prey, "%belly", lowertext(name))
-	absorb_alert_prey = replacetext(absorb_alert_prey, "%countprey", absorbed_count)
-
 	M.absorbed = TRUE
 	if(M.ckey)
 		handle_absorb_langs(M, owner)
-
 		GLOB.prey_absorbed_roundstat++
 
-	to_chat(M, span_vnotice("[absorb_alert_prey]"))
-	to_chat(owner, span_vnotice("[absorb_alert_owner]"))
+	to_chat(M, span_vnotice("[belly_format_string(absorb_messages_prey, M, use_absorbed_count = TRUE)]"))
+	to_chat(owner, span_vnotice("[belly_format_string(absorb_messages_owner, M, use_absorbed_count = TRUE)]"))
 	if(M.noisy) //Mute drained absorbee hunger if enabled.
 		M.noisy = FALSE
 
@@ -1177,11 +681,7 @@
 
 	if(absorbed_desc)
 		//Replace placeholder vars
-		var/formatted_abs_desc
-		formatted_abs_desc = replacetext(absorbed_desc, "%belly", lowertext(name)) //replace with this belly's name
-		formatted_abs_desc = replacetext(formatted_abs_desc, "%pred", owner) //replace with this belly's owner
-		formatted_abs_desc = replacetext(formatted_abs_desc, "%prey", M) //replace with whatever mob entered into this belly
-		to_chat(M, span_vnotice("<B>[formatted_abs_desc]</B>"))
+		to_chat(M, span_vnotice("<B>[belly_format_string(absorbed_desc, M)]</B>"))
 
 	//Update owner
 	owner.updateVRPanel()
@@ -1203,32 +703,13 @@
 
 // Handle a mob being unabsorbed
 /obj/belly/proc/unabsorb_living(mob/living/M)
-	var/unabsorb_alert_owner = pick(unabsorb_messages_owner)
-	var/unabsorb_alert_prey = pick(unabsorb_messages_prey)
-
-	var/absorbed_count = 0
-	for(var/mob/living/L in contents)
-		if(L.absorbed)
-			absorbed_count++
-
-	//Replace placeholder vars
-	unabsorb_alert_owner = replacetext(unabsorb_alert_owner, "%pred", owner)
-	unabsorb_alert_owner = replacetext(unabsorb_alert_owner, "%prey", M)
-	unabsorb_alert_owner = replacetext(unabsorb_alert_owner, "%belly", lowertext(name))
-	unabsorb_alert_owner = replacetext(unabsorb_alert_owner, "%countprey", absorbed_count)
-
-	unabsorb_alert_prey = replacetext(unabsorb_alert_prey, "%pred", owner)
-	unabsorb_alert_prey = replacetext(unabsorb_alert_prey, "%prey", M)
-	unabsorb_alert_prey = replacetext(unabsorb_alert_prey, "%belly", lowertext(name))
-	unabsorb_alert_prey = replacetext(unabsorb_alert_prey, "%countprey", absorbed_count)
-
 	M.absorbed = FALSE
 	handle_absorb_langs(M, owner)
-	to_chat(M, span_vnotice("[unabsorb_alert_prey]"))
-	to_chat(owner, span_vnotice("[unabsorb_alert_owner]"))
+	to_chat(M, span_vnotice(belly_format_string(unabsorb_messages_prey, M, use_absorbed_count = TRUE)))
+	to_chat(owner, span_vnotice(belly_format_string(unabsorb_messages_owner, M, use_absorbed_count = TRUE)))
 
 	if(desc)
-		to_chat(M, span_vnotice("<B>[desc]</B>"))
+		to_chat(M, span_vnotice("<B>[belly_format_string(desc, M)]</B>"))
 
 	//Update owner
 	owner.updateVRPanel()
@@ -1284,46 +765,13 @@
 
 	R.setClickCooldown(50)
 
-	var/living_count = 0
-	for(var/mob/living/L in contents)
-		living_count++
-
-	var/escape_attempt_owner_message = pick(escape_attempt_messages_owner)
-	var/escape_attempt_prey_message = pick(escape_attempt_messages_prey)
-	var/escape_fail_owner_message = pick(escape_fail_messages_owner)
-	var/escape_fail_prey_message = pick(escape_fail_messages_prey)
-
-	escape_attempt_owner_message = replacetext(escape_attempt_owner_message, "%pred", owner)
-	escape_attempt_owner_message = replacetext(escape_attempt_owner_message, "%prey", R)
-	escape_attempt_owner_message = replacetext(escape_attempt_owner_message, "%belly", lowertext(name))
-	escape_attempt_owner_message = replacetext(escape_attempt_owner_message, "%countprey", living_count)
-	escape_attempt_owner_message = replacetext(escape_attempt_owner_message, "%count", contents.len)
-
-	escape_attempt_prey_message = replacetext(escape_attempt_prey_message, "%pred", owner)
-	escape_attempt_prey_message = replacetext(escape_attempt_prey_message, "%prey", R)
-	escape_attempt_prey_message = replacetext(escape_attempt_prey_message, "%belly", lowertext(name))
-	escape_attempt_prey_message = replacetext(escape_attempt_prey_message, "%countprey", living_count)
-	escape_attempt_prey_message = replacetext(escape_attempt_prey_message, "%count", contents.len)
-
-	escape_fail_owner_message = replacetext(escape_fail_owner_message, "%pred", owner)
-	escape_fail_owner_message = replacetext(escape_fail_owner_message, "%prey", R)
-	escape_fail_owner_message = replacetext(escape_fail_owner_message, "%belly", lowertext(name))
-	escape_fail_owner_message = replacetext(escape_fail_owner_message, "%countprey", living_count)
-	escape_fail_owner_message = replacetext(escape_fail_owner_message, "%count", contents.len)
-
-	escape_fail_prey_message = replacetext(escape_fail_prey_message, "%pred", owner)
-	escape_fail_prey_message = replacetext(escape_fail_prey_message, "%prey", R)
-	escape_fail_prey_message = replacetext(escape_fail_prey_message, "%belly", lowertext(name))
-	escape_fail_prey_message = replacetext(escape_fail_prey_message, "%countprey", living_count)
-	escape_fail_prey_message = replacetext(escape_fail_prey_message, "%count", contents.len)
-
-	escape_attempt_owner_message = span_vwarning("[escape_attempt_owner_message]")
-	escape_attempt_prey_message = span_vwarning("[escape_attempt_prey_message]")
-	escape_fail_owner_message = span_vwarning("[escape_fail_owner_message]")
-	escape_fail_prey_message = span_vnotice("[escape_fail_prey_message]")
+	var/escape_attempt_owner_message = span_vwarning(belly_format_string(escape_attempt_messages_owner, R))
+	var/escape_attempt_prey_message = span_vwarning(belly_format_string(escape_attempt_messages_prey, R))
+	var/escape_fail_owner_message = span_vwarning(belly_format_string(escape_fail_messages_owner, R))
+	var/escape_fail_prey_message = span_vnotice(belly_format_string(escape_fail_messages_prey, R))
 
 	if(owner.stat) //If owner is stat (dead, KO) we can actually escape
-		escape_attempt_prey_message = replacetext(escape_attempt_prey_message, new/regex("^(<span(?: \[^>]*)?>.*)(</span>)$", ""), "$1 (This will take around [escapetime/10] seconds.)$2")
+		escape_attempt_prey_message = span_vwarning("[escape_attempt_prey_message] (will take around [escapetime/10] seconds.)")
 		to_chat(R, escape_attempt_prey_message)
 		to_chat(owner, escape_attempt_owner_message)
 
@@ -1342,23 +790,9 @@
 				to_chat(owner, escape_fail_owner_message)
 				return
 			return
-	var/struggle_outer_message = pick(struggle_messages_outside)
-	var/struggle_user_message = pick(struggle_messages_inside)
 
-	struggle_outer_message = replacetext(struggle_outer_message, "%pred", owner)
-	struggle_outer_message = replacetext(struggle_outer_message, "%prey", R)
-	struggle_outer_message = replacetext(struggle_outer_message, "%belly", lowertext(name))
-	struggle_outer_message = replacetext(struggle_outer_message, "%countprey", living_count)
-	struggle_outer_message = replacetext(struggle_outer_message, "%count", contents.len)
-
-	struggle_user_message = replacetext(struggle_user_message, "%pred", owner)
-	struggle_user_message = replacetext(struggle_user_message, "%prey", R)
-	struggle_user_message = replacetext(struggle_user_message, "%belly", lowertext(name))
-	struggle_user_message = replacetext(struggle_user_message, "%countprey", living_count)
-	struggle_user_message = replacetext(struggle_user_message, "%count", contents.len)
-
-	struggle_outer_message = span_valert("[struggle_outer_message]")
-	struggle_user_message = span_valert("[struggle_user_message]")
+	var/struggle_outer_message = span_valert(belly_format_string(struggle_messages_outside, R))
+	var/struggle_user_message = span_valert(belly_format_string(struggle_messages_inside, R))
 
 	for(var/mob/M in hearers(4, owner))
 		M.show_message(struggle_outer_message, 2) // hearable
@@ -1386,34 +820,9 @@
 			to_chat(owner, escape_attempt_owner_message)
 			if(do_after(R, escapetime))
 				if(escapable && C)
-					var/escape_item_owner_message = pick(escape_item_messages_owner)
-					var/escape_item_prey_message = pick(escape_item_messages_prey)
-					var/escape_item_outside_message = pick(escape_item_messages_outside)
-
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%pred", owner)
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%prey", R)
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%belly", lowertext(name))
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%countprey", living_count)
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%count", contents.len)
-					escape_item_owner_message = replacetext(escape_item_owner_message, "%item", C)
-
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%pred", owner)
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%prey", R)
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%belly", lowertext(name))
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%countprey", living_count)
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%count", contents.len)
-					escape_item_prey_message = replacetext(escape_item_prey_message, "%item", C)
-
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%pred", owner)
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%prey", R)
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%belly", lowertext(name))
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%countprey", living_count)
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%count", contents.len)
-					escape_item_outside_message = replacetext(escape_item_outside_message, "%item", C)
-
-					escape_item_owner_message = span_vwarning("[escape_item_owner_message]")
-					escape_item_prey_message = span_vwarning("[escape_item_prey_message]")
-					escape_item_outside_message = span_vwarning("[escape_item_outside_message]")
+					var/escape_item_owner_message = span_vwarning(belly_format_string(escape_item_messages_owner, R, item = C))
+					var/escape_item_prey_message = span_vwarning(belly_format_string(escape_item_messages_prey, R, item = C))
+					var/escape_item_outside_message = span_vwarning(belly_format_string(escape_item_messages_outside, R, item = C))
 
 					release_specific_contents(C)
 					to_chat(R, escape_item_prey_message)
@@ -1422,31 +831,10 @@
 						M.show_message(escape_item_outside_message, 2)
 					return
 				if(escapable && (R.loc == src) && !R.absorbed) //Does the owner still have escapable enabled?
-					var/escape_owner_message = pick(escape_messages_owner)
-					var/escape_prey_message = pick(escape_messages_prey)
-					var/escape_outside_message = pick(escape_messages_outside)
+					var/escape_owner_message = span_vwarning(belly_format_string(escape_messages_owner, R))
+					var/escape_prey_message = span_vwarning(belly_format_string(escape_messages_prey, R))
+					var/escape_outside_message = span_vwarning(belly_format_string(escape_messages_outside, R))
 
-					escape_owner_message = replacetext(escape_owner_message, "%pred", owner)
-					escape_owner_message = replacetext(escape_owner_message, "%prey", R)
-					escape_owner_message = replacetext(escape_owner_message, "%belly", lowertext(name))
-					escape_owner_message = replacetext(escape_owner_message, "%countprey", living_count)
-					escape_owner_message = replacetext(escape_owner_message, "%count", contents.len)
-
-					escape_prey_message = replacetext(escape_prey_message, "%pred", owner)
-					escape_prey_message = replacetext(escape_prey_message, "%prey", R)
-					escape_prey_message = replacetext(escape_prey_message, "%belly", lowertext(name))
-					escape_prey_message = replacetext(escape_prey_message, "%countprey", living_count)
-					escape_prey_message = replacetext(escape_prey_message, "%count", contents.len)
-
-					escape_outside_message = replacetext(escape_outside_message, "%pred", owner)
-					escape_outside_message = replacetext(escape_outside_message, "%prey", R)
-					escape_outside_message = replacetext(escape_outside_message, "%belly", lowertext(name))
-					escape_outside_message = replacetext(escape_outside_message, "%countprey", living_count)
-					escape_outside_message = replacetext(escape_outside_message, "%count", contents.len)
-
-					escape_owner_message = span_vwarning("[escape_owner_message]")
-					escape_prey_message = span_vwarning("[escape_prey_message]")
-					escape_outside_message = span_vwarning("[escape_outside_message]")
 					release_specific_contents(R)
 					to_chat(R, escape_prey_message)
 					to_chat(owner, escape_owner_message)
@@ -1472,25 +860,8 @@
 				transferchance = 0
 				transferlocation = null
 				return
-			var/primary_transfer_owner_message = pick(primary_transfer_messages_owner)
-			var/primary_transfer_prey_message = pick(primary_transfer_messages_prey)
-
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%pred", owner)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%prey", R)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%belly", lowertext(name))
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%countprey", living_count)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%count", contents.len)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%dest", transferlocation)
-
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%pred", owner)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%prey", R)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%belly", lowertext(name))
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%countprey", living_count)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%count", contents.len)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%dest", transferlocation)
-
-			primary_transfer_owner_message = span_vwarning("[primary_transfer_owner_message]")
-			primary_transfer_prey_message = span_vwarning("[primary_transfer_prey_message]")
+			var/primary_transfer_owner_message = span_vwarning(belly_format_string(primary_transfer_messages_owner, R, dest = transferlocation))
+			var/primary_transfer_prey_message = span_vwarning(belly_format_string(primary_transfer_messages_prey, R, dest = transferlocation))
 
 			to_chat(R, primary_transfer_prey_message)
 			to_chat(owner, primary_transfer_owner_message)
@@ -1513,25 +884,8 @@
 				transferlocation_secondary = null
 				return
 
-			var/secondary_transfer_owner_message = pick(secondary_transfer_messages_owner)
-			var/secondary_transfer_prey_message = pick(secondary_transfer_messages_prey)
-
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%pred", owner)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%prey", R)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%belly", lowertext(name))
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%countprey", living_count)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%count", contents.len)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%dest", transferlocation_secondary)
-
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%pred", owner)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%prey", R)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%belly", lowertext(name))
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%countprey", living_count)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%count", contents.len)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%dest", transferlocation_secondary)
-
-			secondary_transfer_owner_message = span_vwarning("[secondary_transfer_owner_message]")
-			secondary_transfer_prey_message = span_vwarning("[secondary_transfer_prey_message]")
+			var/secondary_transfer_owner_message = span_vwarning(belly_format_string(secondary_transfer_messages_owner, R, dest = transferlocation_secondary))
+			var/secondary_transfer_prey_message = span_vwarning(belly_format_string(secondary_transfer_messages_prey, R, dest = transferlocation_secondary))
 
 			to_chat(R, secondary_transfer_prey_message)
 			to_chat(owner, secondary_transfer_owner_message)
@@ -1542,23 +896,8 @@
 			return
 
 		else if(prob(absorbchance) && digest_mode != DM_ABSORB) //After that, let's have it run the absorb chance.
-			var/absorb_chance_owner_message = pick(absorb_chance_messages_owner)
-			var/absorb_chance_prey_message = pick(absorb_chance_messages_prey)
-
-			absorb_chance_owner_message = replacetext(absorb_chance_owner_message, "%pred", owner)
-			absorb_chance_owner_message = replacetext(absorb_chance_owner_message, "%prey", R)
-			absorb_chance_owner_message = replacetext(absorb_chance_owner_message, "%belly", lowertext(name))
-			absorb_chance_owner_message = replacetext(absorb_chance_owner_message, "%countprey", living_count)
-			absorb_chance_owner_message = replacetext(absorb_chance_owner_message, "%count", contents.len)
-
-			absorb_chance_prey_message = replacetext(absorb_chance_prey_message, "%pred", owner)
-			absorb_chance_prey_message = replacetext(absorb_chance_prey_message, "%prey", R)
-			absorb_chance_prey_message = replacetext(absorb_chance_prey_message, "%belly", lowertext(name))
-			absorb_chance_prey_message = replacetext(absorb_chance_prey_message, "%countprey", living_count)
-			absorb_chance_prey_message = replacetext(absorb_chance_prey_message, "%count", contents.len)
-
-			absorb_chance_owner_message = span_vwarning("[absorb_chance_owner_message]")
-			absorb_chance_prey_message = span_vwarning("[absorb_chance_prey_message]")
+			var/absorb_chance_owner_message = span_vwarning(belly_format_string(absorb_chance_messages_owner, R))
+			var/absorb_chance_prey_message = span_vwarning(belly_format_string(absorb_chance_messages_prey, R))
 
 			to_chat(R, absorb_chance_prey_message)
 			to_chat(owner, absorb_chance_owner_message)
@@ -1566,46 +905,16 @@
 			return
 
 		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Then, let's see if it should run the digest chance.
-			var/digest_chance_owner_message = pick(digest_chance_messages_owner)
-			var/digest_chance_prey_message = pick(digest_chance_messages_prey)
-
-			digest_chance_owner_message = replacetext(digest_chance_owner_message, "%pred", owner)
-			digest_chance_owner_message = replacetext(digest_chance_owner_message, "%prey", R)
-			digest_chance_owner_message = replacetext(digest_chance_owner_message, "%belly", lowertext(name))
-			digest_chance_owner_message = replacetext(digest_chance_owner_message, "%countprey", living_count)
-			digest_chance_owner_message = replacetext(digest_chance_owner_message, "%count", contents.len)
-
-			digest_chance_prey_message = replacetext(digest_chance_prey_message, "%pred", owner)
-			digest_chance_prey_message = replacetext(digest_chance_prey_message, "%prey", R)
-			digest_chance_prey_message = replacetext(digest_chance_prey_message, "%belly", lowertext(name))
-			digest_chance_prey_message = replacetext(digest_chance_prey_message, "%countprey", living_count)
-			digest_chance_prey_message = replacetext(digest_chance_prey_message, "%count", contents.len)
-
-			digest_chance_owner_message = span_vwarning("[digest_chance_owner_message]")
-			digest_chance_prey_message = span_vwarning("[digest_chance_prey_message]")
+			var/digest_chance_owner_message = span_vwarning(belly_format_string(digest_chance_messages_owner, R))
+			var/digest_chance_prey_message = span_vwarning(belly_format_string(digest_chance_messages_prey, R))
 
 			to_chat(R, digest_chance_prey_message)
 			to_chat(owner, digest_chance_owner_message)
 			digest_mode = DM_DIGEST
 			return
 		else if(prob(selectchance) && digest_mode != DM_SELECT) //Finally, let's see if it should run the selective mode chance.
-			var/select_chance_owner_message = pick(select_chance_messages_owner)
-			var/select_chance_prey_message = pick(select_chance_messages_prey)
-
-			select_chance_owner_message = replacetext(select_chance_owner_message, "%pred", owner)
-			select_chance_owner_message = replacetext(select_chance_owner_message, "%prey", R)
-			select_chance_owner_message = replacetext(select_chance_owner_message, "%belly", lowertext(name))
-			select_chance_owner_message = replacetext(select_chance_owner_message, "%countprey", living_count)
-			select_chance_owner_message = replacetext(select_chance_owner_message, "%count", contents.len)
-
-			select_chance_prey_message = replacetext(select_chance_prey_message, "%pred", owner)
-			select_chance_prey_message = replacetext(select_chance_prey_message, "%prey", R)
-			select_chance_prey_message = replacetext(select_chance_prey_message, "%belly", lowertext(name))
-			select_chance_prey_message = replacetext(select_chance_prey_message, "%countprey", living_count)
-			select_chance_prey_message = replacetext(select_chance_prey_message, "%count", contents.len)
-
-			select_chance_owner_message = span_vwarning("[select_chance_owner_message]")
-			select_chance_prey_message = span_vwarning("[select_chance_prey_message]")
+			var/select_chance_owner_message = span_vwarning(belly_format_string(select_chance_messages_owner, R))
+			var/select_chance_prey_message = span_vwarning(belly_format_string(select_chance_messages_prey, R))
 
 			to_chat(R, select_chance_prey_message)
 			to_chat(owner, select_chance_owner_message)
@@ -1623,26 +932,8 @@
 
 	R.setClickCooldown(50)
 
-	var/struggle_outer_message = pick(absorbed_struggle_messages_outside)
-	var/struggle_user_message = pick(absorbed_struggle_messages_inside)
-
-	var/absorbed_count = 0
-	for(var/mob/living/L in contents)
-		if(L.absorbed)
-			absorbed_count++
-
-	struggle_outer_message = replacetext(struggle_outer_message, "%pred", owner)
-	struggle_outer_message = replacetext(struggle_outer_message, "%prey", R)
-	struggle_outer_message = replacetext(struggle_outer_message, "%belly", lowertext(name))
-	struggle_outer_message = replacetext(struggle_outer_message, "%countprey", absorbed_count)
-
-	struggle_user_message = replacetext(struggle_user_message, "%pred", owner)
-	struggle_user_message = replacetext(struggle_user_message, "%prey", R)
-	struggle_user_message = replacetext(struggle_user_message, "%belly", lowertext(name))
-	struggle_user_message = replacetext(struggle_user_message, "%countprey", absorbed_count)
-
-	struggle_outer_message = span_valert("[struggle_outer_message]")
-	struggle_user_message = span_valert("[struggle_user_message]")
+	var/struggle_outer_message = span_valert(belly_format_string(absorbed_struggle_messages_outside, R, use_absorbed_count = TRUE))
+	var/struggle_user_message = span_valert(belly_format_string(absorbed_struggle_messages_inside, R, use_absorbed_count = TRUE))
 
 	for(var/mob/M in hearers(4, owner))
 		M.show_message(struggle_outer_message, 2) // hearable
@@ -1662,59 +953,16 @@
 	//absorb resists
 	if(escapable || owner.stat) //If the stomach has escapable enabled or the owner is dead/unconscious
 		if(prob(escapechance) || owner.stat) //Let's have it check to see if the prey's escape attempt starts.
-
-
-			var/living_count = 0
-			for(var/mob/living/L in contents)
-				living_count++
-
-			var/escape_attempt_absorbed_owner_message = pick(escape_attempt_absorbed_messages_owner)
-			var/escape_attempt_absorbed_prey_message = pick(escape_attempt_absorbed_messages_prey)
-
-			escape_attempt_absorbed_owner_message = replacetext(escape_attempt_absorbed_owner_message, "%pred", owner)
-			escape_attempt_absorbed_owner_message = replacetext(escape_attempt_absorbed_owner_message, "%prey", R)
-			escape_attempt_absorbed_owner_message = replacetext(escape_attempt_absorbed_owner_message, "%belly", lowertext(name))
-			escape_attempt_absorbed_owner_message = replacetext(escape_attempt_absorbed_owner_message, "%countprey", living_count)
-			escape_attempt_absorbed_owner_message = replacetext(escape_attempt_absorbed_owner_message, "%count", contents.len)
-
-			escape_attempt_absorbed_prey_message = replacetext(escape_attempt_absorbed_prey_message, "%pred", owner)
-			escape_attempt_absorbed_prey_message = replacetext(escape_attempt_absorbed_prey_message, "%prey", R)
-			escape_attempt_absorbed_prey_message = replacetext(escape_attempt_absorbed_prey_message, "%belly", lowertext(name))
-			escape_attempt_absorbed_prey_message = replacetext(escape_attempt_absorbed_prey_message, "%countprey", living_count)
-			escape_attempt_absorbed_prey_message = replacetext(escape_attempt_absorbed_prey_message, "%count", contents.len)
-
-			escape_attempt_absorbed_owner_message = span_vwarning("[escape_attempt_absorbed_owner_message]")
-			escape_attempt_absorbed_prey_message = span_vwarning("[escape_attempt_absorbed_prey_message]")
+			var/escape_attempt_absorbed_owner_message = span_vwarning(belly_format_string(escape_attempt_absorbed_messages_owner, R))
+			var/escape_attempt_absorbed_prey_message = span_vwarning(belly_format_string(escape_attempt_absorbed_messages_prey, R))
 
 			to_chat(R, escape_attempt_absorbed_prey_message)
 			to_chat(owner, escape_attempt_absorbed_owner_message)
 			if(do_after(R, escapetime))
 				if((escapable || owner.stat) && (R.loc == src) && prob(escapechance_absorbed)) //Does the escape attempt succeed?
-					var/escape_absorbed_owner_message = pick(escape_absorbed_messages_owner)
-					var/escape_absorbed_prey_message = pick(escape_absorbed_messages_prey)
-					var/escape_absorbed_outside_message = pick(escape_absorbed_messages_outside)
-
-					escape_absorbed_owner_message = replacetext(escape_absorbed_owner_message, "%pred", owner)
-					escape_absorbed_owner_message = replacetext(escape_absorbed_owner_message, "%prey", R)
-					escape_absorbed_owner_message = replacetext(escape_absorbed_owner_message, "%belly", lowertext(name))
-					escape_absorbed_owner_message = replacetext(escape_absorbed_owner_message, "%countprey", living_count)
-					escape_absorbed_owner_message = replacetext(escape_absorbed_owner_message, "%count", contents.len)
-
-					escape_absorbed_prey_message = replacetext(escape_absorbed_prey_message, "%pred", owner)
-					escape_absorbed_prey_message = replacetext(escape_absorbed_prey_message, "%prey", R)
-					escape_absorbed_prey_message = replacetext(escape_absorbed_prey_message, "%belly", lowertext(name))
-					escape_absorbed_prey_message = replacetext(escape_absorbed_prey_message, "%countprey", living_count)
-					escape_absorbed_prey_message = replacetext(escape_absorbed_prey_message, "%count", contents.len)
-
-					escape_absorbed_outside_message = replacetext(escape_absorbed_outside_message, "%pred", owner)
-					escape_absorbed_outside_message = replacetext(escape_absorbed_outside_message, "%prey", R)
-					escape_absorbed_outside_message = replacetext(escape_absorbed_outside_message, "%belly", lowertext(name))
-					escape_absorbed_outside_message = replacetext(escape_absorbed_outside_message, "%countprey", living_count)
-					escape_absorbed_outside_message = replacetext(escape_absorbed_outside_message, "%count", contents.len)
-
-					escape_absorbed_owner_message = span_vwarning("[escape_absorbed_owner_message]")
-					escape_absorbed_prey_message = span_vwarning("[escape_absorbed_prey_message]")
-					escape_absorbed_outside_message = span_vwarning("[escape_absorbed_outside_message]")
+					var/escape_absorbed_owner_message = span_vwarning(belly_format_string(escape_absorbed_messages_owner, R))
+					var/escape_absorbed_prey_message = span_vwarning(belly_format_string(escape_absorbed_messages_prey, R))
+					var/escape_absorbed_outside_message = span_vwarning(belly_format_string(escape_absorbed_messages_outside, R))
 
 					release_specific_contents(R)
 					to_chat(R, escape_absorbed_prey_message)
@@ -1725,24 +973,8 @@
 				else if(!(R.loc == src)) //Aren't even in the belly. Quietly fail.
 					return
 				else //Belly became inescapable or you failed your roll.
-
-					var/escape_fail_absorbed_owner_message = pick(escape_fail_absorbed_messages_owner)
-					var/escape_fail_absorbed_prey_message = pick(escape_fail_absorbed_messages_prey)
-
-					escape_fail_absorbed_owner_message = replacetext(escape_fail_absorbed_owner_message, "%pred", owner)
-					escape_fail_absorbed_owner_message = replacetext(escape_fail_absorbed_owner_message, "%prey", R)
-					escape_fail_absorbed_owner_message = replacetext(escape_fail_absorbed_owner_message, "%belly", lowertext(name))
-					escape_fail_absorbed_owner_message = replacetext(escape_fail_absorbed_owner_message, "%countprey", living_count)
-					escape_fail_absorbed_owner_message = replacetext(escape_fail_absorbed_owner_message, "%count", contents.len)
-
-					escape_fail_absorbed_prey_message = replacetext(escape_fail_absorbed_prey_message, "%pred", owner)
-					escape_fail_absorbed_prey_message = replacetext(escape_fail_absorbed_prey_message, "%prey", R)
-					escape_fail_absorbed_prey_message = replacetext(escape_fail_absorbed_prey_message, "%belly", lowertext(name))
-					escape_fail_absorbed_prey_message = replacetext(escape_fail_absorbed_prey_message, "%countprey", living_count)
-					escape_fail_absorbed_prey_message = replacetext(escape_fail_absorbed_prey_message, "%count", contents.len)
-
-					escape_fail_absorbed_owner_message = span_vwarning("[escape_fail_absorbed_owner_message]")
-					escape_fail_absorbed_prey_message = span_vnotice("[escape_fail_absorbed_prey_message]")
+					var/escape_fail_absorbed_owner_message = span_vwarning(belly_format_string(escape_fail_absorbed_messages_owner, R))
+					var/escape_fail_absorbed_prey_message = span_vnotice(belly_format_string(escape_fail_absorbed_messages_prey, R))
 
 					to_chat(R, escape_fail_absorbed_prey_message)
 					to_chat(owner, escape_fail_absorbed_owner_message)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -96,6 +96,23 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 		. = icon2base64(getFlatIcon(target,defdir=SOUTH,no_anim=TRUE))
 		nom_icons[key] = .
 
+/datum/vore_look/tgui_static_data(mob/user)
+	var/list/data = ..()
+
+	data["vore_words"] = list(
+		"%goo" = GLOB.vore_words_goo,
+		"%happybelly" = GLOB.vore_words_hbellynoises,
+		"%fat" = GLOB.vore_words_fat,
+		"%grip" = GLOB.vore_words_grip,
+		"%cozy" = GLOB.vore_words_cozyholdingwords,
+		"%angry" = GLOB.vore_words_angry,
+		"%acid" = GLOB.vore_words_acid,
+		"%snack" = GLOB.vore_words_snackname,
+		"%hot" = GLOB.vore_words_hot,
+		"%snake" = GLOB.vore_words_snake,
+	)
+
+	return data
 
 /datum/vore_look/tgui_data(mob/user)
 	var/list/data = list()
@@ -118,14 +135,8 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 		else if(inside_belly.desc)
 			inside_desc = inside_belly.desc
 
-		//I'd rather not copy-paste this code twice into the previous if-statement
-		//Technically we could just format the text anyway, but IDK how demanding unnecessary text-replacements are
-		if((host.absorbed && inside_belly.absorbed_desc) || (inside_belly.desc))
-			var/formatted_desc
-			formatted_desc = replacetext(inside_desc, "%belly", lowertext(inside_belly.name)) //replace with this belly's name
-			formatted_desc = replacetext(formatted_desc, "%pred", pred) //replace with the pred of this belly
-			formatted_desc = replacetext(formatted_desc, "%prey", host) //replace with whoever's reading this
-			inside_desc = formatted_desc
+		if(inside_desc != "No description.")
+			inside_desc = inside_belly.belly_format_string(inside_desc, host, use_first_only = TRUE)
 
 		inside = list(
 			"absorbed" = host.absorbed,

--- a/tgui/packages/tgui/components/NanoMap.tsx
+++ b/tgui/packages/tgui/components/NanoMap.tsx
@@ -3,17 +3,10 @@ import React, { Component, PropsWithChildren } from 'react';
 import { resolveAsset } from 'tgui/assets';
 import { useBackend } from 'tgui/backend';
 import { KeyEvent } from 'tgui/events';
+import { KeyListener } from 'tgui-core/components';
 
 import { logger } from '../logging';
-import {
-  Box,
-  Button,
-  Icon,
-  KeyListener,
-  LabeledList,
-  Slider,
-  Tooltip,
-} from '.';
+import { Box, Button, Icon, LabeledList, Slider, Tooltip } from '.';
 
 const pauseEvent = (e) => {
   if (e.stopPropagation) {

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyDescriptions.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyDescriptions.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { useBackend } from 'tgui/backend';
-import { Box, Button, LabeledList } from 'tgui/components';
+import { Box, Button, Dimmer, LabeledList, Section } from 'tgui/components';
 
 import { SYNTAX_COLOR, SYNTAX_REGEX } from '../constants';
-import { selectedData } from '../types';
+import { Data, selectedData } from '../types';
 import { VoreSelectedBellyDescriptionsBellymode } from '../VoreSelectedBellyDescriptionTexts/VoreSelectedBellyDescriptionsBellymode';
 import { VoreSelectedBellyDescriptionsEscape } from '../VoreSelectedBellyDescriptionTexts/VoreSelectedBellyDescriptionsEscape';
 import { VoreSelectedBellyDescriptionsIdle } from '../VoreSelectedBellyDescriptionTexts/VoreSelectedBellyDescriptionsIdle';
@@ -30,7 +30,7 @@ const DescriptionSyntaxHighlighting = (props: { desc: string }) => {
     while ((result = regexCopy.exec(desc)) !== null) {
       elements.push(<>{desc.substring(lastIndex, result.index)}</>);
       elements.push(
-        <Box inline color={SYNTAX_COLOR[result[0]]}>
+        <Box inline color={SYNTAX_COLOR[result[0]] || 'purple'}>
           {result[0]}
         </Box>,
       );
@@ -48,7 +48,8 @@ const DescriptionSyntaxHighlighting = (props: { desc: string }) => {
 export const VoreSelectedBellyDescriptions = (props: {
   belly: selectedData;
 }) => {
-  const { act } = useBackend();
+  const { act, data } = useBackend<Data>();
+  const [showFormatHelp, setShowFormatHelp] = useState(false);
 
   const { belly } = props;
   const {
@@ -65,6 +66,57 @@ export const VoreSelectedBellyDescriptions = (props: {
 
   return (
     <Box>
+      {showFormatHelp && (
+        <Dimmer>
+          <Section
+            title="Formatting Help"
+            width={30}
+            height={30}
+            fill
+            buttons={
+              <Button
+                icon="window-close-o"
+                onClick={() => setShowFormatHelp(false)}
+              />
+            }
+            scrollable
+            backgroundColor="black"
+          >
+            <LabeledList>
+              <LabeledList.Item label="%belly">Belly Name</LabeledList.Item>
+              <LabeledList.Item label="%pred">Pred Name</LabeledList.Item>
+              <LabeledList.Item label="%prey">Prey Name</LabeledList.Item>
+              <LabeledList.Item label="%countpreytotal">
+                Number of prey alive, absorbed, and ghosts.
+              </LabeledList.Item>
+              <LabeledList.Item label="%countpreyabsorbed">
+                Number of prey absorbed.
+              </LabeledList.Item>
+              <LabeledList.Item label="%countprey">
+                Number of prey alive or absorbed, depending on whether prey is
+                absorbed.
+              </LabeledList.Item>
+              <LabeledList.Item label="%countghosts">
+                Number of prey ghosts.
+              </LabeledList.Item>
+              <LabeledList.Item label="%count">
+                Number of prey and items, minus ghosts.
+              </LabeledList.Item>
+              <LabeledList.Item label="%item">
+                Only used in resist messages - item the prey is using to escape.
+              </LabeledList.Item>
+              <LabeledList.Item label="%dest">
+                Only used in transfer messages - belly prey is going to.
+              </LabeledList.Item>
+              {Object.entries(data.vore_words).map(([word, options]) => (
+                <LabeledList.Item key={word} label={word}>
+                  Replaces self with one of these options: {options.join(', ')}
+                </LabeledList.Item>
+              ))}
+            </LabeledList>
+          </Section>
+        </Dimmer>
+      )}
       <LabeledList>
         <LabeledList.Item label="Vore Verb">
           <Button onClick={() => act('set_attribute', { attribute: 'b_verb' })}>
@@ -173,6 +225,12 @@ export const VoreSelectedBellyDescriptions = (props: {
         >
           Edit
         </Button>
+        <Button
+          icon="question"
+          tooltip="Formatting help"
+          onClick={() => setShowFormatHelp(!showFormatHelp)}
+          selected={showFormatHelp}
+        />
       </Box>
       <DescriptionSyntaxHighlighting desc={desc} />
       <Box color="label" mt={2} mb={1}>

--- a/tgui/packages/tgui/interfaces/VorePanel/constants.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/constants.ts
@@ -28,7 +28,8 @@ export const digestModeToPreyMode = {
   'Encase In Egg': 'being encased in an egg.',
 };
 
-export const SYNTAX_REGEX = /%belly|%pred|%prey/g;
+export const SYNTAX_REGEX =
+  /%belly|%pred|%prey|%countpreytotal|%countpreyabsorbed|%countprey|%countghosts|%count|%ghost|%item|%dest|%goo|%happybelly|%fat|%grip|%cozy|%angry|%acid|%snack|%hot|%snake/g;
 export const SYNTAX_COLOR = {
   '%belly': 'average',
   '%pred': 'bad',

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -15,6 +15,7 @@ export type Data = {
     maximum_size: number;
     resize_cost: number;
   };
+  vore_words: Record<string, string[]>;
 };
 
 export type hostMob = {

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4184,6 +4184,7 @@
 #include "code\modules\vore\appearance\preferences_vr.dm"
 #include "code\modules\vore\appearance\update_icons_vr.dm"
 #include "code\modules\vore\eating\belly_dat_vr.dm"
+#include "code\modules\vore\eating\belly_messages.dm"
 #include "code\modules\vore\eating\belly_obj_vr.dm"
 #include "code\modules\vore\eating\bellymodes_datum_vr.dm"
 #include "code\modules\vore\eating\bellymodes_vr.dm"


### PR DESCRIPTION
![https://i.tigercat2000.net/2024/10/6d6RXoJaYh.png](https://i.tigercat2000.net/2024/10/6d6RXoJaYh.png)
![https://i.tigercat2000.net/2024/10/zpDyWCF6bk.gif](https://i.tigercat2000.net/2024/10/zpDyWCF6bk.gif)

:cl:
refactor: Belly message formatting has been unified into one proc.
add: All formatted belly messages can now use a number of new %replacements, which choose from a list of preset words. You can see all of the words that will be used in a new help menu next to the belly description, but this PR adds the following: %goo, %happybelly, %fat, %dick, %boob, %pussy, %grip, %cozy, %angry, %acid, %snack, %hot
add: For example, %goo will be replaced randomly with "muck", or "goo", or "sludge", or "slime", or another 10 different options - this random replacement happens every time a message is printed, so it's really helpful for idle messages!
/:cl: