### PR TITLE
Ports grindable ores

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -41,6 +41,7 @@
 #define CE_DARKSIGHT "darksight" // Gives perfect vision in dark
 
 #define REAGENTS_PER_SHEET 20
+#define REAGENTS_PER_ORE 20
 
 // Attached to CE_ANTIBIOTIC
 #define ANTIBIO_NORM	1

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -141,7 +141,7 @@
 		to_chat(user, span_notice("\the [src] is too full to possibly fit anything else inside of it."))
 		return
 
-	if (istype(W, /obj/item/ore))
+	if (istype(W, /obj/item/ore) && !istype(W, /obj/item/ore/slag))
 		var/obj/item/ore/ore = W
 		stored_ore[ore.material]++
 		current_capacity++
@@ -178,6 +178,8 @@
 		if(current_pickup >= max_pickup)
 			max_pickup_reached = 1
 			break
+		if(istype(O, /obj/item/ore/slag))
+			continue
 		var/obj/item/ore/ore = O
 		stored_ore[ore.material]++
 		current_capacity++

--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -1,3 +1,55 @@
+// Don't need a new list for every grinder in the game
+var/global/list/sheet_reagents = list( //have a number of reagents divisible by REAGENTS_PER_SHEET (default 20) unless you like decimals.
+	/obj/item/stack/material/plastic = list("carbon","carbon","oxygen","chlorine","sulfur"),
+	/obj/item/stack/material/copper = list("copper"),
+	/obj/item/stack/material/wood = list("carbon","woodpulp","nitrogen","potassium","sodium"),
+	/obj/item/stack/material/stick = list("carbon","woodpulp","nitrogen","potassium","sodium"),
+	/obj/item/stack/material/log = list("carbon","woodpulp","nitrogen","potassium","sodium"),
+	/obj/item/stack/material/algae = list("carbon","nitrogen","nitrogen","phosphorus","phosphorus"),
+	/obj/item/stack/material/graphite = list("carbon"),
+	/obj/item/stack/material/aluminium = list("aluminum"), // The material is aluminium, but the reagent is aluminum...
+	/obj/item/stack/material/glass/reinforced = list("silicon","silicon","silicon","iron","carbon"),
+	/obj/item/stack/material/leather = list("carbon","carbon","protein","protein","triglyceride"),
+	/obj/item/stack/material/cloth = list("carbon","carbon","carbon","protein","sodium"),
+	/obj/item/stack/material/fiber = list("carbon","carbon","carbon","protein","sodium"),
+	/obj/item/stack/material/fur = list("carbon","carbon","carbon","sulfur","sodium"),
+	/obj/item/stack/material/deuterium = list("hydrogen"),
+	/obj/item/stack/material/glass/phoronrglass = list("silicon","silicon","silicon","phoron","phoron"),
+	/obj/item/stack/material/diamond = list("carbon"),
+	/obj/item/stack/material/durasteel = list("iron","iron","carbon","carbon","platinum"),
+	/obj/item/stack/material/wax = list("ethanol","triglyceride"),
+	/obj/item/stack/material/iron = list("iron"),
+	/obj/item/stack/material/uranium = list("uranium"),
+	/obj/item/stack/material/phoron = list("phoron"),
+	/obj/item/stack/material/gold = list("gold"),
+	/obj/item/stack/material/silver = list("silver"),
+	/obj/item/stack/material/platinum = list("platinum"),
+	/obj/item/stack/material/mhydrogen = list("hydrogen"),
+	/obj/item/stack/material/steel = list("iron", "carbon"),
+	/obj/item/stack/material/plasteel = list("iron", "iron", "carbon", "carbon", "platinum"), //8 iron, 8 carbon, 4 platinum,
+	/obj/item/stack/material/snow = list("water"),
+	/obj/item/stack/material/sandstone = list("silicon", "oxygen"),
+	/obj/item/stack/material/glass = list("silicon"),
+	/obj/item/stack/material/glass/phoronglass = list("platinum", "silicon", "silicon", "silicon"), //5 platinum, 15 silicon,
+	/obj/item/stack/material/supermatter = list("supermatter")
+	)
+var/global/list/ore_reagents = list( //have a number of reageents divisible by REAGENTS_PER_ORE (default 20) unless you like decimals.
+	/obj/item/ore/glass = list("silicon"),
+	/obj/item/ore/iron = list("iron"),
+	/obj/item/ore/coal = list("carbon"),
+	/obj/item/ore/phoron = list("phoron"),
+	/obj/item/ore/silver = list("silver"),
+	/obj/item/ore/gold = list("gold"),
+	/obj/item/ore/marble = list("silicon","aluminum","aluminum","sodium","calcium"), // Some nice variety here
+	/obj/item/ore/uranium = list("uranium"),
+	/obj/item/ore/diamond = list("carbon"),
+	/obj/item/ore/osmium = list("platinum"), // should contain osmium
+	/obj/item/ore/lead = list("lead"),
+	/obj/item/ore/hydrogen = list("hydrogen"),
+	/obj/item/ore/verdantium = list("radium","phoron","nitrogen","phosphorus","sodium"), // Some fun stuff to be useful with
+	/obj/item/ore/rutile = list("tungsten","oxygen") // Should be titanium
+)
+
 /obj/machinery/reagentgrinder
 
 	name = "All-In-One Grinder"
@@ -14,22 +66,6 @@
 	var/obj/item/reagent_containers/beaker = null
 	var/limit = 10
 	var/list/holdingitems = list()
-	var/list/sheet_reagents = list( //have a number of reageents divisible by REAGENTS_PER_SHEET (default 20) unless you like decimals,
-		/obj/item/stack/material/iron = list("iron"),
-		/obj/item/stack/material/uranium = list("uranium"),
-		/obj/item/stack/material/phoron = list("phoron"),
-		/obj/item/stack/material/gold = list("gold"),
-		/obj/item/stack/material/silver = list("silver"),
-		/obj/item/stack/material/platinum = list("platinum"),
-		/obj/item/stack/material/mhydrogen = list("hydrogen"),
-		/obj/item/stack/material/steel = list("iron", "carbon"),
-		/obj/item/stack/material/plasteel = list("iron", "iron", "carbon", "carbon", "platinum"), //8 iron, 8 carbon, 4 platinum,
-		/obj/item/stack/material/snow = list("water"),
-		/obj/item/stack/material/sandstone = list("silicon", "oxygen"),
-		/obj/item/stack/material/glass = list("silicon"),
-		/obj/item/stack/material/glass/phoronglass = list("platinum", "silicon", "silicon", "silicon"), //5 platinum, 15 silicon,
-		/obj/item/stack/material/supermatter = list("supermatter")
-		)
 
 	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")
 	var/static/radial_eject = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_eject")
@@ -137,7 +173,7 @@
 
 		return 0
 
-	if(!sheet_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
+	if(!global.sheet_reagents[O.type] && !global.ore_reagents[O.type] && (!O.reagents || !O.reagents.total_volume))
 		to_chat(user, "\The [O] is not suitable for blending.")
 		return 1
 
@@ -228,10 +264,10 @@
 		if(remaining_volume <= 0)
 			break
 
-		if(sheet_reagents[O.type])
+		if(global.sheet_reagents[O.type])
 			var/obj/item/stack/stack = O
 			if(istype(stack))
-				var/list/sheet_components = sheet_reagents[stack.type]
+				var/list/sheet_components = global.sheet_reagents[stack.type]
 				var/amount_to_take = max(0,min(stack.get_amount(),round(remaining_volume/REAGENTS_PER_SHEET)))
 				if(amount_to_take)
 					stack.use(amount_to_take)
@@ -243,6 +279,21 @@
 							beaker.reagents.add_reagent(i, (amount_to_take*REAGENTS_PER_SHEET))
 					else
 						beaker.reagents.add_reagent(sheet_components, (amount_to_take*REAGENTS_PER_SHEET))
+					continue
+
+		if(global.ore_reagents[O.type])
+			var/obj/item/ore/R = O
+			if(istype(R))
+				var/list/ore_components = global.ore_reagents[R.type]
+				if(remaining_volume >= REAGENTS_PER_ORE)
+					holdingitems -= R
+					qdel(R)
+					if(islist(ore_components))
+						var/amount_to_take = (REAGENTS_PER_ORE/(ore_components.len))
+						for(var/i in ore_components)
+							beaker.reagents.add_reagent(i, amount_to_take)
+					else
+						beaker.reagents.add_reagent(ore_components, REAGENTS_PER_ORE)
 					continue
 
 		if(O.reagents)


### PR DESCRIPTION
-Ports grinding ores for reagents
-Adds more stack materials to the grindable list
-Changed grindables list to a global list
-Blacklists slag from the ore satchel

DOWNSTREAM CHANGELOG
🆑 
add: ores are now grindable
add: many more materials are now grindable
refactor: moves grindable materials to a global list
qol: blacklists slag from the ore satchel
/:cl: