### PR TITLE
Mob-food vore fix

### DIFF
--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -96,6 +96,9 @@
 				if(!F.can_be_drop_prey || !F.food_vore)
 					continue
 
+				if(isanimal(M) && !F.allowmobvore && !M.ckey) //If the one doing the eating is a simple mob controlled by AI, check mob vore prefs
+					continue
+
 				var/do_nom = FALSE
 
 				if(!reagents.total_volume)


### PR DESCRIPTION
Fixed AI-controlled simple mobs being able to eat someone with mobvore disabled when in food via food vore.