### PR TITLE
Ports Janihud rework from Outpost 21.

### DIFF
--- a/code/game/objects/effects/chem/coating.dm
+++ b/code/game/objects/effects/chem/coating.dm
@@ -34,3 +34,5 @@
 /obj/effect/decal/cleanable/chemcoating/update_icon()
 	..()
 	color = reagents.get_color()
+	cut_overlays()
+	add_janitor_hud_overlay()

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -13,6 +13,8 @@
 
 /obj/effect/decal/cleanable/blood/gibs/xeno/update_icon()
 	color = "#FFFFFF"
+	cut_overlays()
+	add_janitor_hud_overlay()
 
 /obj/effect/decal/cleanable/blood/gibs/xeno/up
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibup1","xgibup1","xgibup1")

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -70,6 +70,8 @@ var/global/list/image/splatter_cache=list()
 	else
 		name = initial(name)
 		desc = initial(desc)
+	cut_overlays()
+	add_janitor_hud_overlay()
 
 /obj/effect/decal/cleanable/blood/Crossed(mob/living/carbon/human/perp)
 	if(perp.is_incorporeal())
@@ -210,6 +212,7 @@ var/global/list/image/splatter_cache=list()
 	icon = blood
 	cut_overlays()
 	add_overlay(giblets)
+	add_janitor_hud_overlay()
 
 /obj/effect/decal/cleanable/blood/gibs/up
 	random_icon_states = list("gib1", "gib2", "gib3", "gib5", "gib6","gibup1","gibup1","gibup1")

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -10,6 +10,8 @@
 
 /obj/effect/decal/cleanable/blood/gibs/robot/update_icon()
 	color = "#FFFFFF"
+	cut_overlays()
+	add_janitor_hud_overlay()
 
 /obj/effect/decal/cleanable/blood/gibs/robot/dry()	//pieces of robots do not dry up like
 	return

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -142,6 +142,7 @@ var/global/list/image/fluidtrack_cache=list()
 		stack[stack_idx]=track
 		add_overlay(I)
 	updatedtracks=0 // Clear our memory of updated tracks.
+	add_janitor_hud_overlay()
 
 /obj/effect/decal/cleanable/blood/tracks/footprints
 	name = "wet footprints"

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -55,10 +55,8 @@ generic_filth = TRUE means when the decal is saved, it will be switched out for 
 	hud.plane = PLANE_JANHUD
 	hud.layer = BELOW_MOB_LAYER
 	hud.mouse_opacity = 0
-	//HUD VARIANT: Allows the hud to show up with it's normal alpha, even if the 'dirty thing' it's attached to has a low alpha (ex: dirt)
-	/*
+	//HUD VARIANT: Allows the hud to show up with it's normal alpha, even if the 'dirty thing' it's attached to has a low alpha (ex: dirt). If you want to disable it, simply comment out the lines between the 'HUD VARIANT' tag!
 	hud.appearance_flags = RESET_ALPHA
 	hud.alpha = 255
-	*/
 	//HUD VARIANT end
 	add_overlay(hud)

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -6,12 +6,18 @@
 	layer = DIRTY_LAYER
 	anchored = TRUE
 
-/obj/effect/decal/cleanable/crayon/New(location,main = "#FFFFFF",shade = "#000000",var/type = "rune")
-	..()
-	loc = location
+	var/art_type
+	var/art_color
+	var/art_shade
 
+/obj/effect/decal/cleanable/crayon/Initialize(var/ml, main = "#FFFFFF",shade = "#000000",var/type = "rune", new_age = 0)
 	name = type
 	desc = "A [type] drawn in crayon."
+
+	// Persistence vars. Unused here but used downstream. If someone updates the persistance code, it's here.
+	art_type = type
+	art_color = main
+	art_shade = shade
 
 	switch(type)
 		if("rune")
@@ -19,13 +25,20 @@
 		if("graffiti")
 			type = pick("amyjon","face","matt","revolution","engie","guy","end","dwarf","uboa")
 
-	var/icon/mainOverlay = new/icon('icons/effects/crayondecal.dmi',"[type]",2.1)
-	var/icon/shadeOverlay = new/icon('icons/effects/crayondecal.dmi',"[type]s",2.1)
+	. = ..(ml, new_age) // mapload, age
 
-	mainOverlay.Blend(main,ICON_ADD)
-	shadeOverlay.Blend(shade,ICON_ADD)
+/obj/effect/decal/cleanable/crayon/update_icon()
+	cut_overlays()
+	var/icon/mainOverlay = new/icon('icons/effects/crayondecal.dmi',"[art_type]",2.1)
+	var/icon/shadeOverlay = new/icon('icons/effects/crayondecal.dmi',"[art_type]s",2.1)
 
-	add_overlay(mainOverlay)
-	add_overlay(shadeOverlay)
+	if(mainOverlay && shadeOverlay)
+		mainOverlay.Blend(art_color,ICON_ADD)
+		shadeOverlay.Blend(art_shade,ICON_ADD)
 
-	add_hiddenprint(usr)
+		add_overlay(mainOverlay)
+		add_overlay(shadeOverlay)
+
+	add_janitor_hud_overlay()
+	return
+// CHOMPEdit End

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -113,8 +113,6 @@
 		for(var/atom/movable/A in affecting)
 			if(istype(A,/obj/effect/abstract)) // Flashlight's lights are not physical objects
 				continue
-			if(istype(A,/obj/effect/decal/jan_hud)) // Ignore these too
-				continue
 			if(!A.anchored)
 				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
 					step(A,movedir)


### PR DESCRIPTION
## Ports the Janihud rework from Outpost 21 by Willburd See: [Here](https://github.com/Willburd/CHOMPost21/pull/343)

Downstream of us was finding an issue where the fact that dirty objects had an object made for every single item that would be visible for the janihud if it was dirty.

While in MOST cases this wouldn't cause any issues, there were some edge cases (such as objects that looked at their entire /obj contents) that it would mess up.
Additionally, it was more resource intensive than just adding an overlay, which is what this PR accomplishes. (See at the very bottom for the nerd memory usage stats)

## Changes:
- Converts the janihud dirty indicator from an /obj to an overlay.
- This does not affect the janihud indicator, still works as previously.
- Additionally, due to how overlays works, this allows for the overlays to have some variability in being seen. The more visible an object is, the more visible the overlay. (This only affects dirt atm. But the more dirty a tiile is with dirt, the more visible the overlay is.)
- Adds a commented out section in the code to allow for downstream to toggle if they want the overlay to be 100% visible if it exists. This means dirty tiles will show the HUD display fully if they have dirt on them.


Photos:
Janihud before: 
<img width="327" alt="dreamseeker_2024-11-25_17-27-08" src="https://github.com/user-attachments/assets/5c545566-94e7-4587-8f0f-40f2c2140828">

Janihud after:
<img width="638" alt="dreamseeker_2024-11-25_18-06-05" src="https://github.com/user-attachments/assets/aeb27143-9151-45dc-a520-8babb5d822e9">


Janihud on various dirty objects:
<img width="423" alt="dreamseeker_2024-11-25_20-27-39" src="https://github.com/user-attachments/assets/8ade4821-bc32-4270-9cec-abd6d722f4d2">
(Gibs aren't overlayed with it in this screenshot but that was fixed shortly after the screenshot. See below)
![2024-11-25_20-34-54](https://github.com/user-attachments/assets/a5d756dc-6868-4f45-b7ff-c4589ccee7cf)




Nerd memory usage info:

BEFORE FIX:
`Before Blood:
prototypes:
	obj: 6.92 MB (32,448)
	mob: 13.6 KB (873)
	proc: 26.1 MB (53,414)
	str: 16.6 MB (270,591)
	appearance: 454 KB (14,244)
	filter: 16.3 KB (3)
	id array: 86.4 MB (136,981)
	map: 5.19 MB (100,100,4)
objects:
	mobs: 21 KB (16)
	objs: 2.53 MB (6,834)
	datums: 6.98 MB (53,937)
	images: 4.09 MB (13,682)
	lists: 12.5 MB (95,939)
	procs: 2.96 KB (9)

AFter blood: 
prototypes:
	obj: 6.92 MB (32,448)
	mob: 13.6 KB (873)
	proc: 26.1 MB (53,414)
	str: 16.7 MB (270,591)
	appearance: 1.2 MB (36,738)
	filter: 16.4 KB (6)
	id array: 86.6 MB (154,640)
	map: 7.53 MB (100,100,6)
objects:
	mobs: 55.9 KB (32)
	>>>>>>>>>>>**objs: 3.71 MB (11,111)**
	datums: 7.14 MB (52,220)
	images: 4.07 MB (13,549)
	lists: 13.2 MB (107,075)
	procs: 1.88 KB (7)`


AFTER FIX:
Before blood:
prototypes:
	obj: 6.92 MB (32,447)
	mob: 13.6 KB (873)
	proc: 26.1 MB (53,416)
	str: 16.7 MB (270,594)
	appearance: 357 KB (10,688)
	filter: 16.4 KB (6)
	id array: 86.4 MB (136,984)
	map: 5.2 MB (100,100,4)
objects:
	mobs: 34.3 KB (21)
	objs: 2.59 MB (6,961)
	datums: 6.15 MB (48,176)
	images: 4.06 MB (13,497)
	lists: 12.6 MB (96,062)
	procs: 2.74 KB (10)

After Blood: 
prototypes:
	obj: 6.92 MB (32,447)
	mob: 13.6 KB (873)
	proc: 26.1 MB (53,416)
	str: 16.7 MB (270,594)
	appearance: 359 KB (10,780)
	filter: 16.4 KB (6)
	id array: 86.4 MB (136,984)
	map: 5.24 MB (100,100,4)
objects:
	mobs: 35.8 KB (22)
	>>>>>>>>>>>**objs: 3.23 MB (8,932)**
	datums: 6.86 MB (52,164)
	images: 4.06 MB (13,497)
	lists: 13.3 MB (107,926)
	procs: 2.45 KB (9)


Very small memory optimization, but it's there.