### PR TITLE
some fixes

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -365,6 +365,7 @@ GLOBAL_LIST_BOILERPLATE(allCasters, /obj/machinery/newscaster)
 		if(!viewing_channel.censored)
 			for(var/datum/feed_message/M in viewing_channel.messages)
 				var/list/msgdata = list(
+					"title" = M.title,
 					"body" = M.body,
 					"img" = null,
 					"type" = M.message_type,

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -650,8 +650,10 @@ var/list/global/slot_flags_enumeration = list(
 		return
 
 	//if we haven't made our blood_overlay already
-	if( !blood_overlay )
+	if(!blood_overlay)
 		generate_blood_overlay()
+	else
+		overlays.Remove(blood_overlay)
 
 	//Make the blood_overlay have the proper color then apply it.
 	blood_overlay.color = blood_color

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -75,7 +75,7 @@
 	var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
 	var/OX = M.getOxyLoss() > 50 	? 	span_bold("[M.getOxyLoss()]") 		: M.getOxyLoss()
 	var/TX = M.getToxLoss() > 50 	? 	span_bold("[M.getToxLoss()]")  		: M.getToxLoss()
-	var/BU = M.getFireLoss() > 50 	? 	span_bold("M.getFireLoss()]") 		: M.getFireLoss()
+	var/BU = M.getFireLoss() > 50 	? 	span_bold("[M.getFireLoss()]") 		: M.getFireLoss()
 	var/BR = M.getBruteLoss() > 50 	? 	span_bold("[M.getBruteLoss()]")  	: M.getBruteLoss()
 	var/analyzed_results = ""
 	if(M.status_flags & FAKEDEATH)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -559,9 +559,21 @@
 		return
 	busy = 0
 
-	user.clean_blood()
-	if(ishuman(user))
-		user:update_inv_gloves()
+	if(iscarbon(user))
+		var/mob/living/carbon/human/H = user
+		if(H.gloves)
+			H.gloves.clean_blood()
+			H.update_inv_gloves()
+			H.gloves.germ_level = 0
+		else
+			if(H.r_hand)
+				H.r_hand.clean_blood()
+			if(H.l_hand)
+				H.l_hand.clean_blood()
+			bloody_hands = 0
+			user.germ_level = 0
+	else
+		user.clean_blood()
 	for(var/mob/V in viewers(src, null))
 		V.show_message(span_notice("[user] washes their hands using \the [src]."))
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -559,8 +559,9 @@
 		return
 	busy = 0
 
-	if(iscarbon(user))
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
+		gunshot_residue = null
 		if(H.gloves)
 			H.gloves.clean_blood()
 			H.update_inv_gloves()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -570,8 +570,8 @@
 				H.r_hand.clean_blood()
 			if(H.l_hand)
 				H.l_hand.clean_blood()
-			bloody_hands = 0
-			user.germ_level = 0
+			H.bloody_hands = 0
+			H.germ_level = 0
 	else
 		user.clean_blood()
 	for(var/mob/V in viewers(src, null))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -561,7 +561,7 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		gunshot_residue = null
+		H.gunshot_residue = null
 		if(H.gloves)
 			H.gloves.clean_blood()
 			H.update_inv_gloves()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -212,16 +212,16 @@
 	var/slot_num
 	if(slot_start == 0)
 		slot_num = 1
-		slot_start = 2
 	else
 		slot_num = slot_start + 1
-
-	while(slot_start != slot_num) //If we wrap around without finding any free slots, just give up.
+		if(slot_num > 3)
+			return
+	// Attempt to rotate through the slots until we're past slot 3, or find the next usable slot. Allows skipping empty slots, while still having an empty slot at end of rotation.
+	while(slot_num <= 3)
 		if(module_active(slot_num))
 			select_module(slot_num)
 			return
 		slot_num++
-		if(slot_num > 3) slot_num = 1 //Wrap around.
 
 	return
 

--- a/tgui/packages/tgui/interfaces/Newscaster/NewscasterViewSelected.tsx
+++ b/tgui/packages/tgui/interfaces/Newscaster/NewscasterViewSelected.tsx
@@ -84,7 +84,8 @@ export const NewscasterViewSelected = (props: { setScreen: Function }) => {
       {(!!viewing_channel.messages.length &&
         viewing_channel.messages.map((message) => (
           <Section key={message.ref}>
-            - {decodeHtmlEntities(message.body)}
+            {message.title && decodeHtmlEntities(message.title) + ' - '}
+            {decodeHtmlEntities(message.body)}
             {!!message.img && (
               <Box>
                 <Image src={'data:image/png;base64,' + message.img} />

--- a/tgui/packages/tgui/interfaces/Newscaster/types.ts
+++ b/tgui/packages/tgui/interfaces/Newscaster/types.ts
@@ -31,6 +31,7 @@ export type Data = {
     author: string;
     censored: BooleanLike;
     messages: {
+      title: string | null;
       body: string;
       img: string | null;
       type: string;


### PR DESCRIPTION
Implements the option to show titles on the newscaster, following this https://github.com/Willburd/CHOMPost21/commit/f5df1a71ce9d4d3a1b85130f03c8491a07a19291

🆑 
add: titles to the shown messages in the newscaster
fix: blood overlay should no longer stack endlessly
fix: washing hands will no longer clean all bloodied items, instead only the worn gloves, or without gloves the hands
qol: robot hotkeys module swapping allows deselecting
/🆑 