### PR TITLE
Fixes fluid pump

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/fluidpump.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/fluidpump.dm
@@ -10,5 +10,6 @@
 	origin_tech = list(TECH_DATA = 1)
 	req_components = list(
 							/obj/item/stock_parts/matter_bin = 2,
+							/obj/item/cell = 1,
 							/obj/item/stock_parts/motor = 2,
 							/obj/item/stock_parts/manipulator = 1)


### PR DESCRIPTION
Ports outpost21 fixes and nerfs to the fluid pump. The fluid pump functions now while generated reagent rate has been drastically reduced.

DOWNSTREAM CHANGELOG
🆑 
fix: makes the fluid pump functional
balance: reduces fluid pump reagent generation rate
/:cl: