### PR TITLE
Adds forced eject verb to disposals

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -380,6 +380,15 @@
 // 	return
 
 // eject the contents of the disposal unit
+
+/obj/machinery/disposal/verb/force_eject()
+	set src in oview(1)
+	set category = "Object"
+	set name = "Force Eject"
+	if(flushing)
+		return
+	eject()
+
 /obj/machinery/disposal/proc/eject()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(src.loc)


### PR DESCRIPTION
Right click option to allow you to retrieve items from disposal units when lacking power.

DOWNSTREAM CHANGELOG
🆑 
qol: adds forced eject right-click verb to disposal units
/:cl: