### PR TITLE
Lurker Outfit Fixes

### DIFF
--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -76,3 +76,18 @@
 	headset = /obj/item/radio/headset
 	headset_alt = /obj/item/radio/headset/alt
 	headset_earbud = /obj/item/radio/headset/earbud
+
+	flags = OUTFIT_HAS_BACKPACK
+	backpack = /obj/item/storage/backpack
+	satchel_one  = /obj/item/storage/backpack/satchel/norm
+	satchel_two  = /obj/item/storage/backpack/satchel
+	messenger_bag = /obj/item/storage/backpack/messenger
+	sports_bag = /obj/item/storage/backpack/sport
+	satchel_three = /obj/item/storage/backpack/satchel/strapless
+
+	backpack_contents = list(/obj/item/spacecash/c200 = 1)
+
+/decl/hierarchy/outfit/maint_lurker/post_equip(var/mob/living/carbon/human/H)
+	..()
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/spacecash/c200(H), slot_l_hand)


### PR DESCRIPTION
Some minor fixes for the maint lurker outfit.

:cl:
bugfix: lurkers can now spawn with a backpack (inc. their rig module, for protean lurkers)
tweak: lurkers now spawn with 200 thalers
/:cl: