### PR TITLE
forwards rejuvenate icon update call for simple mobs

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -98,6 +98,10 @@
 			add_eyes()
 	update_transform()
 
+/mob/living/simple_mob/regenerate_icons()
+	..()
+	update_icon()
+
 /mob/living/simple_mob/proc/will_eat(var/mob/living/M)
 	if(client) //You do this yourself, dick!
 		//ai_log("vr/wont eat [M] because we're player-controlled", 3) //VORESTATION AI TEMPORARY REMOVAL


### PR DESCRIPTION
🆑 Upstream
fix: modular mobs no longer keep their dead sprites on rejuvenate 
/🆑 

Rejuvenate uses regenerate_icons(), especially mobs like the big dragon need their icon updated after a rejuvenate not to stay a bone pile. In general an update_icon() call for simple_mobs shouldn't hurt on a revive, so forwarding it for them.