### PR TITLE
Add support for deploying space helmets over top of other helmets

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -460,6 +460,7 @@
 
 	var/light_overlay = "helmet_light"
 	var/image/helmet_light
+	var/overhead = 0			//Used by spacesuit helmets
 
 	sprite_sheets = list(
 		SPECIES_TESHARI = 'icons/inventory/head/mob_teshari.dmi',

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -91,11 +91,11 @@
 			boots.canremove = FALSE
 
 	if(helmet)
-		if(H.head)
-			to_chat(M, "You are unable to deploy your suit's helmet as \the [H.head] is in the way.")
-		else if (H.equip_to_slot_if_possible(helmet, slot_head))
+		if(H.equip_to_slot_if_possible(helmet, slot_head))
 			to_chat(M, "Your suit's helmet deploys with a hiss.")
 			helmet.canremove = FALSE
+		else
+			to_chat(M, "You are unable to deploy your suit's helmet[H.head ? " because [H.head] is in the way." : ""].")
 
 	if(tank)
 		if(H.s_store) //In case someone finds a way.
@@ -190,13 +190,12 @@
 		helmet.forceMove(src)
 		playsound(src.loc, 'sound/machines/click2.ogg', 75, 1)
 	else
-		if(H.head)
-			to_chat(H, span_danger("You cannot deploy your helmet while wearing \the [H.head]."))
-			return
 		if(H.equip_to_slot_if_possible(helmet, slot_head))
 			helmet.canremove = FALSE
 			to_chat(H, span_info("You deploy your suit helmet, sealing you off from the world."))
 			playsound(src.loc, 'sound/machines/click2.ogg', 75, 1)
+		else
+			to_chat(H, span_danger("You cannot deploy your helmet[H.head ? " while wearing \the [H.head]." : ""]"))
 
 /obj/item/clothing/suit/space/void/AltClick(mob/living/user)
 	eject_tank()


### PR DESCRIPTION
![https://i.tigercat2000.net/2024/10/dreamseeker_jzR7dtCN24.gif](https://i.tigercat2000.net/2024/10/dreamseeker_jzR7dtCN24.gif)

Currently, spacesuit helmets can go over any other helmet or head clothing item except other spacesuit helmets. May need to tweak and do stuff like whatever helmets security wears? 

:cl:
add: You can now deploy hardsuit helms over top of your normal headwear, the same as magboots.
/:cl: