### PR TITLE
Remove traces of click to select port

### DIFF
--- a/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
+++ b/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
@@ -48,15 +48,18 @@ export class CircuitComponent extends Component<CircuitProps, CircuitState> {
   // THIS IS IMPORTANT:
   // This reduces the amount of unnecessary updates, which reduces the amount of work that has to be done
   // by the `Plane` component to keep track of where ports are located.
-  shouldComponentUpdate = (nextProps, nextState) => {
+  shouldComponentUpdate = (
+    nextProps: CircuitProps,
+    nextState: CircuitState,
+  ) => {
     const { inputs, outputs, activators } = this.props.circuit;
 
     return (
       shallowDiffers(this.props, nextProps) ||
       shallowDiffers(this.state, nextState) ||
-      shallowDiffers(inputs, nextProps.inputs) ||
-      shallowDiffers(outputs, nextProps.outputs) ||
-      shallowDiffers(activators, nextProps.activators)
+      shallowDiffers(inputs, nextProps.circuit.inputs) ||
+      shallowDiffers(outputs, nextProps.circuit.outputs) ||
+      shallowDiffers(activators, nextProps.circuit.activators)
     );
   };
 

--- a/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
+++ b/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
@@ -182,7 +182,17 @@ export class CircuitComponent extends Component<CircuitProps, CircuitState> {
                 compact
                 tooltip={
                   <Box>
-                    <Box mb={1}>{circuit.extended_desc}</Box>
+                    <Box mb={1}>
+                      {
+                        <div
+                          // All of the descriptions are pulled from the game files
+                          // eslint-disable-next-line react/no-danger
+                          dangerouslySetInnerHTML={{
+                            __html: circuit.extended_desc,
+                          }}
+                        />
+                      }
+                    </Box>
                     {!!circuit.power_draw_idle && (
                       <Box
                         backgroundColor="orange"

--- a/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
+++ b/tgui/packages/tgui/interfaces/ICAssembly/CircuitComponent.tsx
@@ -52,14 +52,14 @@ export class CircuitComponent extends Component<CircuitProps, CircuitState> {
     nextProps: CircuitProps,
     nextState: CircuitState,
   ) => {
-    const { inputs, outputs, activators } = this.props.circuit;
+    const { inputs = [], outputs = [], activators = [] } = this.props.circuit;
 
     return (
       shallowDiffers(this.props, nextProps) ||
       shallowDiffers(this.state, nextState) ||
-      shallowDiffers(inputs, nextProps.circuit.inputs) ||
-      shallowDiffers(outputs, nextProps.circuit.outputs) ||
-      shallowDiffers(activators, nextProps.circuit.activators)
+      shallowDiffers(inputs, nextProps.circuit.inputs!) ||
+      shallowDiffers(outputs, nextProps.circuit.outputs!) ||
+      shallowDiffers(activators, nextProps.circuit.activators!)
     );
   };
 
@@ -138,7 +138,7 @@ export class CircuitComponent extends Component<CircuitProps, CircuitState> {
       ...rest
     } = this.props;
 
-    const { name, ref, inputs, outputs, activators } = circuit;
+    const { name, ref, inputs = [], outputs = [], activators = [] } = circuit;
 
     const { startPos, dragPos } = this.state;
 

--- a/tgui/packages/tgui/interfaces/ICAssembly/Plane.tsx
+++ b/tgui/packages/tgui/interfaces/ICAssembly/Plane.tsx
@@ -182,8 +182,16 @@ export class Plane extends Component<PlaneProps, PlaneState> {
     for (const circuit of data.circuits) {
       if (circuit.inputs) {
         for (const input of circuit.inputs) {
-          for (const output of input.linked) {
+          connectionloop: for (const output of input.linked) {
             const output_port = locations[output.ref];
+            for (const connection of connections) {
+              if (
+                connection.from === locations[input.ref] &&
+                connection.to === output_port
+              ) {
+                continue connectionloop;
+              }
+            }
             connections.push({
               color: PortTypesToColor[decodeHtmlEntities(input.type)] || 'blue',
               from: output_port,
@@ -196,8 +204,16 @@ export class Plane extends Component<PlaneProps, PlaneState> {
         for (const activator of circuit.activators) {
           if (activator.rawdata) {
             // input
-            for (const output of activator.linked) {
+            connectionloop: for (const output of activator.linked) {
               const output_port = locations[output.ref];
+              for (const connection of connections) {
+                if (
+                  connection.from === locations[activator.ref] &&
+                  connection.to === output_port
+                ) {
+                  continue connectionloop;
+                }
+              }
               connections.push({
                 color:
                   PortTypesToColor[decodeHtmlEntities(activator.type)] ||

--- a/tgui/packages/tgui/interfaces/ICAssembly/Plane.tsx
+++ b/tgui/packages/tgui/interfaces/ICAssembly/Plane.tsx
@@ -180,27 +180,32 @@ export class Plane extends Component<PlaneProps, PlaneState> {
     const connections: Connection[] = [];
 
     for (const circuit of data.circuits) {
-      for (const input of circuit.inputs) {
-        for (const output of input.linked) {
-          const output_port = locations[output.ref];
-          connections.push({
-            color: PortTypesToColor[decodeHtmlEntities(input.type)] || 'blue',
-            from: output_port,
-            to: locations[input.ref],
-          });
-        }
-      }
-      for (const activator of circuit.activators) {
-        if (activator.rawdata) {
-          // input
-          for (const output of activator.linked) {
+      if (circuit.inputs) {
+        for (const input of circuit.inputs) {
+          for (const output of input.linked) {
             const output_port = locations[output.ref];
             connections.push({
-              color:
-                PortTypesToColor[decodeHtmlEntities(activator.type)] || 'blue',
-              to: output_port,
-              from: locations[activator.ref],
+              color: PortTypesToColor[decodeHtmlEntities(input.type)] || 'blue',
+              from: output_port,
+              to: locations[input.ref],
             });
+          }
+        }
+      }
+      if (circuit.activators) {
+        for (const activator of circuit.activators) {
+          if (activator.rawdata) {
+            // input
+            for (const output of activator.linked) {
+              const output_port = locations[output.ref];
+              connections.push({
+                color:
+                  PortTypesToColor[decodeHtmlEntities(activator.type)] ||
+                  'blue',
+                to: output_port,
+                from: locations[activator.ref],
+              });
+            }
           }
         }
       }

--- a/tgui/packages/tgui/interfaces/ICAssembly/types.ts
+++ b/tgui/packages/tgui/interfaces/ICAssembly/types.ts
@@ -18,9 +18,9 @@ export type CircuitData = {
   power_draw_idle: number;
   power_draw_per_use: number;
   extended_desc: string;
-  inputs: PortData[];
-  outputs: PortData[];
-  activators: PortData[];
+  inputs?: PortData[];
+  outputs?: PortData[];
+  activators?: PortData[];
 };
 
 export type PortData = {


### PR DESCRIPTION
Fixes #16447

:cl:
fix: Just clicking on a port will no longer crash the circuit UI
tweak: Removed broken click to connect ports, UI now expects you to always hold down the mouse button while connecting ports
/:cl: