### PR TITLE
Virology Patch 1

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -112,6 +112,10 @@ var/global/list/image/splatter_cache=list()
 		var/obj/structure/bed/chair/wheelchair/W = perp.buckled
 		W.bloodiness = 4
 
+	if(viruses)
+		for(var/datum/disease/D in viruses)
+			perp.ContractDisease(D)
+
 	amount--
 
 /obj/effect/decal/cleanable/blood/proc/dry()
@@ -124,6 +128,11 @@ var/global/list/image/splatter_cache=list()
 	..()
 	if (amount && istype(user))
 		add_fingerprint(user)
+
+		if(viruses)
+			for(var/datum/disease/D in viruses)
+				user.ContractDisease(D)
+
 		if (user.gloves)
 			return
 		var/taken = rand(1,amount)
@@ -257,5 +266,15 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/mucus/mapped/Destroy()
 	viruses.Cut()
 	return ..()
+
+/obj/effect/decal/cleanable/mucus/Crossed(mob/living/carbon/human/perp)
+	if(viruses)
+		for(var/datum/disease/D in viruses)
+			perp.ContractDisease(D)
+
+/obj/effect/decal/cleanable/vomit/Crossed(mob/living/carbon/human/perp)
+	if(viruses)
+		for(var/datum/disease/D in viruses)
+			perp.ContractDisease(D)
 
 #undef DRYING_TIME

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -248,7 +248,7 @@
 				else
 					dat += span_warning("Unknown substance[(unknown > 1)?"s":""] found in subject's dermis.")
 					dat += "<br>"
-		if(C.resistances.len)
+		if(C.resistances)
 			for (var/datum/disease/virus in C.GetViruses())
 				if(virus.visibility_flags & HIDDEN_SCANNER || virus.visibility_flags & HIDDEN_PANDEMIC)
 					continue

--- a/code/modules/reagents/reagents/virology.dm
+++ b/code/modules/reagents/reagents/virology.dm
@@ -20,7 +20,7 @@
 /datum/reagent/mutagen/mutagenvirusfood
 	name = "Mutagenic agar"
 	id = "mutagenvirusfood"
-	description = "mutates blood"
+	description = "Mutates viruses when mixed in blood. This one seems rather alright."
 	color = "#A3C00F"
 
 /datum/reagent/mutagen/mutagenvirusfood/sugar
@@ -32,16 +32,16 @@
 /datum/reagent/medicine/adranol/adranolvirusfood
 	name = "Virus rations"
 	id = "adranolvirusfood"
-	description = "mutates blood"
+	description = "Mutates viruses when mixed in blood. This one seems rather weak."
 	color = "#D18AA5"
 
-/datum/reagent/phoron_dust/phoronvirusfood
+/datum/reagent/toxin/phoron/phoronvirusfood
 	name = "Phoronic virus food"
 	id = "phoronvirusfood"
-	description = "mutates blood"
+	description = "Mutates viruses when mixed in blood. This one seems to be the strongest."
 	color = "#A69DA9"
 
-/datum/reagent/phoron_dust/phoronvirusfood/weak
-	name = "Weakened phoronic virus food"
+/datum/reagent/toxin/phoron/phoronvirusfood/weak
+	name = "Weakened phoronic virus food. This one seems to have been weakened, but still strong."
 	id = "weakphoronvirusfood"
 	color = "#CEC3C6"


### PR DESCRIPTION
First of whoever knows how many of these. I broke health analyzers as well, whoops.

🆑
qol: Interacting with contaminated decals infects you with viruses.
qol: The description of the virology chemicals is a bit more clear when checked.
fix: Fixes a runtime regarding health analyzers
fix: Fixes virology phoronic chemicals not being a phoron subtype
/:cl: