### PR TITLE
surgery firstaid bags can carry bone clamps

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid_vr.dm
+++ b/code/game/objects/items/weapons/storage/firstaid_vr.dm
@@ -71,6 +71,7 @@
 
 /obj/item/storage/firstaid/surgery
 	can_hold = list(
+		/obj/item/surgical/bone_clamp,
 		/obj/item/surgical/bonesetter,
 		/obj/item/surgical/cautery,
 		/obj/item/surgical/circular_saw,


### PR DESCRIPTION
🆑 
qol: surgery first aid bags can carry bone clamps
/🆑 