### PR TITLE
fixes vote announce time

### DIFF
--- a/code/modules/vote/vote_datum.dm
+++ b/code/modules/vote/vote_datum.dm
@@ -117,9 +117,9 @@
 
     return null
 
-/datum/vote/proc/announce(start_text, var/time = vote_time/10)
+/datum/vote/proc/announce(start_text, var/time = vote_time)
     to_chat(world, span_lightpurple("Type <b>vote</b> or click <a href='?src=\ref[src];[HrefToken()];vote=open'>here</a> to place your vote. \
-        You have [time] seconds to vote."))
+        You have [time/10] seconds to vote."))
     world << sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = 3)
 
 /datum/vote/Topic(href, list/href_list)

--- a/tgui/packages/tgui/interfaces/Canister.tsx
+++ b/tgui/packages/tgui/interfaces/Canister.tsx
@@ -71,7 +71,6 @@ export const Canister = (props) => {
             <LabeledControls.Item label="Regulator">
               <Box position="relative" left="-8px">
                 <Knob
-                  width="60px"
                   size={1.25}
                   color={!!valveOpen && 'yellow'}
                   value={releasePressure}


### PR DESCRIPTION
Vote time is given in decis, not in seconds. This ends the vote for 60 seconds to be announced for 600 seconds