### PR TITLE
Add button to access tank settings in RIGs

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_tgui.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_tgui.dm
@@ -167,3 +167,6 @@
 					if("select_charge_type")
 						module.charge_selected = params["charge_type"]
 						. = TRUE
+		if("tank_settings")
+			air_supply?.attack_self(usr)
+			. = TRUE

--- a/tgui/packages/tgui/interfaces/RIGSuit/RIGSuitStatus.tsx
+++ b/tgui/packages/tgui/interfaces/RIGSuit/RIGSuitStatus.tsx
@@ -28,47 +28,45 @@ export const RIGSuitStatus = (props) => {
     coverlock,
   } = data;
 
-  const SealButton = (
-    <Button
-      icon={sealing ? 'redo' : sealed ? 'power-off' : 'lock-open'}
-      iconSpin={sealing}
-      disabled={sealing}
-      selected={sealed}
-      onClick={() => act('toggle_seals')}
-    >
-      {'Suit ' +
-        (sealing ? 'seals working...' : sealed ? 'is Active' : 'is Inactive')}
-    </Button>
-  );
-
-  const CoolingButton = (
-    <Button
-      icon={'power-off'}
-      selected={cooling}
-      onClick={() => act('toggle_cooling')}
-    >
-      {'Suit Cooling ' + (cooling ? 'is Active' : 'is Inactive')}
-    </Button>
-  );
-
-  const AIButton = (
-    <Button
-      selected={aioverride}
-      icon="robot"
-      onClick={() => act('toggle_ai_control')}
-    >
-      {'AI Control ' + (aioverride ? 'Enabled' : 'Disabled')}
-    </Button>
-  );
-
   return (
     <Section
       title="Status"
       buttons={
         <>
-          {SealButton}
-          {AIButton}
-          {CoolingButton}
+          <Button
+            icon={sealing ? 'redo' : sealed ? 'power-off' : 'lock-open'}
+            iconSpin={sealing}
+            disabled={sealing}
+            selected={sealed}
+            onClick={() => act('toggle_seals')}
+          >
+            {'Suit ' +
+              (sealing
+                ? 'seals working...'
+                : sealed
+                  ? 'is Active'
+                  : 'is Inactive')}
+          </Button>
+          <Button
+            icon="robot"
+            selected={aioverride}
+            onClick={() => act('toggle_ai_control')}
+            tooltip={'AI Control ' + (aioverride ? 'Enabled' : 'Disabled')}
+            tooltipPosition="bottom-end"
+          />
+          <Button
+            icon="wind"
+            selected={cooling}
+            onClick={() => act('toggle_cooling')}
+            tooltip={'Suit Cooling ' + (cooling ? 'is Active' : 'is Inactive')}
+            tooltipPosition="bottom-end"
+          />
+          <Button
+            icon="lungs"
+            onClick={() => act('tank_settings')}
+            tooltip="Tank Settings"
+            tooltipPosition="bottom-end"
+          />
         </>
       }
     >


### PR DESCRIPTION
![https://i.tigercat2000.net/2024/10/dreamseeker_aZEdaINAB0.png](https://i.tigercat2000.net/2024/10/dreamseeker_aZEdaINAB0.png)

:cl:
add: You can now modify internal tank settings from the RIG UI.
tweak: RIG UI top buttons shifted about and minimized.
/:cl: