### PR TITLE
Disallows buckled mobs in sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -459,6 +459,8 @@
 		return
 	if(stat & (BROKEN|NOPOWER))
 		return
+	if(M.buckled)
+		return
 	if(occupant)
 		to_chat(user, span_warning("\The [src] is already occupied."))
 		return
@@ -471,6 +473,8 @@
 		visible_message("\The [user] starts putting [M] into \the [src].")
 
 	if(do_after(user, 20))
+		if(M.buckled)
+			return
 		if(occupant)
 			to_chat(user, span_warning("\The [src] is already occupied."))
 			return


### PR DESCRIPTION
Prevents you from placing buckled mobs in sleepers, so your roller bed doesn't drag the patient out of life-saving stasis.

DOWNSTREAM CHANGELOG
🆑 
fix: disallows buckled mobs in sleepers
/:cl: