### PR TITLE
Fixes wrist PDA runtiming when firing guns

### DIFF
--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -79,6 +79,8 @@ var/global/list/obj/item/pda/PDAs = list()
 	var/list/notifying_programs = list()
 	var/retro_mode = 0
 
+	var/gunshot_residue // VOREstation edit: prevents wrist PDA from preventing gun use
+
 /obj/item/pda/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))


### PR DESCRIPTION
Fixes wearing a wrist PDA from runtiming when firing guns, due to wrist PDA's being wearable but not clothing.

DOWNSTREAM CHANGELOG
🆑 
fix: fixes wrist PDA runtiming when firing guns
/:cl: