### PR TITLE
fix multizmovement

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -115,11 +115,10 @@
 					to_chat(src, span_warning("You gave up on pulling yourself up."))
 					return 0
 
-			//RS Port #661 Start, Prevents noclipping
-			else if(!istype(destination, /turf/simulated/open))
+			// Explicit check if the destination turf allows full passing
+			else if(!destination.CanZPass(src, direction))
 				to_chat(src, span_warning("Something solid above stops you from passing."))
 				return 0
-			//RS Port #661 End
 
 			else if(isliving(src)) //VOREStation Edit Start. Are they a mob, and are they currently flying??
 				var/mob/living/H = src

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -1,20 +1,23 @@
 /// Multiz support override for CanZPass
-/turf/proc/CanZPass(atom/A, direction)
+/turf/proc/CanZPass(atom/A, direction, recursive = FALSE)
+	if(recursive)
+		return FALSE
 	if(z == A.z) //moving FROM this turf
 		return direction == UP //can't go below
 	else
 		if(direction == UP) //on a turf below, trying to enter
-			return 0
+			return FALSE
 		if(direction == DOWN) //on a turf above, trying to enter
-			return !density && isopenspace(GetAbove(src)) // VOREStation Edit
+			var/turf/above = GetAbove(src)
+			return !density && above?.CanZPass(A, direction, TRUE) // do not call the function again, only accept overrides that return TRUE for a direction
 
 /// Multiz support override for CanZPass
 /turf/simulated/open/CanZPass(atom, direction)
-	return 1
+	return TRUE
 
 /// Multiz support override for CanZPass
 /turf/space/CanZPass(atom, direction)
-	return 1
+	return TRUE
 
 /// WARNING WARNING
 /// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS


### PR DESCRIPTION
Need some testing, but this should resolve our issues and easily allow us to add new turfs in the future which might allow free passing into either direction.

🆑 
fix: multiZmovement in space in cases where a non space turf exists below
/:cl:
