### PR TITLE
Fix a small runtime in actions when dropping rigs

### DIFF
--- a/code/datums/observation/unequipped.dm
+++ b/code/datums/observation/unequipped.dm
@@ -35,7 +35,7 @@ GLOBAL_DATUM_INIT(item_unequipped_event, /decl/observ/item_unequipped, new)
 **********************/
 
 /obj/item/dropped(var/mob/user)
-	..()
+	. = ..(user)
 	//SEND_SIGNAL(user, COMSIG_OBSERVER_MOB_UNEQUIPPED, src)
 	//SEND_SIGNAL(src, COMSIG_OBSERVER_ITEM_UNEQUIPPED, user)
 	if(user) // Cannot always guarantee that user won't be null

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -785,7 +785,7 @@
 		toggle_piece(piece, H, ONLY_DEPLOY)
 
 /obj/item/rig/dropped(var/mob/user)
-	..()
+	. = ..(user)
 	for(var/piece in list("helmet","gauntlets","chest","boots"))
 		toggle_piece(piece, user, ONLY_RETRACT)
 	if(wearer && wearer.wearing_rig == src)

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -349,7 +349,7 @@
 	var/obj/item/rig_module/gauntlets/storing_module
 
 /obj/item/kinetic_crusher/machete/gauntlets/rig/dropped(mob/user)
-	. = ..()
+	. = ..(user)
 	if(storing_module)
 		src.forceMove(storing_module)
 		storing_module.stored_gauntlets = src

--- a/code/modules/organs/internal/augment.dm
+++ b/code/modules/organs/internal/augment.dm
@@ -88,7 +88,7 @@
 	var/obj/item/organ/my_augment = null	// Used to reference the object's host organ.
 
 /obj/item/dropped(mob/user)
-	. = ..()
+	. = ..(user)
 	if(src)
 		if(destroy_on_drop && !QDELETED(src))
 			qdel(src)


### PR DESCRIPTION
:cl:
fix: Runtime in rig/dropped
/:cl: