### PR TITLE
gunshot residue should only be on clothing/human

### DIFF
--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -79,8 +79,6 @@ var/global/list/obj/item/pda/PDAs = list()
 	var/list/notifying_programs = list()
 	var/retro_mode = 0
 
-	var/gunshot_residue // VOREstation edit: prevents wrist PDA from preventing gun use
-
 /obj/item/pda/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -87,6 +87,7 @@
 		var/mob/living/carbon/human/H = loc
 		if(istype(H))
 			if(!H.gloves)
+			if(!istype(H.gloves, /obj/item/clothing))
 				H.gunshot_residue = chambered.caliber
 			else
 				var/obj/item/clothing/G = H.gloves

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -86,7 +86,6 @@
 	if(chambered.leaves_residue)
 		var/mob/living/carbon/human/H = loc
 		if(istype(H))
-			if(!H.gloves)
 			if(!istype(H.gloves, /obj/item/clothing))
 				H.gunshot_residue = chambered.caliber
 			else


### PR DESCRIPTION
Up ports the fix to actually only apply the residue to clothes like gloves or hands from where it can be removed.

Downstream, remove the commented out vars