### PR TITLE
fix subtype handling for robot extra icons

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -142,6 +142,12 @@
 		return TRUE
 	return FALSE
 
+/mob/living/silicon/robot/proc/is_type_in_modules(var/type, var/list/modules)
+	for(var/module in modules)
+		if(istype(module, type))
+			return TRUE
+	return FALSE
+
 //Helper procs for cyborg modules on the UI.
 //These are hackish but they help clean up code elsewhere.
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -136,15 +136,18 @@
 		return 0
 
 // This one takes an object's type instead of an instance, as above.
-/mob/living/silicon/robot/proc/has_active_type(var/type_to_compare)
+/mob/living/silicon/robot/proc/has_active_type(var/type_to_compare, var/explicit = FALSE)
 	var/list/active_modules = list(module_state_1, module_state_2, module_state_3)
-	if(is_type_in_modules(type_to_compare, active_modules))
+	if(is_type_in_modules(type_to_compare, active_modules, explicit))
 		return TRUE
 	return FALSE
 
-/mob/living/silicon/robot/proc/is_type_in_modules(var/type, var/list/modules)
-	for(var/module in modules)
-		if(istype(module, type))
+/mob/living/silicon/robot/proc/is_type_in_modules(var/type, var/list/modules, var/explicit = FALSE)
+	for(var/atom/module in modules)
+		if(explicit && isatom(module))
+			if(module.type == type)
+				return TRUE
+		else if(istype(module, type))
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -138,7 +138,7 @@
 // This one takes an object's type instead of an instance, as above.
 /mob/living/silicon/robot/proc/has_active_type(var/type_to_compare)
 	var/list/active_modules = list(module_state_1, module_state_2, module_state_3)
-	if(is_path_in_list(type_to_compare, active_modules))
+	if(is_type_in_modules(type_to_compare, active_modules))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -343,6 +343,8 @@
 	if(module)
 		var/list/module_sprites = SSrobot_sprites.get_module_sprites(module, src)
 		if(module_sprites.len == 1 || !client)
+			if(!module_sprites.len)
+				return
 			sprite_datum = module_sprites[1]
 			sprite_datum.do_equipment_glamour(module)
 			return


### PR DESCRIPTION
The way we've used the is_type_in_list was exactly inverted to how it should be as modules are our list and the path is only a single path. This led to situations where 

ourborg.has_active_type(/obj/item/gun/energy/taser/mounted/cyborg/ertgun) 

was TRUE when we had only obj/item/gun/energy/taser/mounted/cyborg equipped

🆑 
fix: subtypes being applied in robot extra icons
/:cl: