### PR TITLE
Water Cooler Tweaks

### DIFF
--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -340,7 +340,7 @@
 /obj/structure/reagent_dispensers/water_cooler/Initialize()
 	. = ..()
 	if(bottle)
-		reagents.add_reagent("water",120)
+		reagents.add_reagent("water",2000)
 	update_icon()
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -399,11 +399,18 @@
 	name = "water-cooler bottle"
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "water_cooler_bottle"
-	matter = list(MAT_GLASS = 2000)
-	w_class = ITEMSIZE_NORMAL
+	matter = list(MAT_PLASTIC = 2000)
+	w_class = ITEMSIZE_NO_CONTAINER
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = list(10,20,30,60,120)
-	volume = 120
+	volume = 2000
+	slowdown = 2
+
+	can_be_placed_into = list(
+		/obj/structure/table,
+		/obj/structure/closet,
+		/obj/structure/sink
+		)
 
 /obj/item/reagent_containers/glass/pint_mug
 	desc = "A rustic pint mug designed for drinking ale."


### PR DESCRIPTION
What kind of _shitty-ass_ water cooler only holds a single pint and is made out of glass? I'm firing whoever ordered those bottles out of a goddamn airlock. The paper cups hold 10u of water, so you could drain a water cooler in just 6 cups!

Now they have a realistic(ish) water amount and are made out of plastic. The tradeoff? You can't put them in any kind of bag (because, you know, they're huge) and they incur a pretty nasty slowdown. They can only be put on tables, closets, and into sinks.

:cl:
tweak: fixed water cooler bottles being terrible and bad (they're now made out of plastic and hold a lot more water)
/:cl: