### PR TITLE
Potential partial revert to borg self-upgrading restrictions

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -707,8 +707,6 @@
 				update_icon()
 			else
 				to_chat(user, span_filter_notice("[span_red("Access denied.")]"))
-				if(user == src) //RS edit: No self-unlocking.
-					to_chat(user, span_filter_notice("You are not allowed to manipulate your own lock."))
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
@@ -716,8 +714,8 @@
 			to_chat(usr, span_filter_notice("You must access the borgs internals!"))
 		else if(!src.module && U.require_module)
 			to_chat(usr, span_filter_notice("The borg must choose a module before it can be upgraded!"))
-		else if(user == src) //RS edit: No self-upgrading.
-			to_chat(usr, span_warning("You lack the reach to be able to upgrade yourself."))
+		else if(user == src && istype(W,/obj/item/borg/upgrade/utility/reset))
+			to_chat(usr, span_warning("You are restricted from reseting your own module."))
 		else if(U.locked)
 			to_chat(usr, span_filter_notice("The upgrade is locked and cannot be used yet!"))
 		else
@@ -878,10 +876,7 @@
 	else if(istype(M, /mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = M
 		if(check_access(R.get_active_hand()) || istype(R.get_active_hand(), /obj/item/card/robot))
-			if(R == src) //RS edit: No self-unlocking.
-				return FALSE
-			else
-				return TRUE
+			return TRUE
 	return 0
 
 /mob/living/silicon/robot/proc/check_access(obj/item/I)


### PR DESCRIPTION
Pending staff discussion.

This reverts the restriction of the borgs from upgrading themselves, for the most part. However, it keeps in place a restriction from them resetting their own module.