### PR TITLE
Fixes recursive_content_check

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -172,7 +172,7 @@
 
 		if(ismob(I))
 			if(!sight_check || isInSight(I, O))
-				L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
+				L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects, ignore_show_messages)
 				if(include_mobs)
 					if(client_check)
 						var/mob/M = I
@@ -185,7 +185,7 @@
 			var/obj/check_obj = I
 			if(ignore_show_messages || check_obj.show_messages)
 				if(!sight_check || isInSight(I, O))
-					L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects)
+					L |= recursive_content_check(I, L, recursion_limit - 1, client_check, sight_check, include_mobs, include_objects, ignore_show_messages)
 					if(include_objects)
 						L |= I
 


### PR DESCRIPTION
Adds missing argument to recursive_content_check() so it no longer skips objects without show_messages = TRUE.

DOWNSTREAM CHANGELOG
:cl:
fix: adds missing arguments to recursive_content_check()
/:cl: