### PR TITLE
Add opt-out stat tracking to vore

### DIFF
--- a/code/modules/client/preferences/types/misc.dm
+++ b/code/modules/client/preferences/types/misc.dm
@@ -93,3 +93,9 @@
 		winset(client, null, "browser-options=[DEFAULT_CLIENT_BROWSER_OPTIONS],devtools")
 	else
 		winset(client, null, "browser-options=[DEFAULT_CLIENT_BROWSER_OPTIONS]")
+
+/datum/preference/toggle/vore_stats
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "EnableVoreStats"
+	default_value = TRUE
+	savefile_identifier = PREFERENCE_PLAYER

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -560,6 +560,10 @@
 		var/mob/ourmob = M
 		ourmob.reset_view(null)
 
+		if(ourmob.ckey)
+			ourmob.client?.stats_vr?.tick_counter("stats_times_released")
+			owner.client?.stats_vr?.tick_counter("stats_released_prey")
+
 	if(!owner.ckey && escape_stun)
 		owner.Weaken(escape_stun)
 
@@ -586,6 +590,9 @@
 		M.updateVRPanel()
 
 	if(prey.ckey)
+		prey.client?.stats_vr?.tick_counter("stats_times_eaten")
+		owner.client?.stats_vr?.tick_counter("stats_eaten_prey")
+
 		GLOB.prey_eaten_roundstat++
 		if(owner.mind)
 			owner.mind.vore_prey_eaten++
@@ -597,6 +604,11 @@
 /obj/belly/proc/digestion_death(mob/living/M)
 	digested_prey_count++
 	add_attack_logs(owner, M, "Digested in [lowertext(name)]")
+
+	// Stats
+	if(M.ckey)
+		M.client?.stats_vr?.tick_counter("stats_times_digested")
+		owner.client?.stats_vr?.tick_counter("stats_digested_prey")
 
 	// If digested prey is also a pred... anyone inside their bellies gets moved up.
 	if(is_vore_predator(M))
@@ -647,6 +659,9 @@
 	if(M.ckey)
 		handle_absorb_langs(M, owner)
 		GLOB.prey_absorbed_roundstat++
+
+		M.client?.stats_vr?.tick_counter("stats_times_absorbed")
+		owner.client?.stats_vr?.tick_counter("stats_absorbed_prey")
 
 	to_chat(M, span_vnotice("[belly_format_string(absorb_messages_prey, M, use_absorbed_count = TRUE)]"))
 	to_chat(owner, span_vnotice("[belly_format_string(absorb_messages_owner, M, use_absorbed_count = TRUE)]"))

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -561,8 +561,8 @@
 		ourmob.reset_view(null)
 
 		if(ourmob.ckey)
-			ourmob.client?.stats_vr?.tick_counter("stats_times_released")
-			owner.client?.stats_vr?.tick_counter("stats_released_prey")
+			ourmob.client?.stats_vr?.tick_counter("stats_times_released", owner.read_preference(/datum/preference/toggle/vore_stats) || !owner.ckey)
+			owner.client?.stats_vr?.tick_counter("stats_released_prey", ourmob.read_preference(/datum/preference/toggle/vore_stats))
 
 	if(!owner.ckey && escape_stun)
 		owner.Weaken(escape_stun)
@@ -590,8 +590,8 @@
 		M.updateVRPanel()
 
 	if(prey.ckey)
-		prey.client?.stats_vr?.tick_counter("stats_times_eaten")
-		owner.client?.stats_vr?.tick_counter("stats_eaten_prey")
+		prey.client?.stats_vr?.tick_counter("stats_times_eaten", owner.read_preference(/datum/preference/toggle/vore_stats) || !owner.ckey)
+		owner.client?.stats_vr?.tick_counter("stats_eaten_prey", prey.read_preference(/datum/preference/toggle/vore_stats))
 
 		GLOB.prey_eaten_roundstat++
 		if(owner.mind)
@@ -607,8 +607,8 @@
 
 	// Stats
 	if(M.ckey)
-		M.client?.stats_vr?.tick_counter("stats_times_digested")
-		owner.client?.stats_vr?.tick_counter("stats_digested_prey")
+		M.client?.stats_vr?.tick_counter("stats_times_digested", owner.read_preference(/datum/preference/toggle/vore_stats) || !owner.ckey)
+		owner.client?.stats_vr?.tick_counter("stats_digested_prey", M.read_preference(/datum/preference/toggle/vore_stats))
 
 	// If digested prey is also a pred... anyone inside their bellies gets moved up.
 	if(is_vore_predator(M))
@@ -660,8 +660,8 @@
 		handle_absorb_langs(M, owner)
 		GLOB.prey_absorbed_roundstat++
 
-		M.client?.stats_vr?.tick_counter("stats_times_absorbed")
-		owner.client?.stats_vr?.tick_counter("stats_absorbed_prey")
+		M.client?.stats_vr?.tick_counter("stats_times_absorbed", owner.read_preference(/datum/preference/toggle/vore_stats) || !owner.ckey)
+		owner.client?.stats_vr?.tick_counter("stats_absorbed_prey", M.read_preference(/datum/preference/toggle/vore_stats))
 
 	to_chat(M, span_vnotice("[belly_format_string(absorb_messages_prey, M, use_absorbed_count = TRUE)]"))
 	to_chat(owner, span_vnotice("[belly_format_string(absorb_messages_owner, M, use_absorbed_count = TRUE)]"))

--- a/code/modules/vore/eating/stats_vr.dm
+++ b/code/modules/vore/eating/stats_vr.dm
@@ -30,9 +30,9 @@
 		load_stats()
 
 // Helpers
-/// Usage: mob.client?.stats_vr?.tick_counter("stats_times_eaten")
-/datum/vore_stats/proc/tick_counter(name)
-	if(!client.prefs.read_preference(/datum/preference/toggle/vore_stats))
+/// Usage: mob.client?.stats_vr?.tick_counter("stats_times_eaten", other.read_preference(/datum/preference/toggle/vore_stats))
+/datum/vore_stats/proc/tick_counter(name, other_consents = FALSE)
+	if(!client.prefs.read_preference(/datum/preference/toggle/vore_stats) || !other_consents)
 		return // drop all input when vore stats toggle is off
 
 	switch(name)

--- a/code/modules/vore/eating/stats_vr.dm
+++ b/code/modules/vore/eating/stats_vr.dm
@@ -1,0 +1,164 @@
+/client
+	var/datum/vore_stats/stats_vr
+
+/hook/client_new/proc/add_stats_vr(client/C)
+	C.stats_vr = new /datum/vore_stats(C)
+	if(C.stats_vr)
+		return TRUE
+
+	return FALSE
+
+/datum/vore_stats
+	var/client/client
+	var/client_ckey
+	var/path
+	var/slot
+
+	var/stats_times_eaten = 0
+	var/stats_eaten_prey = 0
+	var/stats_times_digested = 0
+	var/stats_digested_prey = 0
+	var/stats_times_absorbed = 0
+	var/stats_absorbed_prey = 0
+	var/stats_times_released = 0
+	var/stats_released_prey = 0
+
+/datum/vore_stats/New(client/C)
+	if(istype(C))
+		client = C
+		client_ckey = C.ckey
+		load_stats()
+
+// Helpers
+/// Usage: mob.client?.stats_vr?.tick_counter("stats_times_eaten")
+/datum/vore_stats/proc/tick_counter(name)
+	if(!client.prefs.read_preference(/datum/preference/toggle/vore_stats))
+		return // drop all input when vore stats toggle is off
+
+	switch(name)
+		if("stats_times_eaten")
+			stats_times_eaten++
+		if("stats_eaten_prey")
+			stats_eaten_prey++
+		if("stats_times_digested")
+			stats_times_digested++
+		if("stats_digested_prey")
+			stats_digested_prey++
+		if("stats_times_absorbed")
+			stats_times_absorbed++
+		if("stats_absorbed_prey")
+			stats_absorbed_prey++
+		if("stats_times_released")
+			stats_times_released++
+		if("stats_released_prey")
+			stats_released_prey++
+
+	save_stats()
+
+/datum/vore_stats/tgui_data(mob/user, datum/tgui/ui, datum/tgui_state/state)
+	var/list/data = ..()
+
+	data["enabled"] = user.read_preference(/datum/preference/toggle/vore_stats)
+	data["stats_times_eaten"] = stats_times_eaten
+	data["stats_eaten_prey"] = stats_eaten_prey
+	data["stats_times_digested"] = stats_times_digested
+	data["stats_digested_prey"] = stats_digested_prey
+	data["stats_times_absorbed"] = stats_times_absorbed
+	data["stats_absorbed_prey"] = stats_absorbed_prey
+	data["stats_times_released"] = stats_times_released
+	data["stats_released_prey"] = stats_released_prey
+
+	return data
+
+/datum/vore_stats/proc/load_path(ckey, slot, filename = "character_stats", ext = "json")
+	if(!ckey || !slot)
+		return
+	path = "data/player_saves/[copytext(ckey,1,2)]/[ckey]/vore/[filename][slot].[ext]"
+
+/datum/vore_stats/proc/load_stats()
+	if(!client || !client_ckey)
+		return FALSE //No client, how can we save?
+	if(!client.prefs || !client.prefs.default_slot)
+		return FALSE //Need to know what character to load!
+
+	slot = client.prefs.default_slot
+	load_path(client_ckey, slot)
+
+	if(!path)
+		return FALSE //Path couldn't be set?
+
+	if(!fexists(path)) //Never saved before
+		save_stats() //Make the file first
+		return TRUE
+
+	var/list/json_from_file = json_decode(file2text(path))
+	if(!json_from_file)
+		return FALSE //My concern grows
+
+	var/version = json_from_file["version"]
+	json_from_file = patch_version(json_from_file,version)
+
+	// Load stats
+	stats_times_eaten = json_from_file["stats_times_eaten"]
+	stats_eaten_prey = json_from_file["stats_eaten_prey"]
+	stats_times_digested = json_from_file["stats_times_digested"]
+	stats_digested_prey = json_from_file["stats_digested_prey"]
+	stats_times_absorbed = json_from_file["stats_times_absorbed"]
+	stats_absorbed_prey = json_from_file["stats_absorbed_prey"]
+	stats_times_released = json_from_file["stats_times_released"]
+	stats_released_prey = json_from_file["stats_released_prey"]
+
+	// Sanitize stats
+	if(isnull(stats_times_eaten))
+		stats_times_eaten = 0
+	if(isnull(stats_eaten_prey))
+		stats_eaten_prey = 0
+	if(isnull(stats_times_digested))
+		stats_times_digested = 0
+	if(isnull(stats_digested_prey))
+		stats_digested_prey = 0
+	if(isnull(stats_times_absorbed))
+		stats_times_absorbed = 0
+	if(isnull(stats_absorbed_prey))
+		stats_absorbed_prey = 0
+	if(isnull(stats_times_released))
+		stats_times_released = 0
+	if(isnull(stats_released_prey))
+		stats_released_prey = 0
+
+
+/datum/vore_stats/proc/save_stats()
+	if(!path)
+		return FALSE
+
+	var/version = VORE_VERSION	//For "good times" use in the future
+	var/list/settings_list = list(
+		"version" = version,
+		"stats_times_eaten" = stats_times_eaten,
+		"stats_eaten_prey" = stats_eaten_prey,
+		"stats_times_digested" = stats_times_digested,
+		"stats_digested_prey" = stats_digested_prey,
+		"stats_times_absorbed" = stats_times_absorbed,
+		"stats_absorbed_prey" = stats_absorbed_prey,
+		"stats_times_released" = stats_times_released,
+		"stats_released_prey" = stats_released_prey,
+	)
+
+	//List to JSON
+	var/json_to_file = json_encode(settings_list)
+	if(!json_to_file)
+		log_debug("Saving: [path] failed jsonencode")
+		return FALSE
+
+	//Write it out
+	rustg_file_write(json_to_file, path)
+
+	if(!fexists(path))
+		log_debug("Saving: [path] failed file write")
+		return FALSE
+
+	return TRUE
+
+/datum/vore_stats/proc/patch_version(json, version)
+	// Apply migrations
+	return json

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -361,6 +361,11 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 		"allow_mimicry" = host.allow_mimicry,
 	)
 
+	data["stats"] = null
+	if(host?.client?.prefs?.read_preference(/datum/preference/toggle/vore_stats))
+		var/datum/vore_stats/VS = host.client.stats_vr
+		data["stats"] = VS.tgui_data(user)
+
 	return data
 
 /datum/vore_look/tgui_act(action, params)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/misc.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/misc.tsx
@@ -96,3 +96,10 @@ export const BrowserDevTools: FeatureToggle = {
     'When enabled, you can right click -> inspect to open Microsoft Edge dev tools. BYOND 516+ Only.',
   component: CheckboxInput,
 };
+
+export const EnableVoreStats: FeatureToggle = {
+  name: 'Enable Vore Stat Tracking',
+  category: 'VORE',
+  description: 'When enabled, some statistics about vore are tracked.',
+  component: CheckboxInput,
+};

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreInsidePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreInsidePanel.tsx
@@ -15,7 +15,11 @@ export const VoreInsidePanel = (props: {
     inside;
 
   if (!belly_name) {
-    return <Section title="Inside">You aren&apos;t inside anyone.</Section>;
+    return (
+      <Section fill title="Inside">
+        You aren&apos;t inside anyone.
+      </Section>
+    );
   }
 
   return (

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreStats.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreStats.tsx
@@ -1,0 +1,98 @@
+import { Chart } from 'react-google-charts';
+import { Section, Stack } from 'tgui-core/components';
+
+import { Stats } from './types';
+
+const PieChart = (props: { data: (string | number)[][]; title: string }) => (
+  <Chart
+    chartType="PieChart"
+    data={props.data}
+    options={{
+      backgroundColor: 'none',
+      title: props.title,
+      titleTextStyle: { color: 'white' },
+      legend: { textStyle: { color: 'white' } },
+      height: 300,
+    }}
+    height="300px"
+    width="300px"
+  />
+);
+
+const PreyPredPieChart = (props: { prey: number; pred: number }) => {
+  const { prey, pred } = props;
+
+  const slices = [
+    ['Type', 'Count'],
+    ['Prey', prey],
+    ['Pred', pred],
+  ];
+
+  return <PieChart data={slices} title="Pred/Prey Ratio" />;
+};
+
+const EndResultPieChart = (props: {
+  title: string;
+  absorb: number;
+  digest: number;
+  release: number;
+}) => {
+  const { title, absorb, digest, release, ...rest } = props;
+
+  let slices = [
+    ['Type', 'Count'],
+    ['Absorb', absorb],
+    ['Digest', digest],
+    ['Release', release],
+  ];
+
+  if (!absorb && !digest && !release) {
+    slices = [
+      ['Type', 'Count'],
+      ['None', 1],
+    ];
+  }
+
+  return <PieChart data={slices} title={title} {...rest} />;
+};
+
+export const VoreStats = (props: { stats: Stats }) => {
+  const { stats } = props;
+
+  if (!stats.enabled) {
+    return (
+      <Section title="Statistics" fill>
+        Statistics are disabled by preference.
+      </Section>
+    );
+  }
+
+  return (
+    <Section title="Statistics" fill>
+      <Stack>
+        <Stack.Item>
+          <PreyPredPieChart
+            pred={stats.stats_eaten_prey}
+            prey={stats.stats_times_eaten}
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <EndResultPieChart
+            title="Absorb/Digest/Release (Pred)"
+            absorb={stats.stats_absorbed_prey}
+            digest={stats.stats_digested_prey}
+            release={stats.stats_released_prey}
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <EndResultPieChart
+            title="Absorb/Digest/Release (Prey)"
+            absorb={stats.stats_times_absorbed}
+            digest={stats.stats_times_digested}
+            release={stats.stats_times_released}
+          />
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/VorePanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Stack } from 'tgui-core/components';
+import { Section, Stack } from 'tgui-core/components';
 
 import { useBackend } from '../../backend';
 import { Button, Flex, Icon, NoticeBox, Tabs } from '../../components';
@@ -7,6 +7,7 @@ import { Window } from '../../layouts';
 import { Data } from './types';
 import { VoreBellySelectionAndCustomization } from './VoreBellySelectionAndCustomization';
 import { VoreInsidePanel } from './VoreInsidePanel';
+import { VoreStats } from './VoreStats';
 import { VoreUserPreferences } from './VoreUserPreferences';
 
 /**
@@ -18,8 +19,15 @@ import { VoreUserPreferences } from './VoreUserPreferences';
 export const VorePanel = (props) => {
   const { act, data } = useBackend<Data>();
 
-  const { inside, our_bellies, selected, prefs, show_pictures, host_mobtype } =
-    data;
+  const {
+    inside,
+    our_bellies,
+    selected,
+    prefs,
+    show_pictures,
+    host_mobtype,
+    stats,
+  } = data;
 
   const [tabIndex, setTabIndex] = useState(0);
 
@@ -35,6 +43,11 @@ export const VorePanel = (props) => {
   );
 
   tabs[1] = <VoreUserPreferences prefs={prefs} show_pictures={show_pictures} />;
+  tabs[2] = stats ? (
+    <VoreStats stats={stats} />
+  ) : (
+    <Section fill>Disabled by preference.</Section>
+  );
 
   return (
     <Window width={890} height={660} theme="abstract">
@@ -84,6 +97,12 @@ export const VorePanel = (props) => {
               >
                 Preferences
                 <Icon name="user-cog" ml={0.5} />
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={tabIndex === 2}
+                onClick={() => setTabIndex(2)}
+              >
+                Stats <Icon name="chart-pie" ml={0.5} />
               </Tabs.Tab>
             </Tabs>
           </Stack.Item>

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -16,6 +16,7 @@ export type Data = {
     resize_cost: number;
   };
   vore_words: Record<string, string[]>;
+  stats: Stats | null;
 };
 
 export type hostMob = {
@@ -215,4 +216,16 @@ export type preferenceData = {
   content: { enabled: string; disabled: string };
   fluid?: boolean;
   back_color?: { enabled: string; disabled: string };
+};
+
+export type Stats = {
+  enabled: BooleanLike;
+  stats_times_eaten: number;
+  stats_eaten_prey: number;
+  stats_times_digested: number;
+  stats_digested_prey: number;
+  stats_times_absorbed: number;
+  stats_absorbed_prey: number;
+  stats_times_released: number;
+  stats_released_prey: number;
 };

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -15,6 +15,7 @@
     "marked": "^4.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-google-charts": "^5.2.1",
     "react-popper": "^2.3.0",
     "tgui-core": "^1.2.0",
     "tgui-dev-server": "workspace:*",

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -7126,6 +7126,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-google-charts@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "react-google-charts@npm:5.2.1"
+  peerDependencies:
+    react: ">=16.3.0"
+    react-dom: ">=16.3.0"
+  checksum: 10c0/de9e4a685a7f0db37a2b89fc91e88a702b56819d59f1f2a9f02b8fa94604964cf1e7f59223332220548ebfd04f5e27e3a4b8f4a8842c87f5d5634eb23da1ff2a
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -8353,6 +8363,7 @@ __metadata:
     marked: "npm:^4.3.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-google-charts: "npm:^5.2.1"
     react-popper: "npm:^2.3.0"
     tgui-core: "npm:^1.2.0"
     tgui-dev-server: "workspace:*"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4274,6 +4274,7 @@
 #include "code\modules\vore\eating\silicon_vr.dm"
 #include "code\modules\vore\eating\simple_animal_vr.dm"
 #include "code\modules\vore\eating\slipvore_vr.dm"
+#include "code\modules\vore\eating\stats_vr.dm"
 #include "code\modules\vore\eating\stumblevore_vr.dm"
 #include "code\modules\vore\eating\transforming_vr.dm"
 #include "code\modules\vore\eating\vertical_nom_vr.dm"


### PR DESCRIPTION
This adds a simple stat tracking system for vore mechanics! It's an opt-out system, because all this information is used for is displaying pie charts to the user.

These metrics are measured *by character*. 

Current metrics:
- Times eaten by anything.
- Times you have eaten a player.
- Times you have absorbed a player/been absorbed by anything.
- Times you have digested a player/been digested by anything.
- Times you have released a player/been released by anything.

All stats require both players to be opted in to data collection, except for prey stats inside a ckeyless mob.

Uses a separate stats_vr system that writes to a separate json file, `ata/player_saves/t/tigercat2000/vore/character_stats1.json`

![https://i.tigercat2000.net/2024/11/6JXMFursL3.png](https://i.tigercat2000.net/2024/11/6JXMFursL3.png)
![https://i.tigercat2000.net/2024/11/zWTPxif570.png](https://i.tigercat2000.net/2024/11/zWTPxif570.png)
![https://i.tigercat2000.net/2024/11/2CUWBwwgPL.png](https://i.tigercat2000.net/2024/11/2CUWBwwgPL.png)

This also adds [react-google-charts](https://www.npmjs.com/package/react-google-charts) to our tgui bundle, which is really cool and works all the way back to IE8 with minimal overhead, as it lazily loads the google charts library only when used in a UI.

:cl:
add: Vore stat tracking, total times eating someone/eaten, plus absorb, digest, and release 
/:cl: