### PR TITLE
Fixes non-contagious diseases not transferring on blood

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -250,7 +250,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		B.data["viruses"] = list()
 
 	for(var/datum/disease/D in GetViruses())
-		if(D.spread_flags & SPECIAL || D.spread_flags & NON_CONTAGIOUS)
+		if(D.spread_flags & SPECIAL)
 			continue
 		B.data["viruses"] |= D.Copy()
 


### PR DESCRIPTION
This made Food Poisoning invisible until the symptoms showed up, oops. Don't eat the weird old food please.

🆑
fix: Fixed non-contagious diseases not being placed in extracted blood
/:cl: