### PR TITLE
Makes leporazine respect species body temp

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -1329,10 +1329,14 @@
 /datum/reagent/leporazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(M.bodytemperature > 310)
-		M.bodytemperature = max(310, M.bodytemperature - (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
-	else if(M.bodytemperature < 311)
-		M.bodytemperature = min(310, M.bodytemperature + (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
+	var/temp = 310
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		temp = H.species.body_temperature
+	if(M.bodytemperature > temp)
+		M.bodytemperature = max(temp, M.bodytemperature - (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
+	else if(M.bodytemperature < temp+1)
+		M.bodytemperature = min(temp, M.bodytemperature + (40 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
 /datum/reagent/rezadone
 	name = "Rezadone"


### PR DESCRIPTION
Leporazine now uses species body temp instead of the hard coded human value.

DOWNSTREAM CHANGELOG
🆑 
fix: leporazine now respects species body temperature
/:cl: