### PR TITLE
Space Ghost and SD Mining spawn tweaks

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
@@ -97,7 +97,8 @@
 
 /mob/living/simple_mob/vore/alienanimals/space_ghost/apply_melee_effects(var/atom/A)
 	var/mob/living/L = A
-	L.hallucination += 50
+	if(L.hallucination <= 100)
+		L.hallucination += rand(1,10)
 
 /mob/living/simple_mob/vore/alienanimals/space_ghost/shoot(atom/A) //We're shooting ghosts at people and need them to have the same faction as their parent, okay?
 	if(!projectiletype)
@@ -209,7 +210,8 @@
 /mob/living/simple_mob/vore/alienanimals/spooky_ghost/apply_melee_effects(var/atom/A)
 	var/mob/living/L = A
 	if(L && istype(L))
-		L.hallucination += rand(1,50)
+		if(L.hallucination <= 100)
+			L.hallucination += rand(1,10)
 
 /mob/living/simple_mob/vore/alienanimals/spooky_ghost/Life()
 	. = ..()

--- a/maps/submaps/space_rocks/space_rocks_stuff.dm
+++ b/maps/submaps/space_rocks/space_rocks_stuff.dm
@@ -19,11 +19,13 @@
 	prob_fall = 40
 	//guard = 20
 	mobs_to_pick_from = list(
-		/mob/living/simple_mob/animal/space/bats = 10,
-		/mob/living/simple_mob/vore/alienanimals/space_jellyfish = 15,
-		/mob/living/simple_mob/vore/alienanimals/startreader = 15,
-		/mob/living/simple_mob/vore/alienanimals/space_ghost = 6,
+		/mob/living/simple_mob/vore/alienanimals/space_jellyfish = 1,
+		/mob/living/simple_mob/vore/alienanimals/startreader = 3,
+		/mob/living/simple_mob/vore/alienanimals/space_ghost = 2,
 		/mob/living/simple_mob/vore/oregrub = 1,
+		/mob/living/simple_mob/animal/space/ray = 10,
+		/mob/living/simple_mob/animal/space/bats = 10,
+		/mob/living/simple_mob/animal/space/gnat = 15,
 		/mob/living/simple_mob/animal/space/carp = 3,
 		/mob/living/simple_mob/animal/space/carp/large = 1,
 		/mob/living/simple_mob/animal/space/carp/large/huge = 1


### PR DESCRIPTION
Salvages some changes from #15777 (as the PR was stale due to map changes).

I haven't canned treaders entirely like that PR, but they spawn far less. Jellyfish and spaceghosts are rarer too. The big carp have not been removed. Everything will be a little rarer given the addition of rays and gnats.

:cl:
tweak: capped the max hallucinations space ghosts can inflict with their attacks, and reduced the amount applied
tweak: adjusted mining spawns on SD asteroids
/:cl: