### PR TITLE
Shapeshifter love

### DIFF
--- a/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
@@ -90,6 +90,8 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_secondary_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
 		/mob/living/proc/set_size,
+		/mob/living/carbon/human/proc/shapeshifter_copy_body,
+		/mob/living/carbon/human/proc/shapeshifter_regenerate,
 //		/mob/living/carbon/human/proc/lleill_contact,
 //		/mob/living/carbon/human/proc/lleill_alchemy,
 //		/mob/living/carbon/human/proc/hanner_beast_form

--- a/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
@@ -84,6 +84,8 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_secondary_ears,
 		/mob/living/proc/set_size,
+		/mob/living/carbon/human/proc/shapeshifter_copy_body,
+		/mob/living/carbon/human/proc/shapeshifter_regenerate,
 //		/mob/living/carbon/human/proc/lleill_invisibility,
 //		/mob/living/carbon/human/proc/lleill_transmute,
 //		/mob/living/carbon/human/proc/lleill_rings,

--- a/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
+++ b/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
@@ -47,5 +47,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_secondary_ears,
 		/mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
-		/mob/living/proc/set_size
+		/mob/living/proc/set_size,
+		/mob/living/carbon/human/proc/shapeshifter_copy_body,
+		/mob/living/carbon/human/proc/shapeshifter_regenerate
 		)


### PR DESCRIPTION
Added a fully reform ability to lleill, hanner and gamma replicants. Works the same as protean regeneration except without the option to heal yourself. Copies the appearance of your current slot minus any prosthetics (they get replaced with organic equivalents, so you don't just lose a hand, etc).

Added the ability to copy form to lleill, hanner and gamma replicants. This works the same as the protean version, except it ignores prosthetics instead of forcing them. Allows the user to copy the appearance of someone they have grabbed, but only with their OOC consent.

As lleill aren't technically shapeshifters codewise, they will still have to use the "select body type" verb to match the other person, but all other appearance bits are copied over fine. None of these are available to prometheans at this time, partially due to the lack of whitelisting but also other goo based considerations that make it a bit more complicated.