### PR TITLE
Revert "Add support for deploying space helmets over top of other helmets"

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -460,7 +460,6 @@
 
 	var/light_overlay = "helmet_light"
 	var/image/helmet_light
-	var/overhead = 0			//Used by spacesuit helmets
 
 	sprite_sheets = list(
 		SPECIES_TESHARI = 'icons/inventory/head/mob_teshari.dmi',

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -16,7 +16,6 @@
 	ear_protection = 1
 	drop_sound = 'sound/items/drop/helm.ogg'
 	pickup_sound = 'sound/items/pickup/helm.ogg'
-	overhead = TRUE
 
 /obj/item/clothing/head/helmet/solgov
 	name = "\improper Solar Confederate Government helmet"

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -31,44 +31,6 @@
 	light_overlay = "helmet_light"
 	light_range = 4
 
-	overhead = TRUE // prevents stacking helmets indefinitely
-	var/obj/item/clothing/head/stored_under_head = null // under head
-	var/mob/living/carbon/human/wearer = null	// Used to restore our under when we're dropped
-
-/obj/item/clothing/head/helmet/space/mob_can_equip(mob/user, slot, disable_warning = FALSE)
-	var/mob/living/carbon/human/H = user
-	if(H.head)
-		stored_under_head = H.head
-		if(!istype(stored_under_head))
-			to_chat(user, "You are unable to wear \the [src] as \the [H.head] is in the way.")
-			stored_under_head = null
-			return 0
-		if(stored_under_head.overhead)
-			to_chat(user, "You are unable to wear \the [src] as \the [H.head] is in the way.")
-			stored_under_head = null
-			return 0
-		H.drop_from_inventory(stored_under_head)
-		stored_under_head.forceMove(src)
-
-	if(!..())
-		if(stored_under_head)
-			if(H.equip_to_slot_if_possible(stored_under_head, slot_head))
-				stored_under_head = null
-			return 0
-	if(stored_under_head)
-		to_chat(user, "You slip \the [src] on over \the [stored_under_head].")
-	wearer = H
-	return 1
-
-/obj/item/clothing/head/helmet/space/dropped()
-	..()
-	var/mob/living/carbon/human/H = wearer
-	if(stored_under_head)
-		if(!H.equip_to_slot_if_possible(stored_under_head, slot_head))
-			stored_under_head.forceMove(get_turf(src))
-		src.stored_under_head = null
-	wearer = null
-
 /obj/item/clothing/head/helmet/space/Initialize()
 	. = ..()
 	if(camera_networks)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -91,11 +91,11 @@
 			boots.canremove = FALSE
 
 	if(helmet)
-		if(H.equip_to_slot_if_possible(helmet, slot_head))
+		if(H.head)
+			to_chat(M, "You are unable to deploy your suit's helmet as \the [H.head] is in the way.")
+		else if (H.equip_to_slot_if_possible(helmet, slot_head))
 			to_chat(M, "Your suit's helmet deploys with a hiss.")
 			helmet.canremove = FALSE
-		else
-			to_chat(M, "You are unable to deploy your suit's helmet[H.head ? " because [H.head] is in the way." : ""].")
 
 	if(tank)
 		if(H.s_store) //In case someone finds a way.
@@ -190,12 +190,13 @@
 		helmet.forceMove(src)
 		playsound(src.loc, 'sound/machines/click2.ogg', 75, 1)
 	else
+		if(H.head)
+			to_chat(H, span_danger("You cannot deploy your helmet while wearing \the [H.head]."))
+			return
 		if(H.equip_to_slot_if_possible(helmet, slot_head))
 			helmet.canremove = FALSE
 			to_chat(H, span_info("You deploy your suit helmet, sealing you off from the world."))
 			playsound(src.loc, 'sound/machines/click2.ogg', 75, 1)
-		else
-			to_chat(H, span_danger("You cannot deploy your helmet[H.head ? " while wearing \the [H.head]." : ""]"))
 
 /obj/item/clothing/suit/space/void/AltClick(mob/living/user)
 	eject_tank()


### PR DESCRIPTION
This reverts #16475

Something's horribly broken about this and I can't figure out why, the whole system for this is just really cursed 

:cl:
del: You can no longer deploy space helmets over other helmets, it was very very broken
/:cl: