### PR TITLE
fix regeneration multipliers

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -12,10 +12,12 @@
 /datum/config_entry/flag/limbs_can_break
 
 /datum/config_entry/number/organ_health_multiplier
-	default = 1
+	integer = FALSE
+	default = 1.0
 
 /datum/config_entry/number/organ_regeneration_multiplier
-	default = 1
+	integer = FALSE
+	default = 1.0
 
 // FIXME: Unused
 ///datum/config_entry/flag/revival_pod_plants

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -18,12 +18,12 @@ BONES_CAN_BREAK 1
 LIMBS_CAN_BREAK 1
 
 ## multiplier which enables organs to take more damage before bones breaking or limbs being destroyed
-## 100 means normal, 50 means half
-ORGAN_HEALTH_MULTIPLIER 100
+## 1.0 means normal, 0.5 means half
+ORGAN_HEALTH_MULTIPLIER 1.0
 
 ## multiplier which influences how fast organs regenerate naturally
-## 100 means normal, 50 means half
-ORGAN_REGENERATION_MULTIPLIER 50
+## 1.0 means normal, 0.5 means half
+ORGAN_REGENERATION_MULTIPLIER 0.5
 
 ### REVIVAL ###
 


### PR DESCRIPTION
🆑 
fix: fixes regeneration multipliers
/🆑 

That must have been an oversight on the config controller change. Those entries are not like in the old one divided by 100. You'll need to adjust your config server side to bring healing back to where it should be. I sadly can't help there.