### PR TITLE
Add Engineering Drake to plushies crate

### DIFF
--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -80,6 +80,7 @@
 			/obj/item/toy/plushie/slimeplushie,
 			/obj/item/toy/plushie/box,
 			/obj/item/toy/plushie/borgplushie,
+			/obj/item/toy/plushie/borgplushie/drake/eng,
 			/obj/item/toy/plushie/borgplushie/medihound,
 			/obj/item/toy/plushie/borgplushie/scrubpuppy,
 			/obj/item/toy/plushie/foxbear,


### PR DESCRIPTION
I figure the drake's iconic enough to include in the plushie pool. (I would also like it added for an RP reason.)
🆑
tweak: added the engineering drake borg plushie to cargo's random plushie crate contents
/:cl: