### PR TITLE
Item TF smite

### DIFF
--- a/code/modules/admin/player_effects.dm
+++ b/code/modules/admin/player_effects.dm
@@ -339,6 +339,32 @@
 				M.forceMove(new_mob)
 				new_mob.tf_mob_holder = M
 
+		if("item_tf")
+			var/mob/living/M = target
+
+			if(!istype(M))
+				return
+
+			if(!M.ckey)
+				return
+
+			var/obj/item/spawning = user.client.get_path_from_partial_text()
+
+			to_chat(user,span_warning("spawning is: [spawning]"))
+
+			if(!ispath(spawning, /obj/item/))
+				to_chat(user,span_warning("Can only spawn items."))
+				return
+
+			var/obj/item/spawned_obj = new spawning(M.loc)
+			var/obj/item/original_name = spawned_obj.name
+			spawned_obj.inhabit_item(M, original_name, M)
+			var/mob/living/possessed_voice = spawned_obj.possessed_voice
+			spawned_obj.trash_eatable = M.devourable
+			spawned_obj.unacidable = !M.digestable
+			M.forceMove(possessed_voice)
+
+
 		////////MEDICAL//////////////
 
 		if("appendicitis")

--- a/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlSmites.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlSmites.tsx
@@ -66,6 +66,9 @@ export const ControlSmites = (props) => {
       <Button fluid onClick={() => act('mob_tf')}>
         Mob Transformation
       </Button>
+      <Button fluid onClick={() => act('item_tf')}>
+        Object Transformation
+      </Button>
     </Section>
   );
 };


### PR DESCRIPTION
Added a new admin smite to the player effects panel: Item Transformation. This allows the admin to pick an object to transform the player into. They can transform back using OOC Escape.