### PR TITLE
Enable research module / prevent AI shells from building more AI shells

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -164,6 +164,9 @@
 
 	if(istype(W, /obj/item/mmi))
 		var/obj/item/mmi/M = W
+		if (isshell(user) && istype(W, /obj/item/mmi/inert/ai_remote))
+			to_chat(user, span_warning("Your hardware prohibits you from self-replicating."))
+			return
 		if(check_completion())
 			if(!istype(loc,/turf))
 				to_chat(user, span_warning("You can't put \the [W] in, the frame has to be standing on the ground to be perfectly precise."))

--- a/code/global.dm
+++ b/code/global.dm
@@ -140,7 +140,7 @@ var/list/emergency_module_types = list(
 // List of modules available to AI shells
 var/list/shell_module_types = list(
 	"Standard", "Engineering", "Surgeon", "Crisis",
-	"Miner", "Janitor", "Service", "Clerical", "Security"
+	"Miner", "Janitor", "Service", "Clerical", "Security", "Research"
 )
 // List of whitelisted modules
 var/list/whitelisted_module_types = list(


### PR DESCRIPTION
I believe the staff conclusion was that we trust the playerbase to handle this short of the self-replication which was considered to be a rules trap, so this disables self-replication.