### PR TITLE
Allow pAIs to attack_ai the machine they're inside,

### DIFF
--- a/code/modules/food/kitchen/microwave.dm
+++ b/code/modules/food/kitchen/microwave.dm
@@ -219,6 +219,11 @@
 	..()
 	SStgui.update_uis(src)
 
+/obj/machinery/microwave/tgui_status(mob/user)
+	if(user == paicard?.pai)
+		return STATUS_INTERACTIVE
+	. = ..()
+
 /obj/machinery/microwave/tgui_state(mob/user)
 	return GLOB.tgui_physical_state
 

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -291,6 +291,16 @@
 		if(I_GRAB)
 			pai_nom(A)
 
+// Allow card inhabited machines to be interacted with
+// This has to override ClickOn because of storage depth nonsense with how pAIs are in cards in machines
+/mob/living/silicon/pai/ClickOn(var/atom/A, var/params)
+	if(istype(A, /obj/machinery))
+		var/obj/machinery/M = A
+		if(M.paicard == card)
+			M.attack_ai(src)
+			return
+	return ..()
+
 /mob/living/silicon/pai/proc/hug(var/mob/living/silicon/pai/H, var/mob/living/target)
 
 	var/t_him = "them"


### PR DESCRIPTION
this literally just means rn microwaves can be triggered by them

:cl:
add: pAI cards put into a machine are allowed to attack_ai() their machine
/:cl: