### PR TITLE
Restricted aghosting and detailed advanced who to staff

### DIFF
--- a/code/modules/client/verbs/advanced_who.dm
+++ b/code/modules/client/verbs/advanced_who.dm
@@ -7,7 +7,7 @@
 
 	var/list/Lines = list()
 
-	if(holder)
+	if(check_rights(R_ADMIN|R_SERVER|R_MOD,FALSE,src))
 		for(var/client/C in GLOB.clients)
 			var/entry = "<tr><td>[C.key]"
 			if(C.holder && C.holder.fakekey)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -223,7 +223,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		announce_ghost_joinleave(ghostize(1))
 	else
 		var/response
-		if(src.client && src.client.holder)
+		if(check_rights(R_ADMIN|R_SERVER|R_MOD,FALSE,src)) //No need to sanity check for client and holder here as that is part of check_rights
 			response = tgui_alert(src, "You have the ability to Admin-Ghost. The regular Ghost verb will announce your presence to dead chat. Both variants will allow you to return to your body using 'aghost'.\n\nWhat do you wish to do?", "Are you sure you want to ghost?", list("Admin Ghost", "Ghost", "Stay in body"))
 			if(response == "Admin Ghost")
 				if(!src.client)


### PR DESCRIPTION
Fixed the ghost verb so that it no longer gives the option to aghost to non-staff in some circumstances.

Fixed the advanced who verb so that it no longer gives the admin version of the verb to non-staff in some circumstances.