### PR TITLE
cut old overlays on paperstack

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -219,7 +219,7 @@
 /obj/item/paper_bundle/update_icon()
 	var/obj/item/paper/P = pages[1]
 	icon_state = P.icon_state
-	copy_overlays(P)
+	copy_overlays(P, TRUE)
 	underlays = 0
 	var/i = 0
 	var/photo


### PR DESCRIPTION
We copy overlays on every change of the stack but never cut them...

🆑 Upstream
fix: overlay overflow on paper stacks
/🆑 