### PR TITLE
Supply Pack Details/Descriptions

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -9,6 +9,7 @@
 
 /datum/supply_pack/atmos/inflatable
 	name = "Inflatable barriers"
+	desc = "Three cases of self-inflating barriers."
 	contains = list(/obj/item/storage/briefcase/inflatable = 3)
 	cost = 20
 	containertype = /obj/structure/closet/crate/aether
@@ -16,42 +17,50 @@
 
 /datum/supply_pack/atmos/canister_empty
 	name = "Empty gas canister"
+	desc = "An empty gas canister."
 	cost = 7
 	contains = list(/obj/machinery/portable_atmospherics/canister)
 
 /datum/supply_pack/atmos/canister_air
 	name = "Air canister"
+	desc = "A large canister full of standard oxy/nitro air mix."
 	cost = 10
 	contains = list(/obj/machinery/portable_atmospherics/canister/air)
 
 /datum/supply_pack/atmos/canister_oxygen
 	name = "Oxygen canister"
+	desc = "A large canister full of pure oxygen gas. Warning: flammable!"
 	cost = 15
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 
 /datum/supply_pack/atmos/canister_nitrogen
 	name = "Nitrogen canister"
+	desc = "A large canister full of pure nitrogen gas."
 	cost = 10
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 
 /datum/supply_pack/atmos/canister_phoron
 	name = "Phoron gas canister"
+	desc = "A large canister full of pure phoron gas. Warning: flammable!"
 	cost = 60
 	contains = list(/obj/machinery/portable_atmospherics/canister/phoron)
 
 /datum/supply_pack/atmos/canister_nitrous_oxide
 	name = "N2O gas canister"
+	desc = "A large canister full of pure nitrous oxide gas."
 	cost = 15
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
 
 /datum/supply_pack/atmos/canister_carbon_dioxide
 	name = "Carbon dioxide gas canister"
+	desc = "A large canister full of pure carbon dioxide gas."
 	cost = 15
 	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 
 /datum/supply_pack/atmos/air_dispenser
 	contains = list(/obj/machinery/pipedispenser/orderable)
 	name = "Pipe Dispenser"
+	desc = "A portable atmospherics pipe dispensing/laying machine. Atmospherics Access required."
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/large/aether
 	containername = "Pipe Dispenser Crate"
@@ -60,6 +69,7 @@
 /datum/supply_pack/atmos/disposals_dispenser
 	contains = list(/obj/machinery/pipedispenser/disposal/orderable)
 	name = "Disposals Pipe Dispenser"
+	desc = "A portable disposals pipe dispensing/laying machine. Atmospherics Access required."
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/large/aether
 	containername = "Disposal Dispenser Crate"
@@ -68,6 +78,7 @@
 /datum/supply_pack/atmos/rapid_pipe_dispenser
 	contains = list(/obj/item/pipe_dispenser)
 	name = "Rapid Pipe Dispenser"
+	desc = "A handheld rapid pipe deploying machine. Atmospherics Access required."
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/aether
 	containername = "Rapid Pipe Dispenser Crate"
@@ -75,6 +86,7 @@
 
 /datum/supply_pack/atmos/internals
 	name = "Internals crate"
+	desc = "A set of 3 gas masks and air tanks."
 	contains = list(
 			/obj/item/clothing/mask/gas = 3,
 			/obj/item/tank/air = 3
@@ -85,6 +97,7 @@
 
 /datum/supply_pack/atmos/evacuation
 	name = "Emergency equipment"
+	desc = "Emergency evacuation supplies."
 	contains = list(
 			/obj/item/storage/toolbox/emergency = 2,
 			/obj/item/clothing/suit/storage/hazardvest = 2,

--- a/code/datums/supplypacks/contraband.dm
+++ b/code/datums/supplypacks/contraband.dm
@@ -14,6 +14,7 @@
 			)
 
 	name = "Contraband crate"
+	desc = "REDACTED"
 	cost = 25
 	containertype = /obj/structure/closet/crate
 	containername = "Unlabeled crate"
@@ -22,6 +23,7 @@
 
 /datum/supply_pack/security/specialops
 	name = "Special Ops supplies"
+	desc = "ERR: explosive contents detected"
 	contains = list(
 			/obj/item/storage/box/emps,
 			/obj/item/grenade/smokebomb = 4,
@@ -34,6 +36,7 @@
 
 /datum/supply_pack/supply/moghes
 	name = "Moghes imports"
+	desc = "Black market imports, straight from the Hegemony."
 	contains = list(
 			/obj/item/reagent_containers/food/drinks/bottle/redeemersbrew = 2,
 			/obj/item/reagent_containers/food/snacks/unajerky = 4
@@ -44,18 +47,20 @@
 	contraband = 1
 
 /datum/supply_pack/munitions/bolt_rifles_militia
- 	name = "Weapon - Surplus militia rifles"
- 	contains = list(
- 			/obj/item/gun/projectile/shotgun/pump/rifle = 3,
- 			/obj/item/ammo_magazine/clip/c762 = 6
- 			)
- 	cost = 50
- 	contraband = 1
- 	containertype = /obj/structure/closet/crate/hedberg
- 	containername = "Ballistic weapons crate"
+	name = "Weapon - Surplus militia rifles"
+	desc = "Vintage ballistic rifles that fell off the back of a truck. A few centuries ago, that is."
+	contains = list(
+			/obj/item/gun/projectile/shotgun/pump/rifle = 3,
+			/obj/item/ammo_magazine/clip/c762 = 6
+			)
+	cost = 50
+	contraband = 1
+	containertype = /obj/structure/closet/crate/hedberg
+	containername = "Ballistic weapons crate"
 
 /datum/supply_pack/randomised/misc/telecrate //you get something awesome, a couple of decent things, and a few weak/filler things
 	name = "ERR_NULL_ENTRY" //null crate! also dream maker is hell,
+	desc = "NO DATA FOUND"
 	num_contained = 1
 	contains = list(
 			list( //the operator,
@@ -116,6 +121,7 @@
 
 /datum/supply_pack/supply/stolen
 	name = "Stolen supply crate"
+	desc = "ERR: NO DATA!"
 	contains = list(/obj/item/stolenpackage = 1)
 	cost = 150
 	containertype = /obj/structure/closet/crate
@@ -124,6 +130,7 @@
 
 /datum/supply_pack/supply/wolfgirl
 	name = "Wolfgirl Crate"
+	desc = "Half wolf, half girl, no brains."
 	cost = 200 //I mean, it's a whole wolfgirl
 	containertype = /obj/structure/largecrate/animal/wolfgirl
 	containername = "Wolfgirl crate"
@@ -131,6 +138,7 @@
 
 /datum/supply_pack/supply/catgirl
 	name = "Catgirl Crate"
+	desc = "Half cat, half girl, no brains."
 	cost = 200 //I mean, it's a whole catgirl
 	containertype = /obj/structure/largecrate/animal/catgirl
 	containername = "Catgirl crate"
@@ -144,6 +152,7 @@
 			/obj/item/pizzavoucher
 			)
 	name = "FANTASTIC PIZZA PIE VOUCHER CRATE!"
+	desc = "WE ALWAYS DELIVER!"
 	cost = 60
 	containertype = /obj/structure/closet/crate
 	containername = "WE ALWAYS DELIVER!"

--- a/code/datums/supplypacks/costumes.dm
+++ b/code/datums/supplypacks/costumes.dm
@@ -12,6 +12,7 @@
 
 /datum/supply_pack/costumes/wizard
 	name = "Wizard costume"
+	desc = "A generic robe and wizard hat."
 	contains = list(
 			/obj/item/staff,
 			/obj/item/clothing/suit/wizrobe/fake,
@@ -47,6 +48,7 @@
 			/obj/item/clothing/head/collectable/petehat
 			)
 	name = "Collectable hat crate!"
+	desc = "Collect them all for bragging rights."
 	cost = 200
 	containertype = /obj/structure/closet/crate/nanothreads
 	containername = "Collectable hats crate"
@@ -83,6 +85,7 @@
 			/obj/item/clothing/under/kilt
 			)
 	name = "Costumes crate"
+	desc = "Three choices from a random selection of assorted costumes."
 	cost = 10
 	containertype = /obj/structure/closet/crate/nanothreads
 	containername = "Actor Costumes"
@@ -105,12 +108,14 @@
 			/obj/item/clothing/accessory/wcoat
 			)
 	name = "Formalwear (Suits)"
+	desc = "Fancy formal clothing, for formal occasions."
 	cost = 30
 	containertype = /obj/structure/closet/crate/gilthari
 	containername = "Formal suit crate"
 
 /datum/supply_pack/costumes/witch
 	name = "Witch costume"
+	desc = "Not to be mistaken for a wizard costume."
 	containername = "Witch costume"
 	containertype = /obj/structure/closet/crate/nanothreads
 	cost = 20
@@ -123,6 +128,7 @@
 
 /datum/supply_pack/randomised/costumes/costume_hats
 	name = "Costume hats"
+	desc = "Three random hats from a modest selection."
 	containername = "Actor hats crate"
 	containertype = /obj/structure/closet/crate/nanothreads
 	cost = 10
@@ -148,6 +154,7 @@
 
 /datum/supply_pack/randomised/costumes/dresses
 	name = "Formalwear (Dresses)"
+	desc = "Formal dresses for formal occasions."
 	containername = "Formal dress crate"
 	containertype = /obj/structure/closet/crate/gilthari
 	cost = 15
@@ -168,6 +175,7 @@
 
 /datum/supply_pack/costumes/xenowear_vr
 	name = "Xenowear crate"
+	desc = "An assortment of non-human clothing."
 	contains = list(
 			/obj/item/clothing/shoes/footwraps,
 			/obj/item/clothing/shoes/boots/jackboots/toeless,
@@ -189,6 +197,7 @@
 
 /datum/supply_pack/costumes/tesh_smocks_vr
 	name = "Teshari smocks"
+	desc = "An assortment of teshari smocks."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/under/teshari/smock,
@@ -208,6 +217,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_coats_vr
 	name = "Teshari undercoats"
+	desc = "An assortment of teshari undercoats."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/under/teshari/undercoat/standard/orange_grey,
@@ -229,6 +239,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_coats_b_vr
 	name = "Teshari undercoats (black)"
+	desc = "Another assortment of teshari undercoats."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/under/teshari/undercoat,
@@ -250,6 +261,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_cloaks_vr
 	name = "Teshari cloaks"
+	desc = "An assortment of teshari cloaks."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/teshari/cloak/standard/white,
@@ -271,6 +283,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_cloaks_b_vr
 	name = "Teshari cloaks (black)"
+	desc = "Another assortment of teshari cloaks."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/teshari/cloak,
@@ -293,6 +306,7 @@
 
 /datum/supply_pack/costumes/tesh_worksuits_vr
 	name = "Teshari worksuits"
+	desc = "An assortment of teshari worksuits."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/under/teshari/undercoat/standard/worksuit,
@@ -312,6 +326,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_beltcloaks_vr
 	name = "Teshari cloaks (belted)"
+	desc = "An assortment of belted teshari cloaks."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/teshari/beltcloak/standard/orange_grey,
@@ -333,6 +348,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_beltcloaks_b_vr
 	name = "Teshari cloaks (belted, black)"
+	desc = "Another assortment of belted teshari cloaks."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/teshari/beltcloak,
@@ -356,6 +372,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_hoodcloaks_vr
 	name = "Teshari cloaks (hooded)"
+	desc = "An assortment of teshari cloaks, with hoods."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/hooded/teshari/standard/orange_grey,
@@ -376,6 +393,7 @@
 
 /datum/supply_pack/randomised/costumes/tesh_hoodcloaks_b_vr
 	name = "Teshari cloaks (hooded, black)"
+	desc = "Another assortment of teshari cloaks, with hoods."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/suit/storage/hooded/teshari,
@@ -399,10 +417,13 @@
 
 /datum/supply_pack/costumes/utility_vr
 	name = "Utility uniforms"
+	desc = "A set of standard worksuits."
 	contains = list(
 			/obj/item/clothing/under/utility,
 			/obj/item/clothing/under/utility/blue,
-			/obj/item/clothing/under/utility/grey
+			/obj/item/clothing/under/utility/grey,
+			/obj/item/clothing/under/utility/tan,
+			/obj/item/clothing/under/utility/green
 			)
 	cost = 30
 	containertype = /obj/structure/closet/crate
@@ -410,6 +431,7 @@
 
 /datum/supply_pack/costumes/skirts_vr
 	name = "Skirts crate"
+	desc = "A set of standard skirts."
 	contains = list(
 			/obj/item/clothing/under/skirt,
 			/obj/item/clothing/under/skirt/blue,
@@ -428,6 +450,7 @@
 
 /datum/supply_pack/costumes/varsity_vr
 	name = "Varsity jackets"
+	desc = "A set of varsity jackets."
 	contains = list(
 			/obj/item/clothing/suit/varsity,
 			/obj/item/clothing/suit/varsity/blue,
@@ -442,6 +465,7 @@
 
 /datum/supply_pack/randomised/costumes/leathergear_vr
 	name = "Leather gear"
+	desc = "An assortment of leather clothing. Not the naughty kind."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/suit/leathercoat,
@@ -475,6 +499,7 @@
 
 /datum/supply_pack/costumes/eyewear_vr
 	name = "Eyewear crate"
+	desc = "Assorted eyewear."
 	contains = list(
 			/obj/item/clothing/glasses/eyepatch,
 			/obj/item/clothing/glasses/fakesunglasses,
@@ -494,6 +519,7 @@
 
 /datum/supply_pack/randomised/costumes/gloves_vr
 	name = "Gloves crate"
+	desc = "A random assortment of gloves."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/gloves/black,
@@ -518,6 +544,7 @@
 
 /datum/supply_pack/randomised/costumes/boots_vr
 	name = "Boots crate"
+	desc = "A random assortment of boots."
 	num_contained = 3
 	contains = list(
 			/obj/item/clothing/shoes/boots/workboots,
@@ -535,6 +562,7 @@
 
 /datum/supply_pack/costumes/taurbags
 	name = "Saddlebags crate"
+	desc = "A pack of saddlebags for tauric body types. Not for actual horses."
 	contains = list(
 			/obj/item/storage/backpack/saddlebag_common,
 			/obj/item/storage/backpack/saddlebag_common/robust,
@@ -546,6 +574,7 @@
 
 /datum/supply_pack/costumes/knights_gear
 	name = "Knights Gear"
+	desc = "Knightly costumes, for knightly individuals. No actual protective properties."
 	contains = list(
 			/obj/item/clothing/suit/storage/hooded/knight_costume,
 			/obj/item/clothing/suit/storage/hooded/knight_costume/galahad,
@@ -566,6 +595,7 @@
 
 /datum/supply_pack/costumes/christmas
 	name = "Christmas costume pack"
+	desc = "Ho ho ho!"
 	contains = list(
 			/obj/item/clothing/head/santa,
 			/obj/item/clothing/head/santa/green,

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -9,6 +9,7 @@
 
 /datum/supply_pack/eng/lightbulbs
 	name = "Replacement lights"
+	desc = "Three boxes of replacement light tubes and bulbs."
 	contains = list(/obj/item/storage/box/lights/mixed = 3)
 	cost = 10
 	containertype = /obj/structure/closet/crate/galaksi
@@ -16,6 +17,7 @@
 
 /datum/supply_pack/eng/smescoil
 	name = "Superconducting Magnetic Coil"
+	desc = "A single standard superconducting magnetic coil."
 	contains = list(/obj/item/smes_coil)
 	cost = 75
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -23,6 +25,7 @@
 
 /datum/supply_pack/eng/smescoil/super_capacity
 	name = "Superconducting Capacitance Coil"
+	desc = "A single high-capacity superconducting magnetic coil."
 	contains = list(/obj/item/smes_coil/super_capacity)
 	cost = 90
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -30,6 +33,7 @@
 
 /datum/supply_pack/eng/smescoil/super_io
 	name = "Superconducting Transmission Coil"
+	desc = "A single high-transmission superconducting magnetic coil."
 	contains = list(/obj/item/smes_coil/super_io)
 	cost = 90
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -37,6 +41,7 @@
 
 /datum/supply_pack/eng/shield_capacitor
 	name = "Shield Capacitor"
+	desc = "A standard shield capacitor block."
 	contains = list(/obj/machinery/shield_capacitor)
 	cost = 20
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -44,6 +49,7 @@
 
 /datum/supply_pack/eng/shield_capacitor/advanced
 	name = "Advanced Shield Capacitor"
+	desc = "An advanced shield capacitor block."
 	contains = list(/obj/machinery/shield_capacitor/advanced)
 	cost = 30
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -51,6 +57,7 @@
 
 /datum/supply_pack/eng/bubble_shield
 	name = "Bubble Shield Generator"
+	desc = "A standard bubble shield generator."
 	contains = list(/obj/machinery/shield_gen)
 	cost = 40
 	containertype =/obj/structure/closet/crate/focalpoint
@@ -58,6 +65,7 @@
 
 /datum/supply_pack/eng/bubble_shield/advanced
 	name = "Advanced Bubble Shield Generator"
+	desc = "An advanced bubble shield generator."
 	contains = list(/obj/machinery/shield_gen/advanced)
 	cost = 60
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -65,6 +73,7 @@
 
 /datum/supply_pack/eng/hull_shield
 	name = "Hull Shield Generator"
+	desc = "A standard hull shield generator."
 	contains = list(/obj/machinery/shield_gen/external)
 	cost = 80
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -72,6 +81,7 @@
 
 /datum/supply_pack/eng/hull_shield/advanced
 	name = "Advanced Hull Shield Generator"
+	desc = "An advanced hull shield generator."
 	contains = list(/obj/machinery/shield_gen/external/advanced)
 	cost = 120
 	containertype = /obj/structure/closet/crate/focalpoint
@@ -79,6 +89,7 @@
 
 /datum/supply_pack/eng/point_defense_cannon_circuit
 	name = "Point Defense Turret Circuit"
+	desc = "A pair of point defense turret control circuits."
 	contains = list(/obj/item/circuitboard/pointdefense = 2)
 	cost = 20
 	containertype = /obj/structure/closet/crate/heph
@@ -86,6 +97,7 @@
 
 /datum/supply_pack/eng/point_defense_control_circuit
 	name = "Point Defense Controller Circuit"
+	desc = "A point defense mainframe master control circuit."
 	contains = list(/obj/item/circuitboard/pointdefense_control = 1)
 	cost = 30
 	containertype = /obj/structure/closet/crate/heph
@@ -93,6 +105,7 @@
 
 /datum/supply_pack/eng/electrical
 	name = "Electrical maintenance crate"
+	desc = "A pack of equipment and supplies for carrying out electrical maintenance."
 	contains = list(
 			/obj/item/storage/toolbox/electrical = 2,
 			/obj/item/clothing/gloves/yellow = 2,
@@ -105,6 +118,7 @@
 
 /datum/supply_pack/eng/e_welders
 	name = "Electric welder crate"
+	desc = "A set of three electric-powered welders."
 	contains = list(
 			/obj/item/weldingtool/electric = 3
 			)
@@ -114,6 +128,7 @@
 
 /datum/supply_pack/eng/mechanical
 	name = "Mechanical maintenance crate"
+	desc = "A pack of equipment and supplies for carrying out mechanical maintenance."
 	contains = list(
 			/obj/item/storage/belt/utility/full = 3,
 			/obj/item/clothing/suit/storage/hazardvest = 3,
@@ -126,6 +141,7 @@
 
 /datum/supply_pack/eng/fueltank
 	name = "Fuel tank crate"
+	desc = "Contains a fuel tank dispenser."
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 10
 	containertype = /obj/structure/closet/crate/large/nanotrasen
@@ -133,6 +149,7 @@
 
 /datum/supply_pack/eng/solar
 	name = "Solar Pack crate"
+	desc = "Contains basic supplies for setting up a small solar power array (panels, tracker, and controller, no SMES)."
 	contains  = list(
 			/obj/item/solar_assembly = 21,
 			/obj/item/circuitboard/solar_control,
@@ -145,6 +162,7 @@
 
 /datum/supply_pack/eng/engine
 	name = "Emitter crate"
+	desc = "Two emitters. Requires Chief Engineer access."
 	contains = list(/obj/machinery/power/emitter = 2)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/einstein
@@ -153,6 +171,7 @@
 
 /datum/supply_pack/eng/engine/field_gen
 	name = "Field Generator crate"
+	desc = "Two containment field generators. Requires Chief Engineer access."
 	contains = list(/obj/machinery/field_generator = 2)
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Field Generator crate"
@@ -160,6 +179,7 @@
 
 /datum/supply_pack/eng/engine/sing_gen
 	name = "Singularity Generator crate"
+	desc = "Singularity core generator. Requires Chief Engineer access."
 	contains = list(/obj/machinery/the_singularitygen)
 	containertype = /obj/structure/closet/crate/secure/einstein
 	containername = "Singularity Generator crate"
@@ -167,6 +187,7 @@
 
 /datum/supply_pack/eng/engine/tesla_gen
 	name = "Tesla Generator crate"
+	desc = "Tesla core generator. Requires Chief Engineer access."
 	contains = list(/obj/machinery/the_singularitygen/tesla)
 	containertype = /obj/structure/closet/crate/secure/einstein
 	containername = "Tesla Generator crate"
@@ -174,12 +195,14 @@
 
 /datum/supply_pack/eng/engine/collector
 	name = "Collector crate"
+	desc = "Three radiation collectors, for use with a singularity or supermatter core."
 	contains = list(/obj/machinery/power/rad_collector = 3)
 	containertype = /obj/structure/closet/crate/secure/einstein
 	containername = "Collector crate"
 
 /datum/supply_pack/eng/engine/PA
 	name = "Particle Accelerator crate"
+	desc = "All the parts needed to set up a particle accelerator. Requires Chief Engineer access."
 	cost = 40
 	contains = list(
 			/obj/structure/particle_accelerator/fuel_chamber,
@@ -197,6 +220,7 @@
 /datum/supply_pack/eng/shield_gen
 	contains = list(/obj/item/circuitboard/shield_gen)
 	name = "Bubble shield generator circuitry"
+	desc = "A bubble shield generator circuitboard. Requires Chief Engineer access."
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/focalpoint
 	containername = "bubble shield generator circuitry crate"
@@ -205,6 +229,7 @@
 /datum/supply_pack/eng/shield_gen_ex
 	contains = list(/obj/item/circuitboard/shield_gen_ex)
 	name = "Hull shield generator circuitry"
+	desc = "A hull shield generator circuitboard. Requires Chief Engineer access."
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/focalpoint
 	containername = "hull shield generator circuitry crate"
@@ -213,6 +238,7 @@
 /datum/supply_pack/eng/shield_cap
 	contains = list(/obj/item/circuitboard/shield_cap)
 	name = "Bubble shield capacitor circuitry"
+	desc = "A bubble shield capacitor circuitboard. Requires Chief Engineer access."
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/focalpoint
 	containername = "shield capacitor circuitry crate"
@@ -220,6 +246,7 @@
 
 /datum/supply_pack/eng/smbig
 	name = "Supermatter Core"
+	desc = "A transport-safe supermatter crystal. EXTREMELY HAZARDOUS. Requires Chief Engineer access."
 	contains = list(/obj/machinery/power/supermatter)
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure/phoron
@@ -229,6 +256,7 @@
 /datum/supply_pack/eng/teg
 	contains = list(/obj/machinery/power/generator)
 	name = "Mark I Thermoelectric Generator"
+	desc = "A basic thermoelectric generator."
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/large/einstein
 	containername = "Mk1 TEG crate"
@@ -237,6 +265,7 @@
 /datum/supply_pack/eng/circulator
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
 	name = "Binary atmospheric circulator"
+	desc = "Heavy atmospherics machinery."
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/large/einstein
 	containername = "Atmospheric circulator crate"
@@ -248,6 +277,7 @@
 			/obj/item/clothing/head/radiation = 3
 			)
 	name = "Radiation suits package (Humanoid)"
+	desc = "Three radiation suits (with hoods) fit for most humanoids."
 	cost = 20
 	containertype = /obj/structure/closet/radiation
 	containername = "Radiation suit locker"
@@ -258,12 +288,14 @@
 			/obj/item/clothing/head/radiation/teshari = 3
 			)
 	name = "Radiation suits package (Teshari)"
+	desc = "Three radiation suits (with hoods) fit for teshari."
 	cost = 40
 	containertype = /obj/structure/closet/crate/aether
 	containername = "Teshari radiation suit locker"
 
 /datum/supply_pack/eng/pacman_parts
 	name = "P.A.C.M.A.N. portable generator parts"
+	desc = "Supplies for assembling a basic phoron-fuelled PACMAN generator."
 	cost = 25
 	containername = "P.A.C.M.A.N. Portable Generator Construction Kit"
 	containertype = /obj/structure/closet/crate/secure/focalpoint
@@ -277,6 +309,7 @@
 
 /datum/supply_pack/eng/super_pacman_parts
 	name = "Super P.A.C.M.A.N. portable generator parts"
+	desc = "Supplies for assembling a uranium-fuelled Super PACMAN generator."
 	cost = 35
 	containername = "Super P.A.C.M.A.N. portable generator construction kit"
 	containertype = /obj/structure/closet/crate/secure/focalpoint
@@ -290,6 +323,7 @@
 
 /datum/supply_pack/eng/fusion_core
 	name = "R-UST Mk. 8 Tokamak fusion core crate"
+	desc = "Supplies for assembling a R-UST Tokamak fusion core. Requires Engine access."
 	cost = 50
 	containername = "R-UST Mk. 8 Tokamak Fusion Core crate"
 	containertype = /obj/structure/closet/crate/secure/einstein
@@ -302,6 +336,7 @@
 
 /datum/supply_pack/eng/fusion_fuel_injector
 	name = "R-UST Mk. 8 fuel injector crate"
+	desc = "Supplies for assembling a R-UST Tokamak fusion core's fuel injector. Requires Engine access."
 	cost = 30
 	containername = "R-UST Mk. 8 fuel injector crate"
 	containertype = /obj/structure/closet/crate/secure/einstein
@@ -314,6 +349,7 @@
 
 /datum/supply_pack/eng/gyrotron
 	name = "Gyrotron crate"
+	desc = "Supplies for assembling a gyrotron."
 	cost = 15
 	containername = "Gyrotron Crate"
 	containertype = /obj/structure/closet/crate/secure/einstein
@@ -325,6 +361,7 @@
 
 /datum/supply_pack/eng/fusion_fuel_compressor
 	name = "Fusion Fuel Compressor circuitry crate"
+	desc = "A circuitboard for assembling a fusion fuel compressor."
 	cost = 10
 	containername = "Fusion Fuel Compressor circuitry crate"
 	containertype = /obj/structure/closet/crate/einstein
@@ -332,6 +369,7 @@
 
 /datum/supply_pack/eng/deuterium
 	name = "Deuterium crate"
+	desc = "A stack of 50 deuterium ingots."
 	cost = 50
 	containername = "Deuterium crate"
 	containertype = /obj/structure/closet/crate/einstein
@@ -339,6 +377,7 @@
 
 /datum/supply_pack/eng/tritium
 	name = "Tritium crate"
+	desc = "A stack of 50 tritium ingots."
 	cost = 75
 	containername = "Tritium crate"
 	containertype = /obj/structure/closet/crate/einstein
@@ -346,6 +385,7 @@
 
 /datum/supply_pack/eng/modern_shield
 	name = "Modern Shield Construction Kit"
+	desc = "A set of supplies for constructing a shield generator."
 	contains = list(
 		/obj/item/circuitboard/shield_generator,
 		/obj/item/stock_parts/capacitor,
@@ -361,20 +401,16 @@
 /datum/supply_pack/eng/thermoregulator
 	contains = list(/obj/machinery/power/thermoregulator)
 	name = "Thermal Regulator"
+	desc = "A thermal regulator, ready for deployment. Atmospherics access required."
 	cost = 30
 	containertype = /obj/structure/closet/crate/large
 	containername = "thermal regulator crate"
 	access = access_atmospherics
 
-/datum/supply_pack/eng/radsuit
-	contains = list(
-			/obj/item/clothing/suit/radiation = 3,
-			/obj/item/clothing/head/radiation = 3
-			)
-
 /datum/supply_pack/eng/dosimeter
 	contains = list(/obj/item/storage/box/dosimeter = 6)
 	name = "Dosimeters"
+	desc = "A set of six dosimeters, for basic radiation detection/safety purposes."
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "dosimeter crate"
@@ -382,20 +418,15 @@
 /datum/supply_pack/eng/algae
 	contains = list(/obj/item/stack/material/algae/ten)
 	name = "Algae Sheets (10)"
+	desc = "Ten sheets of algae, for carbon dioxide recycling."
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "algae sheets crate"
 
-/datum/supply_pack/eng/engine/tesla_gen
-	name = "Tesla Generator crate"
-	contains = list(/obj/machinery/the_singularitygen/tesla)
-	containertype = /obj/structure/closet/crate/secure/engineering
-	containername = "Tesla Generator crate"
-	access = access_ce
-
 /datum/supply_pack/eng/inducer
 	contains = list(/obj/item/inducer = 3)
 	name = "inducer"
+	desc = "A trio of inducers, used for remotely recharging powered devices. Requires Engine access."
 	cost = 90	//Relatively expensive
 	containertype = /obj/structure/closet/crate/xion
 	containername = "Inducers crate"

--- a/code/datums/supplypacks/hardsuits.dm
+++ b/code/datums/supplypacks/hardsuits.dm
@@ -8,7 +8,8 @@
 	group = "Hardsuits"
 
 /datum/supply_pack/hardsuits/eva_rig
-	name = "eva hardsuit (empty)"
+	name = "EVA hardsuit (empty)"
+	desc = "An EVA hardsuit with no components. Requires Mining, EVA, or Pilot's access."
 	contains = list(
 			/obj/item/rig/eva = 1
 			)
@@ -22,6 +23,7 @@
 
 /datum/supply_pack/hardsuits/mining_rig
 	name = "industrial hardsuit (empty)"
+	desc = "A standard mining hardsuit with no components. Requires Mining or EVA access."
 	contains = list(
 			/obj/item/rig/industrial = 1
 			)
@@ -34,6 +36,7 @@
 
 /datum/supply_pack/hardsuits/medical_rig
 	name = "medical hardsuit (empty)"
+	desc = "A medical hardsuit with no components. Requires Medical access."
 	contains = list(
 			/obj/item/rig/medical = 1
 			)
@@ -44,6 +47,7 @@
 
 /datum/supply_pack/hardsuits/security_rig
 	name = "hazard hardsuit (empty)"
+	desc = "A hazardous environment combat hardsuit with no components. Requires Armory access."
 	contains = list(
 			/obj/item/rig/hazard = 1
 			)
@@ -54,6 +58,7 @@
 
 /datum/supply_pack/hardsuits/science_rig
 	name = "ami hardsuit (empty)"
+	desc = "An advanced Materials hardsuit, with no components. Requires Research Director authorization."
 	contains = list(
 			/obj/item/rig/hazmat = 1
 			)
@@ -64,6 +69,7 @@
 
 /datum/supply_pack/hardsuits/ce_rig
 	name = "advanced hardsuit (empty)"
+	desc = "An advanced Engineering hardsuit, with no components. Requires Chief Engineer authorization."
 	contains = list(
 			/obj/item/rig/ce = 1
 			)
@@ -74,6 +80,7 @@
 
 /datum/supply_pack/hardsuits/com_medical_rig
 	name = "commonwealth medical hardsuit (loaded)"
+	desc = "A fully-equipped Commonwealth of Sol-Procyon Medical hardsuit. Requires Medical access."
 	contains = list(
 			/obj/item/rig/baymed/equipped = 1
 			)
@@ -84,6 +91,7 @@
 
 /datum/supply_pack/hardsuits/com_engineering_rig
 	name = "commonwealth engineering hardsuit (loaded)"
+	desc = "A fully-equipped Commonwealth of Sol-Procyon Engineering hardsuit. Requires Engineering access."
 	contains = list(
 			/obj/item/rig/bayeng/equipped = 1
 			)
@@ -94,6 +102,7 @@
 
 /datum/supply_pack/hardsuits/breacher_rig
 	name = "unathi breacher hardsuit (empty)"
+	desc = "A Hegemony \'Breacher\' combat hardsuit. Requires Armory access, and can only be worn by unathi."
 	contains = list(
 			/obj/item/rig/breacher = 1
 			)
@@ -104,6 +113,7 @@
 
 /datum/supply_pack/hardsuits/zero_rig
 	name = "null hardsuit (jets)"
+	desc = "A low-profile hardsuit with pre-installed maneuvering jets."
 	contains = list(
 			/obj/item/rig/zero = 1
 			)

--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -9,6 +9,7 @@
 
 /datum/supply_pack/hospitality/party
 	name = "Party equipment"
+	desc = "Miscellaneous alcohol, glasses, and smokes, for partying!"
 	contains = list(
 			/obj/item/storage/box/mixedglasses = 2,
 			/obj/item/storage/box/glasses/square,
@@ -29,6 +30,7 @@
 
 /datum/supply_pack/hospitality/barsupplies
 	name = "Bar supplies"
+	desc = "Spare glasses and extras, for bartending. No booze."
 	contains = list(
 			/obj/item/storage/box/glasses/cocktail,
 			/obj/item/storage/box/glasses/rocks,
@@ -50,6 +52,7 @@
 
 /datum/supply_pack/hospitality/cookingoil
 	name = "Cooking oil tank crate"
+	desc = "A tank of cooking oil."
 	contains = list(/obj/structure/reagent_dispensers/cookingoil)
 	cost = 10
 	containertype = /obj/structure/largecrate
@@ -57,6 +60,7 @@
 
 /datum/supply_pack/hospitality/pizza
 	name = "Surprise pack of five pizzas"
+	desc = "Five random pizzas, a plastic knife, and a pizza delivery outfit."
 	contains = list(
 			/obj/random/pizzabox/supplypack = 5,
 			/obj/item/material/knife/plastic,
@@ -69,6 +73,7 @@
 
 /datum/supply_pack/hospitality/gifts
 	name = "Gift crate"
+	desc = "A selection of gifts from AlliCo."
 	contains = list(
 		/obj/item/toy/bouquet = 3,
 		/obj/item/storage/fancy/heartbox = 2,
@@ -83,6 +88,7 @@
 
 /datum/supply_pack/hospitality/painting
 	name = "Painting equipment"
+	desc = "Miscellaneous items for painting and artistry."
 	contains = list(
 		/obj/item/paint_brush = 2,
 		/obj/item/paint_palette = 2,
@@ -100,6 +106,7 @@
 
 /datum/supply_pack/hospitality/holywater
 	name = "Holy water crate"
+	desc = "Three flasks of genuine Holy water, guaranteed to have been blessed by at least one ordained priest."
 	contains = list(
 		/obj/item/reagent_containers/food/drinks/bottle/holywater = 3
 		)
@@ -112,6 +119,7 @@
 
 /datum/supply_pack/randomised/hospitality/burgers_vr
 	num_contained = 5
+	desc = "A random selection of burgers and/or fries."
 	contains = list(
 			/obj/item/reagent_containers/food/snacks/bigbiteburger,
 			/obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -188,6 +196,7 @@
 			/obj/item/reagent_containers/food/snacks/hotandsoursoup
 			)
 	name = "Chinese takeout crate"
+	desc = "Classic chinese-style takeout, a Terran staple throughout much of the 21st century."
 	cost = 50
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Chinese takeout crate"
@@ -206,6 +215,7 @@
 		/obj/item/storage/box/jaffacake
 		)
 	name = "Desatti jaffa cake crate"
+	desc = "More jaffa cakes than you know what to do with."
 	cost = 25
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Desatti jaffa cake crate"
@@ -220,6 +230,7 @@
 			/obj/item/storage/box/rhubarbcustard
 			)
 	name = "Sweets crate"
+	desc = "A random selection of sweet treats from Desatti."
 	cost = 25
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "Sweets crate"

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -9,6 +9,7 @@
 
 /datum/supply_pack/hydro/monkey
 	name = "Monkey crate"
+	desc = "Monkey cubes! Instant monkey, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer/nanotrasen
@@ -16,6 +17,7 @@
 
 /datum/supply_pack/hydro/farwa
 	name = "Farwa crate"
+	desc = "Farwa cubes! Instant farwa, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/farwacubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -23,6 +25,7 @@
 
 /datum/supply_pack/hydro/neara
 	name = "Neaera crate"
+	desc = "Neaera cubes! Instant nearea, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/neaeracubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -30,6 +33,7 @@
 
 /datum/supply_pack/hydro/stok
 	name = "Stok crate"
+	desc = "Stok cubes! Instant stok, just add water! DO NOT INGEST. NOT SOUP STOCK."
 	contains = list (/obj/item/storage/box/monkeycubes/stokcubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -37,6 +41,7 @@
 
 /datum/supply_pack/hydro/lisa
 	name = "Corgi Crate"
+	desc = "A corgi in a box."
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/animal/corgi
@@ -44,6 +49,7 @@
 
 /datum/supply_pack/hydro/cat
 	name = "Cat Crate"
+	desc = "A cat in a box."
 	contains = list()
 	cost = 45
 	containertype = /obj/structure/largecrate/animal/cat
@@ -51,6 +57,7 @@
 
 /datum/supply_pack/hydro/catslug
 	name = "Catslug Crate"
+	desc = "A catslug in a box. Legally distinct from a slugcat."
 	contains = list()
 	cost = 200
 	containertype = /obj/structure/largecrate/animal/catslug
@@ -58,6 +65,7 @@
 
 /datum/supply_pack/hydro/hydroponics
 	name = "Hydroponics Supply Crate"
+	desc = "A set of standard hydroponics supplies. Requires Hydroponics access."
 	contains = list(
 			/obj/item/reagent_containers/spray/plantbgone = 4,
 			/obj/item/reagent_containers/glass/bottle/ammonia = 2,
@@ -76,6 +84,7 @@
 
 /datum/supply_pack/hydro/cow
 	name = "Cow crate"
+	desc = "A cow in a crate."
 	cost = 25
 	containertype = /obj/structure/largecrate/animal/cow
 	containername = "Cow crate"
@@ -83,6 +92,7 @@
 
 /datum/supply_pack/hydro/goat
 	name = "Goat crate"
+	desc = "A goat in a crate. Useful for dealing with space vines."
 	cost = 25
 	containertype = /obj/structure/largecrate/animal/goat
 	containername = "Goat crate"
@@ -90,6 +100,7 @@
 
 /datum/supply_pack/hydro/chicken
 	name = "Chicken crate"
+	desc = "A chicken in a crate."
 	cost = 25
 	containertype = /obj/structure/largecrate/animal/chick
 	containername = "Chicken crate"
@@ -97,6 +108,7 @@
 
 /datum/supply_pack/hydro/turkey
 	name = "Turkey crate"
+	desc = "A turkey in a crate."
 	cost = 25
 	containertype = /obj/structure/largecrate/animal/turkey
 	containername = "Turkey crate"
@@ -104,6 +116,7 @@
 
 /datum/supply_pack/hydro/seeds
 	name = "Seeds crate"
+	desc = "A wide selection of seed packets. Requires Hydroponics access."
 	contains = list(
 			/obj/item/seeds/chiliseed,
 			/obj/item/seeds/berryseed,
@@ -130,6 +143,7 @@
 
 /datum/supply_pack/hydro/weedcontrol
 	name = "Weed control crate"
+	desc = "Equipment for dealing with out-of-control weeds. Requires Hydroponics access."
 	contains = list(
 			/obj/item/material/knife/machete/hatchet = 2,
 			/obj/item/reagent_containers/spray/plantbgone = 4,
@@ -144,6 +158,7 @@
 
 /datum/supply_pack/hydro/watertank
 	name = "Water tank crate"
+	desc = "A water tank in a crate."
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 10
 	containertype = /obj/structure/closet/crate/large/aether
@@ -151,6 +166,7 @@
 
 /datum/supply_pack/hydro/bee_keeper
 	name = "Beekeeping crate"
+	desc = "Supplies for keeping bees. Requires Hydroponics access."
 	contains = list(
 			/obj/item/beehive_assembly,
 			/obj/item/bee_smoker,
@@ -164,6 +180,7 @@
 
 /datum/supply_pack/hydro/tray
 	name = "Empty hydroponics trays"
+	desc = "Three empty hydroponics trays, ready for use."
 	cost = 50
 	containertype = /obj/structure/closet/crate/aether
 	containername = "Hydroponics tray crate"
@@ -172,6 +189,7 @@
 
 /datum/supply_pack/hydro/birds
 	name = "Birds Crate"
+	desc = "A raging case of birds."
 	cost = 200 //You're getting 22 birds. Of course it's going to be a lot!
 	containertype = /obj/structure/largecrate/birds
 	containername = "Bird crate"
@@ -179,6 +197,7 @@
 
 /datum/supply_pack/hydro/sobaka
 	name = "Sobaka crate"
+	desc = "Sobaka cubes! Instant sobaka, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/sobakacubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -186,6 +205,7 @@
 
 /datum/supply_pack/hydro/saru
 	name = "Saru crate"
+	desc = "Saru cubes! Instant saru, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/sarucubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -193,6 +213,7 @@
 
 /datum/supply_pack/hydro/sparra
 	name = "Sparra crate"
+	desc = "Sparra cubes! Instant sparra, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/sparracubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -200,6 +221,7 @@
 
 /datum/supply_pack/hydro/wolpin
 	name = "Wolpin crate"
+	desc = "Wolpin cubes! Instant wolpin, just add water! DO NOT INGEST."
 	contains = list (/obj/item/storage/box/monkeycubes/wolpincubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
@@ -207,12 +229,14 @@
 
 /datum/supply_pack/hydro/fennec
 	name = "Fennec crate"
+	desc = "Two fennecs in a crate."
 	cost = 60 //considering a corgi crate is 50, and you get two fennecs
 	containertype = /obj/structure/largecrate/animal/fennec
 	containername = "Fennec crate"
 
 /datum/supply_pack/hydro/fish
 	name = "Fish supply crate"
+	desc = "An assortment of seafood, kept on ice."
 	contains = list(
 			/obj/item/reagent_containers/food/snacks/lobster = 6,
 			/obj/item/reagent_containers/food/snacks/cuttlefish = 8,
@@ -224,6 +248,7 @@
 
 /datum/supply_pack/hydro/fennec_food
 	name = "Fennec treats crate"
+	desc = "Assorted treats fit for a fennec."
 	contains = list(
 			/obj/item/reagent_containers/food/snacks/locust = 6,
 			/obj/item/storage/box/wings/bucket = 2,
@@ -240,12 +265,14 @@
 
 /datum/supply_pack/hydro/jerboa
 	name = "Jerboa crate"
+	desc = "A jerboa in a box."
 	cost = 10
 	containertype = /obj/structure/largecrate/animal/jerboa
 	containername = "Jerboa crate"
 
 /datum/supply_pack/hydro/tits
 	name = "A pair of great tits"
+	desc = "Exactly what it sounds like."
 	cost = 10
 	containertype = /obj/structure/largecrate/tits
 	containername = "A pair of great tits"

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -112,7 +112,7 @@
 
 /datum/supply_pack/materials/linoleum
 	name = "Linoleum flooring"
-	desc = "Easy-to-clean, easy-to-lay, guaranteed non-stick linoleum."
+	desc = "Easy-to-clean, easy-to-lay, guaranteed non-stick linoleum floor tiles."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Linoleum crate"
 	cost = 15

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -6,6 +6,7 @@
 
 /datum/supply_pack/materials
 	group = "Materials"
+	desc = "A stack of fifty sheets (or ingots)."
 
 /datum/supply_pack/materials/metal50
 	name = "50 metal sheets"
@@ -58,6 +59,7 @@
 
 /datum/supply_pack/materials/carpet
 	name = "Imported standard carpet"
+	desc = "Three standard carpet designs in easy-to-lay tiles."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Imported carpet crate"
 	cost = 15
@@ -69,6 +71,7 @@
 
 /datum/supply_pack/materials/carpet_ornate
 	name = "Imported ornate carpet"
+	desc = "Ornate, high-quality carpet in easy-to-lay tiles."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Imported ornate carpet crate"
 	cost = 20
@@ -81,6 +84,7 @@
 
 /datum/supply_pack/materials/carpet_diamond
 	name = "Imported diamond carpet"
+	desc = "Classy diamond-patterned carpets in easy-to-lay tiles."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Imported diamond carpet crate"
 	cost = 30
@@ -95,6 +99,7 @@
 
 /datum/supply_pack/materials/retrocarpet
 	name = "Imported retro carpet"
+	desc = "Terran retro-style carpets in easy-to-lay tiles."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Imported retro carpet crate"
 	cost = 20
@@ -106,14 +111,16 @@
 					)
 
 /datum/supply_pack/materials/linoleum
-	name = "Linoleum"
+	name = "Linoleum flooring"
+	desc = "Easy-to-clean, easy-to-lay, guaranteed non-stick linoleum."
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Linoleum crate"
 	cost = 15
 	contains = list(/obj/fiftyspawner/linoleum)
 
 /datum/supply_pack/materials/concrete
-	name = "Concrete"
+	name = "Concrete blocks"
+	desc = "Cheap structural concrete blocks. Rebar sold seperately."
 	cost = 10
 	containertype = /obj/structure/closet/crate/grayson
 	contains = list(/obj/fiftyspawner/concrete)

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -8,7 +8,8 @@
 	group = "Medical"
 
 /datum/supply_pack/med/medical
-	name = "Medical crate"
+	name = "Basic Medical Supplies"
+	desc = "A selection of basic medical supplies, used for treating most simple maladies."
 	contains = list(
 			/obj/item/storage/firstaid/regular,
 			/obj/item/storage/firstaid/fire,
@@ -27,13 +28,15 @@
 
 /datum/supply_pack/med/bloodpack
 	name = "BloodPack crate"
+	desc = "Three boxes of bloodbags."
 	contains = list(/obj/item/storage/box/bloodpacks = 3)
 	cost = 10
-	containertype = /obj/structure/closet/crate/nanomed
+	containertype = /obj/structure/closet/crate/medical/blood
 	containername = "BloodPack crate"
 
 /datum/supply_pack/med/synthplas
 	name = "BloodPack (Synthplas) crate"
+	desc = "Six containers of synthetic blood replacement."
 	contains = list(/obj/item/reagent_containers/blood/synthplas = 6)
 	cost = 80
 	containertype = /obj/structure/closet/crate/nanomed
@@ -41,6 +44,7 @@
 
 /datum/supply_pack/med/bodybag
 	name = "Body bag crate"
+	desc = "Five boxes of body bags."
 	contains = list(/obj/item/storage/box/bodybags = 3)
 	cost = 10
 	containertype = /obj/structure/closet/crate/nanomed
@@ -48,6 +52,7 @@
 
 /datum/supply_pack/med/cryobag
 	name = "Stasis bag crate"
+	desc = "Three stasis bags."
 	contains = list(/obj/item/bodybag/cryobag = 3)
 	cost = 40
 	containertype = /obj/structure/closet/crate/nanomed
@@ -55,6 +60,7 @@
 
 /datum/supply_pack/med/surgery
 	name = "Surgery crate"
+	desc = "A set of replacement surgical equipment. Requires Medical access."
 	contains = list(
 			/obj/item/surgical/cautery,
 			/obj/item/surgical/surgicaldrill,
@@ -75,6 +81,7 @@
 
 /datum/supply_pack/med/deathalarm
 	name = "Death Alarm crate"
+	desc = "Death alarms, a now somewhat-antiquated means of tracking the status of vital personnel. Requires Medical access."
 	contains = list(
 			/obj/item/storage/box/cdeathalarm_kit,
 			/obj/item/storage/box/cdeathalarm_kit
@@ -86,6 +93,7 @@
 
 /datum/supply_pack/med/clotting
 	name = "Clotting Medicine crate"
+	desc = "Zeng Hu-branded \'clotting\' nanomedicine, used to treat internal bleeding without resorting to invasive surgeries. Requires Medical access."
 	contains = list(
 			/obj/item/storage/firstaid/clotting
 			)
@@ -96,6 +104,7 @@
 
 /datum/supply_pack/med/sterile
 	name = "Sterile equipment crate"
+	desc = "A pack of standard sterile equipment and medical scrubs."
 	contains = list(
 			/obj/item/clothing/under/rank/medical/scrubs/green = 2,
 			/obj/item/clothing/head/surgery/green = 2,
@@ -109,6 +118,7 @@
 
 /datum/supply_pack/med/extragear
 	name = "Medical surplus equipment"
+	desc = "Assorted surplus medical equipment. Requires Medical access."
 	contains = list(
 			/obj/item/storage/belt/medical = 3,
 			/obj/item/clothing/glasses/hud/health = 3,
@@ -121,7 +131,8 @@
 	access = access_medical
 
 /datum/supply_pack/med/cmogear
-	name = "Chief medical officer equipment"
+	name = "Chief Medical Officer equipment"
+	desc = "Standard equipment for the Chief Medical Officer. Requires CMO access."
 	contains = list(
 			/obj/item/storage/belt/medical,
 			/obj/item/radio/headset/heads/cmo,
@@ -146,6 +157,7 @@
 
 /datum/supply_pack/med/doctorgear
 	name = JOB_MEDICAL_DOCTOR + " equipment"
+	desc = "Standard equipment for basic Medical personnel. Requires Medical access."
 	contains = list(
 			/obj/item/storage/belt/medical,
 			/obj/item/radio/headset/headset_med,
@@ -169,6 +181,7 @@
 
 /datum/supply_pack/med/chemistgear
 	name = JOB_CHEMIST + " equipment"
+	desc = "Standard equipment for Chemists. Requires Chemistry access."
 	contains = list(
 			/obj/item/storage/box/beakers,
 			/obj/item/radio/headset/headset_med,
@@ -192,6 +205,7 @@
 
 /datum/supply_pack/med/paramedicgear
 	name = JOB_PARAMEDIC + " equipment"
+	desc = "Standard equipment for Paramedics and EMTs. Requires Medical Equipment access."
 	contains = list(
 			/obj/item/storage/belt/medical/emt,
 			/obj/item/radio/headset/headset_med,
@@ -220,6 +234,7 @@
 
 /datum/supply_pack/med/psychiatristgear
 	name = JOB_PSYCHIATRIST + " equipment"
+	desc = "Standard equipment for Psychiatrists. Requires Psychiatry access."
 	contains = list(
 			/obj/item/clothing/under/rank/psych,
 			/obj/item/radio/headset/headset_med,
@@ -239,8 +254,9 @@
 
 /datum/supply_pack/med/medicalscrubs
 	name = "Medical scrubs"
+	desc = "Plenty of extra surgical scrubs. Requires Medical Equipment access."
 	contains = list(
-			/obj/item/clothing/shoes/white = 3,,
+			/obj/item/clothing/shoes/white = 3,
 			/obj/item/clothing/under/rank/medical/scrubs = 3,
 			/obj/item/clothing/under/rank/medical/scrubs/green = 3,
 			/obj/item/clothing/under/rank/medical/scrubs/purple = 3,
@@ -260,6 +276,7 @@
 
 /datum/supply_pack/med/autopsy
 	name = "Autopsy equipment"
+	desc = "Supplies for conducting thorough autopsies. Requires Morgue access."
 	contains = list(
 			/obj/item/folder/white,
 			/obj/item/camera,
@@ -277,6 +294,7 @@
 
 /datum/supply_pack/med/medicaluniforms
 	name = "Medical uniforms"
+	desc = "A set of standard Medical uniforms. Requires Medical Equipment access."
 	contains = list(
 			/obj/item/clothing/shoes/white = 3,
 			/obj/item/clothing/under/rank/chief_medical_officer,
@@ -304,14 +322,15 @@
 
 /datum/supply_pack/med/medicalbiosuits
 	name = "Medical biohazard gear"
+	desc = "Several sets of Medical Biohazard suits. Requires Medical Equipment access."
 	contains = list(
-			/obj/item/clothing/head/bio_hood/modern = 3,
-			/obj/item/clothing/suit/bio_suit/modern = 3,
-			/obj/item/clothing/head/bio_hood/virology = 2,
+			/obj/item/clothing/head/bio_hood/scientist = 3,
+			/obj/item/clothing/suit/bio_suit/scientist = 3,
 			/obj/item/clothing/suit/bio_suit/cmo,
 			/obj/item/clothing/head/bio_hood/cmo,
-			/obj/item/clothing/mask/gas = 5,
-			/obj/item/tank/oxygen = 5,
+			/obj/item/clothing/shoes/white = 4,
+			/obj/item/clothing/mask/gas = 4,
+			/obj/item/tank/oxygen = 4,
 			/obj/item/storage/box/masks,
 			/obj/item/storage/box/gloves
 			)
@@ -322,6 +341,7 @@
 
 /datum/supply_pack/med/portablefreezers
 	name = "Portable freezers crate"
+	desc = "Several portable freezers, for safely transporting organs and other temperature-sensitive objects. Requires Medical Equipment access."
 	contains = list(/obj/item/storage/box/freezer = 7)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/veymed
@@ -330,6 +350,7 @@
 
 /datum/supply_pack/med/virus
 	name = "Virus culture crate"
+	desc = "Glass bottles with viral cultures. HANDLE WITH CARE. Requires Chief Medical Officer access."
 	contains = list(/obj/item/reagent_containers/glass/bottle/culture/cold = 1, /obj/item/reagent_containers/glass/bottle/culture/flu = 1)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/zenghu
@@ -338,6 +359,7 @@
 
 /datum/supply_pack/med/defib
 	name = "Defibrillator crate"
+	desc = "A pair of defibrillators."
 	contains = list(/obj/item/defib_kit = 2)
 	cost = 30
 	containertype = /obj/structure/closet/crate/veymed
@@ -345,6 +367,7 @@
 
 /datum/supply_pack/med/distillery
 	name = "Chemical distiller crate"
+	desc = "A portable reagent distillery, for advanced chemistry. Standalone model."
 	contains = list(/obj/machinery/portable_atmospherics/powered/reagent_distillery = 1)
 	cost = 50
 	containertype = /obj/structure/closet/crate/large/nanotrasen
@@ -352,6 +375,7 @@
 
 /datum/supply_pack/med/advdistillery
 	name = "Industrial Chemical distiller crate"
+	desc = "A portable industrial reagent distillery, for advanced chemistry. Requires atmospherics experience and equipment to set up."
 	contains = list(/obj/machinery/portable_atmospherics/powered/reagent_distillery/industrial = 1)
 	cost = 150
 	containertype = /obj/structure/closet/crate/large/xion
@@ -359,6 +383,7 @@
 
 /datum/supply_pack/med/oxypump
 	name = "Oxygen pump crate"
+	desc = "A mobile oxygen pump."
 	contains = list(/obj/machinery/oxygen_pump/mobile = 1)
 	cost = 125
 	containertype = /obj/structure/closet/crate/large/xion
@@ -366,6 +391,7 @@
 
 /datum/supply_pack/med/anestheticpump
 	name = "Anesthetic pump crate"
+	desc = "A mobile anaesthetic pump."
 	contains = list(/obj/machinery/oxygen_pump/mobile/anesthetic = 1)
 	cost = 130
 	containertype = /obj/structure/closet/crate/large/nanotrasen
@@ -373,29 +399,15 @@
 
 /datum/supply_pack/med/stablepump
 	name = "Portable stabilizer crate"
+	desc = "A portable stabilizer, for conducting sensitive operations such as heart transplants."
 	contains = list(/obj/machinery/oxygen_pump/mobile/stabilizer = 1)
 	cost = 175
 	containertype = /obj/structure/closet/crate/large/nanotrasen
 	containername = "Portable stabilizer crate"
 
-/datum/supply_pack/med/medicalbiosuits
-	contains = list(
-			/obj/item/clothing/head/bio_hood/scientist = 3,
-			/obj/item/clothing/suit/bio_suit/scientist = 3,
-			/obj/item/clothing/suit/bio_suit/virology = 3,
-			/obj/item/clothing/head/bio_hood/virology = 3,
-			/obj/item/clothing/suit/bio_suit/cmo,
-			/obj/item/clothing/head/bio_hood/cmo,
-			/obj/item/clothing/shoes/white = 7,
-			/obj/item/clothing/mask/gas = 7,
-			/obj/item/tank/oxygen = 7,
-			/obj/item/storage/box/masks,
-			/obj/item/storage/box/gloves
-			)
-	cost = 40
-
 /datum/supply_pack/med/virologybiosuits
 	name = "Virology biohazard gear"
+	desc = "Three virology biohazard suits plus associated equipment. Requires Medical Equipment access."
 	contains = list(
 			/obj/item/clothing/suit/bio_suit/virology = 3,
 			/obj/item/clothing/head/bio_hood/virology = 3,
@@ -409,20 +421,9 @@
 	containername = "Virology biohazard equipment"
 	access = access_medical_equip
 
-/datum/supply_pack/med/virus
-	name = "Virus culture crate"
-	contains = list(/obj/item/reagent_containers/glass/bottle/culture/cold = 1, /obj/item/reagent_containers/glass/bottle/culture/flu = 1)
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure
-	containername = "Virus culture crate"
-	access = access_medical_equip
-
-
-/datum/supply_pack/med/bloodpack
-	containertype = /obj/structure/closet/crate/medical/blood
-
 /datum/supply_pack/med/compactdefib
 	name = "Compact Defibrillator crate"
+	desc = "A compact defibrillator. Requires Medical Equipment access."
 	contains = list(/obj/item/defib_kit/compact = 1)
 	cost = 90
 	containertype = /obj/structure/closet/crate/secure

--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -19,6 +19,7 @@
 			/obj/item/deck/holder
 			)
 	name = "Trading Card Crate"
+	desc = "A random set of trading cards. Gotta collect \'em all!"
 	cost = 10
 	containertype = /obj/structure/closet/crate/oculum
 	containername = "cards crate"
@@ -35,8 +36,9 @@
 			/obj/item/toy/character/lich
 			)
 	name = "Miniatures Crate"
+	desc = "Four random prepainted tabletop gaming miniatures."
 	cost = 200
-	containertype = /obj/structure/closet/crate/oculum
+	containertype = /obj/structure/closet/crate/allico
 	containername = "Miniature Crate"
 
 /datum/supply_pack/randomised/misc/plushies
@@ -90,6 +92,7 @@
 			/obj/item/toy/plushie/shark)
 			//VOREStation Add End
 	name = "Plushies Crate"
+	desc = "Five random plushies from AlliCo's wide selection!"
 	cost = 15
 	containertype = /obj/structure/closet/crate/allico
 	containername = "Plushies Crate"
@@ -97,12 +100,14 @@
 /datum/supply_pack/misc/eftpos
 	contains = list(/obj/item/eftpos)
 	name = "EFTPOS scanner"
+	desc = "A handheld Electronic Funds Transfer At Point Of Sale scanner."
 	cost = 10
 	containertype = /obj/structure/closet/crate/nanotrasen
 	containername = "EFTPOS crate"
 
 /datum/supply_pack/misc/chaplaingear
 	name = JOB_CHAPLAIN + " equipment"
+	desc = "A standard set of liturgical equipment, suitable for various faiths."
 	contains = list(
 			/obj/item/clothing/under/rank/chaplain,
 			/obj/item/clothing/shoes/black,
@@ -121,6 +126,7 @@
 
 /datum/supply_pack/misc/hoverpod
 	name = "Hoverpod Shipment"
+	desc = "A hoverpod."
 	contains = list()
 	cost = 80
 	containertype = /obj/structure/largecrate/hoverpod
@@ -128,6 +134,7 @@
 
 /datum/supply_pack/randomised/misc/webbing
 	name = "Webbing crate"
+	desc = "Four random webbing sets from a modest selection."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/accessory/storage/black_vest,
@@ -144,6 +151,7 @@
 
 /datum/supply_pack/misc/holoplant
 	name = "Holoplant Pot"
+	desc = "A holoplant, for livening up places with none of the maintenance of a regular plant."
 	contains = list(/obj/machinery/holoplant/shipped)
 	cost = 15
 	containertype = /obj/structure/closet/crate/thinktronic
@@ -151,6 +159,7 @@
 
 /datum/supply_pack/misc/glucose_hypos
 	name = "Glucose Hypoinjectors"
+	desc = "A set of five glucose autoinjectors, for those with blood sugar issues."
 	contains = list(
 			/obj/item/reagent_containers/hypospray/autoinjector/biginjector/glucose = 5
 			)
@@ -161,6 +170,7 @@
 /datum/supply_pack/misc/mre_rations
 	num_contained = 6
 	name = "Emergency - MREs"
+	desc = "Six random ready-to-eat meals. Guaranteed to still be edible."
 	contains = list(/obj/item/storage/mre,
 					/obj/item/storage/mre/menu2,
 					/obj/item/storage/mre/menu3,
@@ -177,6 +187,7 @@
 
 /datum/supply_pack/misc/paste_rations
 	name = "Emergency - Paste"
+	desc = "Two packages of emergency nutripaste rations."
 	contains = list(
 			/obj/item/storage/mre/menu11 = 2
 			)
@@ -186,6 +197,7 @@
 
 /datum/supply_pack/misc/medical_rations
 	name = "Emergency - VitaPaste"
+	desc = "Two packages of high-grade \'VitaPaste\' rations."
 	contains = list(
 			/obj/item/storage/mre/menu13 = 2
 			)
@@ -195,6 +207,7 @@
 
 /datum/supply_pack/misc/reagentpump
 	name = "Machine - Pump"
+	desc = "A pump."
 	contains = list(
 			/obj/machinery/pump = 1
 			)
@@ -204,6 +217,7 @@
 
 /datum/supply_pack/misc/beltminer
 	name = "Belt-miner gear crate"
+	desc = "A set of supplies for belt mining. Requires Mining or Xenoarchaeology access."
 	contains = list(
 			/obj/item/gun/energy/particle = 2,
 			/obj/item/cell/device/weapon = 2,
@@ -221,6 +235,7 @@
 
 /datum/supply_pack/misc/jetpack
 	name = "jetpack (empty)"
+	desc = "An empty jetpack. Requires Mining, Xenoarchaeology, EVA, or Pilot's access."
 	contains = list(
 			/obj/item/tank/jetpack = 1
 			)
@@ -235,6 +250,7 @@
 
 /datum/supply_pack/randomised/misc/explorer_shield
 	name = JOB_EXPLORER + " shield"
+	desc = "A pair of shields for use by away teams. Requires EVA or Pilot's access."
 	num_contained = 2
 	contains = list(
 			/obj/item/shield/riot/explorer,
@@ -249,6 +265,7 @@
 
 /datum/supply_pack/misc/music_players
 	name = "music players (3)"
+	desc = "A trio of 'walkpod' portable music players."
 	contains = list(
 		/obj/item/walkpod = 3
 	)
@@ -258,6 +275,7 @@
 
 /datum/supply_pack/misc/juke_remotes
 	name = "jukebox remote speakers (2)"
+	desc = "A pair of remote speakers that can be linked to a jukebox."
 	contains = list(
 		/obj/item/juke_remote = 2
 	)
@@ -267,6 +285,7 @@
 
 /datum/supply_pack/misc/explorer_headsets
 	name = "shortwave-capable headsets (x4)"
+	desc = "Four headsets with shortwave fallback capacity. Requires Exploration, EVA, or Pilot's access."
 	contains = list(
 		/obj/item/radio/headset/explorer = 4
 	)
@@ -282,6 +301,7 @@
 
 /datum/supply_pack/misc/emergency_beacons
 	name = "emergency locator beacons (x4)"
+	desc = "Four personnel locator emergency beacons."
 	contains = list(
 		/obj/item/emergency_beacon = 4
 	)
@@ -291,6 +311,7 @@
 
 /datum/supply_pack/misc/random_corpo
 	name = "random corporate supply crate"
+	desc = "A random corporate supply crate. Could contain almost anything!"
 	contains = list(
 		/obj/random/multiple/corp_crate_supply
 	)
@@ -299,6 +320,7 @@
 
 /datum/supply_pack/misc/random_corpo_special
 	name = "special corporate supply crate"
+	desc = "A cache of corporate supplies. Could contain more valuable items than the random supply crate."
 	contains = list(
 		/obj/random/multiple/corp_crate
 	)

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -26,6 +26,7 @@
 
 /datum/supply_pack/munitions/egunpistol
 	name = "Weapons - Energy sidearms"
+	desc = "A pair of standard two-setting energy guns, from Lawson Arms. Requires Armory access."
 	contains = list(/obj/item/gun/energy/gun = 2)
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/lawson
@@ -34,6 +35,7 @@
 
 /datum/supply_pack/munitions/flareguns
 	name = "Weapons - Flare guns"
+	desc = "A set of flare-round ballistic arms and ammunition. Requires Armory access."
 	contains = list(
 			/obj/item/gun/projectile/sec/flash,
 			/obj/item/ammo_magazine/m45/flash,
@@ -47,6 +49,7 @@
 
 /datum/supply_pack/munitions/eweapons
 	name = "Weapons - Experimental weapons crate"
+	desc = "A pair of experimental x-ray laser rifles and portable energy shields. Requires Armory access."
 	contains = list(
 			/obj/item/gun/energy/xray = 2,
 			/obj/item/shield/energy = 2)
@@ -57,6 +60,7 @@
 
 /datum/supply_pack/munitions/energyweapons
 	name = "Weapons - Laser rifle crate"
+	desc = "A pair of standard laser rifles, from Hephaestus Arms. Requires Armory access."
 	contains = list(/obj/item/gun/energy/laser = 2) //VOREStation Edit - Made to be consistent with the energy guns crate.
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/heph
@@ -65,6 +69,7 @@
 
 /datum/supply_pack/munitions/shotgun
 	name = "Weapons - Shotgun crate"
+	desc = "Two pump-action combat shotguns and two boxes of 12-gauge ammunition. Requires Armory access."
 	contains = list(
 			/obj/item/ammo_magazine/ammo_box/b12g,
 			/obj/item/ammo_magazine/ammo_box/b12g/pellet,
@@ -105,7 +110,8 @@
 	access = access_armory
 */
 /datum/supply_pack/munitions/ionweapons
-	name = "Weapons - Electromagnetic Rifles"
+	name = "Weapons - Electromagnetic Pulse Rifles"
+	desc = "A pair of EMP rifles and low-power EMP grenades. Requires Armory access."
 	contains = list(
 			/obj/item/gun/energy/ionrifle = 2,
 			/obj/item/storage/box/empslite
@@ -116,7 +122,8 @@
 	access = access_armory
 
 /datum/supply_pack/munitions/ionpistols
-	name = "Weapons - Electromagnetic pistols"
+	name = "Weapons - Electromagnetic Pulse pistols"
+	desc = "A pair of EMP pistols and low-power EMP grenades. Requires Armory access."
 	contains = list(
 			/obj/item/gun/energy/ionrifle/pistol = 2,
 			/obj/item/storage/box/empslite
@@ -128,6 +135,7 @@
 
 /datum/supply_pack/munitions/bsmg
 	name = "Weapons - Ballistic SMGs"
+	desc = "A pair of WT-550 ballistic submachineguns. Requires Armory access."
 	contains = list(/obj/item/gun/projectile/automatic/wt550 = 2)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/ward
@@ -136,6 +144,7 @@
 
 /datum/supply_pack/munitions/brifle
 	name = "Weapons - Ballistic Rifles"
+	desc = "A pair of Z-8 ballistic rifles. Requires Armory access."
 	contains = list(/obj/item/gun/projectile/automatic/z8 = 2)
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/weapon
@@ -143,44 +152,48 @@
 	access = access_armory
 
 /datum/supply_pack/munitions/bolt_rifles_lethal
- 	name = "Weapons - Bolt-Action Rifles"
- 	contains = list(
- 			/obj/item/gun/projectile/shotgun/pump/rifle = 2,
- 			/obj/item/ammo_magazine/ammo_box/b762 = 4,
- 			)
- 	cost = 60
- 	containertype = /obj/structure/closet/crate/secure/weapon
- 	containername = "Ballistic Weapons crate"
- 	access = access_armory
+	name = "Weapons - Bolt-Action Rifles"
+	desc = "A pair of vintage 7.62mm bolt-action rifles, and four clips. Requires Armory access."
+	contains = list(
+			/obj/item/gun/projectile/shotgun/pump/rifle = 2,
+			/obj/item/ammo_magazine/ammo_box/b762 = 4,
+			)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Ballistic Weapons crate"
+	access = access_armory
 
 /datum/supply_pack/munitions/bolt_rifles_competitive
- 	name = "Weapons - Competitive shooting rifles"
- 	contains = list(
- 			/obj/item/assembly/timer,
- 			/obj/item/gun/projectile/shotgun/pump/rifle/practice = 2,
- 			/obj/item/ammo_magazine/clip/c762/practice = 4,
- 			/obj/item/target = 2,
- 			/obj/item/target/alien = 2,
- 			/obj/item/target/syndicate = 2
- 			)
- 	cost = 40
- 	containertype = /obj/structure/closet/crate/secure/weapon
- 	containername = "Ballistic Weapons crate"
- 	access = access_armory //VOREStation Edit - Guns are for the armory.
+	name = "Weapons - Competitive shooting rifles"
+	desc = "A set of 7.62mm bolt-action practice/sport rifles, a timer, and targets. Requires Armory access."
+	contains = list(
+			/obj/item/assembly/timer,
+			/obj/item/gun/projectile/shotgun/pump/rifle/practice = 2,
+			/obj/item/ammo_magazine/clip/c762/practice = 4,
+			/obj/item/target = 2,
+			/obj/item/target/alien = 2,
+			/obj/item/target/syndicate = 2
+			)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Ballistic Weapons crate"
+	access = access_armory //VOREStation Edit - Guns are for the armory.
 
 /datum/supply_pack/munitions/caseless
 	name = "Weapons - Prototype Caseless Rifle"
+	desc = "A prototype 5mm caseless automatic rifle. Requires Armory access."
 	contains = list(
 			/obj/item/gun/projectile/caseless/prototype,
 			/obj/item/ammo_magazine/m5mmcaseless = 3
 			)
 	cost = 60
-	containertype = /obj/structure/closet/crate/secure/gilthari
+	containertype = /obj/structure/closet/crate/secure/heph
 	containername = "Caseless rifle crate"
-	access = access_security
+	access = access_armory
 
 /datum/supply_pack/munitions/mrifle
 	name = "Weapons - Magnetic Rifles"
+	desc = "A pair of Hephaestus man-portable railguns. Requires Armory access."
 	contains = list(/obj/item/gun/magnetic/railgun/heater = 2)
 	cost = 120
 	containertype = /obj/structure/closet/crate/secure/heph
@@ -189,6 +202,7 @@
 
 /datum/supply_pack/munitions/mpistol
 	name = "Weapons - Magnetic Pistols"
+	desc = "A pair of Hephaestus man-portable rail-pistols. Requires Armory access."
 	contains = list(/obj/item/gun/magnetic/railgun/heater/pistol = 2)
 	cost = 200
 	containertype = /obj/structure/closet/crate/secure/heph
@@ -197,22 +211,25 @@
 
 /datum/supply_pack/munitions/mcarbine
 	name = "Weapons - Magnetic Carbines"
+	desc = "A pair of Lawson magnetic flechette carbines. Requires Armory access."
 	contains = list(/obj/item/gun/magnetic/railgun/flechette/sif = 2)
 	cost = 130
 	containertype = /obj/structure/closet/crate/secure/lawson
 	containername = "Magnetic weapon crate"
-	access = access_security
+	access = access_armory
 
 /datum/supply_pack/munitions/mshells
 	name = "Weapons - Magnetic Shells"
+	desc = "A set of ammo for magnetic weapons. Requires Armory access."
 	contains = list(/obj/item/magnetic_ammo = 3)
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Magnetic ammunition crate"
-	access = access_security
+	access = access_armory
 
 /datum/supply_pack/munitions/claymore
 	name = "Weapons - Melee - Claymores"
+	desc = "A pair of replica two-handed claymore swords. Requires Armory access."
 	contains = list(/obj/item/material/sword = 2)
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure/weapon
@@ -221,6 +238,7 @@
 
 /datum/supply_pack/munitions/shotgunammo
 	name = "Ammunition - Shotgun shells"
+	desc = "Four boxes of 12-gauge lethal ammunition; slug and shot. Requires Armory access."
 	contains = list(
 			/obj/item/ammo_magazine/ammo_box/b12g = 2,
 			/obj/item/ammo_magazine/ammo_box/b12g/pellet = 2
@@ -232,6 +250,7 @@
 
 /datum/supply_pack/munitions/beanbagammo
 	name = "Ammunition - Beanbag shells"
+	desc = "Three boxes of 12-gauge less-lethal ammunition; beanbag. Requires Armory access."
 	contains = list(/obj/item/ammo_magazine/ammo_box/b12g/beanbag = 3)
 	cost = 25
 	containertype = /obj/structure/closet/crate
@@ -240,6 +259,7 @@
 
 /datum/supply_pack/munitions/bsmgammo
 	name = "Ammunition - 9mm top mounted lethal"
+	desc = "Six magazines of lethal 9mm ammunition, top-mount. Requires Armory access."
 	contains = list(/obj/item/ammo_magazine/m9mmt = 6)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
@@ -248,14 +268,16 @@
 
 /datum/supply_pack/munitions/bsmgammorubber
 	name = "Ammunition - 9mm top mounted rubber"
+	desc = "Six magazines of less-lethal 9mm rubber ammunition, top-mount. Requires Armory access."
 	contains = list(/obj/item/ammo_magazine/m9mmt/rubber = 6)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Ballistic ammunition crate"
-	access = access_security
+	access = access_armory
 
 /datum/supply_pack/munitions/brifleammo
 	name = "Ammunition - 7.62mm lethal"
+	desc = "Six magazines of lethal 7.62mm ammunition. Requires Armory access."
 	contains = list(/obj/item/ammo_magazine/m762 = 6)
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/weapon
@@ -264,6 +286,7 @@
 
 /datum/supply_pack/munitions/pcellammo
 	name = "Ammunition - Power cell"
+	desc = "Three standard weapon power cells. Requires Security access."
 	contains = list(/obj/item/cell/device/weapon = 3)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/weapon
@@ -295,6 +318,7 @@
 
 /datum/supply_pack/munitions/ofd_charge_emp
 	name = "OFD Charge - EMP"
+	desc = "An obstruction field disperser charge, electromagnetic pulse core. Inert until catalyzed by the launcher. Requires Security access."
 	contains = list(
 			/obj/structure/ship_munition/disperser_charge/emp
 			)
@@ -305,6 +329,7 @@
 
 /datum/supply_pack/munitions/ofd_charge_explosive
 	name = "OFD Charge - Explosive"
+	desc = "An obstruction field disperser charge, explosive core. Inert until catalyzed by the launcher. Requires Security access."
 	contains = list(
 			/obj/structure/ship_munition/disperser_charge/explosive
 			)
@@ -315,6 +340,7 @@
 
 /datum/supply_pack/munitions/ofd_charge_incendiary
 	name = "OFD Charge - Incendiary"
+	desc = "An obstruction field disperser charge, incendiary core. Inert until catalyzed by the launcher. Requires Security access."
 	contains = list(
 			/obj/structure/ship_munition/disperser_charge/fire
 			)
@@ -325,6 +351,7 @@
 
 /datum/supply_pack/munitions/ofd_charge_mining
 	name = "OFD Charge - Mining"
+	desc = "An obstruction field disperser charge, mining core. Inert until catalyzed by the launcher. Requires Security access."
 	contains = list(
 			/obj/structure/ship_munition/disperser_charge/mining
 			)
@@ -335,6 +362,7 @@
 
 /datum/supply_pack/munitions/longsword
 	name = "Weapons - Melee -Longsword (Steel)"
+	desc = "A pair of replica two-handed longswords. Requires Armory access."
 	contains = list(
 			/obj/item/material/twohanded/longsword=2
 			)

--- a/code/datums/supplypacks/musical.dm
+++ b/code/datums/supplypacks/musical.dm
@@ -6,6 +6,7 @@
         /obj/item/instrument/eguitar,
     )
 	name = "string instruments"
+	desc = "A set of string instruments."
 	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "string instrument crate"
@@ -21,6 +22,7 @@
         /obj/item/instrument/bikehorn,
     )
 	name = "wind instruments"
+	desc = "A set of wind instruments."
 	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "wind instrument crate"
@@ -32,6 +34,7 @@
         /obj/item/instrument/musicalmoth
     )
 	name = "keyed instruments"
+	desc = "A set of keyboard-style instruments."
 	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "keyed instruments crate"

--- a/code/datums/supplypacks/recreation.dm
+++ b/code/datums/supplypacks/recreation.dm
@@ -13,6 +13,7 @@
 
 /datum/supply_pack/recreation/foam_weapons
 	name = "Foam Weapon Crate"
+	desc = "A set of foam weapons, from AlliCo."
 	contains = list(
 			/obj/item/material/sword/foam = 2,
 			/obj/item/material/twohanded/baseballbat/foam = 2,
@@ -25,6 +26,7 @@
 
 /datum/supply_pack/recreation/donksoftweapons
 	name = "Donk-Soft Weapon Crate"
+	desc = "Donk-Soft foam dart guns, and extra darts, from AlliCo."
 	contains = list(
 			/obj/item/ammo_magazine/ammo_box/foam = 2,
 			/obj/item/gun/projectile/shotgun/pump/toy = 2,
@@ -37,6 +39,7 @@
 
 /datum/supply_pack/recreation/donksoftborg
 	name = "Donk-Soft Cyborg Blaster Crate"
+	desc = "A pair of modular attachable Donk-Soft foam dart guns, for installation in various cyborg platforms."
 	contains = list(
 			/obj/item/borg/upgrade/no_prod/toygun = 2,
 			)
@@ -46,6 +49,7 @@
 
 /datum/supply_pack/recreation/donksoftvend
 	name = "Donk-Soft Vendor Crate"
+	desc = "A Donk-Soft vending machine."
 	contains = list()
 	cost = 75
 	containertype = /obj/structure/largecrate/donksoftvendor
@@ -53,6 +57,7 @@
 
 /datum/supply_pack/recreation/lasertag
 	name = "Lasertag equipment"
+	desc = "A standard set of Laser Tag equipment."
 	contains = list(
 			/obj/item/gun/energy/lasertag/red,
 			/obj/item/clothing/suit/redtag,
@@ -65,6 +70,7 @@
 
 /datum/supply_pack/recreation/artscrafts
 	name = "Arts and Crafts supplies"
+	desc = "A set of painting, drawing, and photography supplies."
 	contains = list(
 			/obj/item/storage/fancy/crayons,
 			/obj/item/storage/fancy/markers,
@@ -89,6 +95,7 @@
 
 /datum/supply_pack/recreation/painters
 	name = "Station Painting Supplies"
+	desc = "A set of supplies for turning the walls and floors into your canvas."
 	cost = 10
 	containername = "station painting supplies crate"
 	containertype = /obj/structure/closet/crate/grayson
@@ -110,6 +117,7 @@
 
 /datum/supply_pack/recreation/cheapbait
 	name = "Cheap Fishing Bait"
+	desc = "Some cheap, low-quality bait for fishing with."
 	cost = 10
 	containername = "cheap bait crate"
 	containertype = /obj/structure/closet/crate/freezer
@@ -119,6 +127,7 @@
 
 /datum/supply_pack/randomised/recreation/cheapbait
 	name = "Deluxe Fishing Bait"
+	desc = "High-quality bait for masterful fishing."
 	cost = 40
 	containername = "deluxe bait crate"
 	containertype = /obj/structure/closet/crate/carp
@@ -130,6 +139,7 @@
 
 /datum/supply_pack/recreation/ltagturrets
 	name = "Laser Tag Turrets"
+	desc = "A pair of portable laser tag turrets."
 	cost = 40
 	containername = "laser tag turret crate"
 	containertype = /obj/structure/closet/crate/ward
@@ -140,6 +150,7 @@
 
 /datum/supply_pack/recreation/monster_bait
 	name = "Monster Bait Toy"
+	desc = "A simple toy for playing with various critters."
 	cost = 5
 	containername = "monster bait crate"
 	containertype = /obj/structure/closet/crate/allico
@@ -159,6 +170,7 @@
 */
 /datum/supply_pack/recreation/restraints
 	name = "Recreational Restraints"
+	desc = "You know what these are for. If you have to ask, you're too innocent for this end of the galaxy."
 	contains = list(
 			/obj/item/clothing/mask/muzzle,
 			/obj/item/clothing/glasses/sunglasses/blindfold,
@@ -178,6 +190,7 @@
 
 /datum/supply_pack/recreation/wolfgirl_cosplay_crate
 	name = "Wolfgirl Cosplay Crate"
+	desc = "A set of cosplay supplies."
 	contains = list(
 			/obj/item/clothing/head/fluff/wolfgirl = 1,
 			/obj/item/clothing/shoes/fluff/wolfgirl = 1,
@@ -191,6 +204,7 @@
 
 /datum/supply_pack/randomised/recreation/figures
 	name = "Action figures crate"
+	desc = "Five random action figures."
 	num_contained = 5
 	contains = list(
 			/obj/random/action_figure/supplypack
@@ -201,6 +215,7 @@
 
 /datum/supply_pack/recreation/collars
 	name = "Collar bundle"
+	desc = "Collars."
 	contains = list(
 			/obj/item/clothing/accessory/collar/shock = 1,
 			/obj/item/clothing/accessory/collar/spike = 1,
@@ -216,6 +231,7 @@
 
 /datum/supply_pack/recreation/shiny
 	name = "Shiny Clothing"
+	desc = "Questionably shiny clothing. If you have to ask, you're too innocent for this end of the galaxy."
 	contains = list(
 			/obj/item/clothing/mask/muzzle/ballgag = 1,
 			/obj/item/clothing/mask/muzzle/ballgag/ringgag = 1,
@@ -239,6 +255,7 @@
 //3/19/21
 /datum/supply_pack/recreation/smoleworld
 	name = "Smole Bulding Bricks"
+	desc = "A set of interlocking plastic bricks for building things with."
 	contains = list(
 			/obj/item/storage/smolebrickcase, /obj/item/storage/smolebrickcase,
 			)
@@ -248,6 +265,7 @@
 
 /datum/supply_pack/recreation/smolesnackplanets
 	name = "Snack planets pack"
+	desc = "Bags of planet-shaped snacks."
 	num_contained = 4
 	contains = list(
 			/obj/item/storage/bagoplanets, /obj/item/storage/bagoplanets
@@ -258,6 +276,7 @@
 
 /datum/supply_pack/recreation/pinkpillows
 	name = "Pillow Crate - Pink"
+	desc = "Six pink pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow = 6
 	)
@@ -266,6 +285,7 @@
 
 /datum/supply_pack/recreation/tealpillows
 	name = "Pillow Crate - Teal"
+	desc = "Six teal pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/teal = 6
 	)
@@ -274,6 +294,7 @@
 
 /datum/supply_pack/recreation/whitepillows
 	name = "Pillow Crate - White"
+	desc = "Six white pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/white = 6
 	)
@@ -282,6 +303,7 @@
 
 /datum/supply_pack/recreation/blackpillows
 	name = "Pillow Crate - Black"
+	desc = "Six black pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/black = 6
 	)
@@ -290,6 +312,7 @@
 
 /datum/supply_pack/recreation/redpillows
 	name = "Pillow Crate - Red"
+	desc = "Six red pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/red = 6
 	)
@@ -298,6 +321,7 @@
 
 /datum/supply_pack/recreation/greenpillows
 	name = "Pillow Crate - Green"
+	desc = "Six green pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/green = 6
 	)
@@ -306,6 +330,7 @@
 
 /datum/supply_pack/recreation/orangepillows
 	name = "Pillow Crate - Orange"
+	desc = "Six orange pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/orange = 6
 	)
@@ -314,6 +339,7 @@
 
 /datum/supply_pack/recreation/yellowpillows
 	name = "Pillow Crate - Yellow"
+	desc = "Six yellow pillows."
 	contains = list(
 		/obj/item/bedsheet/pillow/yellow = 6
 	)

--- a/code/datums/supplypacks/robotics.dm
+++ b/code/datums/supplypacks/robotics.dm
@@ -13,6 +13,7 @@
 
 /datum/supply_pack/robotics/robotics_assembly
 	name = "Robotics assembly crate"
+	desc = "An assortment of basic robotics assembly supplies. Requires Robotics access."
 	contains = list(
 			/obj/item/assembly/prox_sensor = 3,
 			/obj/item/storage/toolbox/electrical,
@@ -54,6 +55,7 @@
 
 /datum/supply_pack/robotics/robolimbs/morpheus
 	name = "Morpheus robolimb blueprints"
+	desc = "A disk of robolimbs from the Morpheus catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/morpheus)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/morpheus
@@ -62,6 +64,7 @@
 
 /datum/supply_pack/robotics/robolimbs/cybersolutions
 	name = "Cyber Solutions robolimb blueprints"
+	desc = "A disk of robolimbs from the Cyber Solutions catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/cybersolutions)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/cybersolutions
@@ -70,6 +73,7 @@
 
 /datum/supply_pack/robotics/robolimbs/xion
 	name = "Xion robolimb blueprints"
+	desc = "A disk of robolimbs from the Xion Manufacturing catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/xion)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/xion
@@ -78,6 +82,7 @@
 
 /datum/supply_pack/robotics/robolimbs/grayson
 	name = "Grayson robolimb blueprints"
+	desc = "A disk of robolimbs from the Grayson Industries catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/grayson)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/grayson
@@ -86,6 +91,7 @@
 
 /datum/supply_pack/robotics/robolimbs/hephaestus
 	name = "Hephaestus robolimb blueprints"
+	desc = "A disk of robolimbs from the Hephaestus Arms catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/hephaestus)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/heph
@@ -94,6 +100,7 @@
 
 /datum/supply_pack/robotics/robolimbs/wardtakahashi
 	name = "Ward-Takahashi robolimb blueprints"
+	desc = "A disk of robolimbs from the Ward-Takahashi catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/wardtakahashi)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/ward
@@ -102,6 +109,7 @@
 
 /datum/supply_pack/robotics/robolimbs/zenghu
 	name = "Zeng Hu robolimb blueprints"
+	desc = "A disk of robolimbs from the Zeng Hu Medical catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/zenghu)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/zenghu
@@ -110,6 +118,7 @@
 
 /datum/supply_pack/robotics/robolimbs/bishop
 	name = "Bishop robolimb blueprints"
+	desc = "A disk of robolimbs from the Bishop catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/bishop)
 	cost = 70
 	containertype = /obj/structure/closet/crate/secure/bishop
@@ -118,15 +127,16 @@
 
 /datum/supply_pack/robotics/robolimbs/cenilimicybernetics
 	name = "Cenilimi Cybernetics robolimb blueprints"
+	desc = "A disk of teshari robolimbs from the Cenilimi Cybernetics catalogue. Requires Robotics access."
 	contains = list(/obj/item/disk/limb/cenilimicybernetics)
 	cost = 45
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "Robolimb blueprints (Cenilimi Cybernetics)"
 	access = access_robotics
 
-
 /datum/supply_pack/robotics/mecha_ripley
 	name = "Circuit Crate (\"Ripley\" APLU)"
+	desc = "A set of standard core components for a Ripley Power-Loader mech, plus an assembly manual. Requires Robotics access."
 	contains = list(
 			/obj/item/book/manual/ripley_build_and_repair,
 			/obj/item/circuitboard/mecha/ripley/main,
@@ -139,6 +149,7 @@
 
 /datum/supply_pack/robotics/mecha_odysseus
 	name = "Circuit Crate (\"Odysseus\")"
+	desc = "A set of standard core components for an Odysseus Medical Response mech. Requires Robotics access."
 	contains = list(
 			/obj/item/circuitboard/mecha/odysseus/peripherals,
 			/obj/item/circuitboard/mecha/odysseus/main
@@ -157,6 +168,7 @@
 			/obj/item/kit/paint/ripley/flames_blue
 			)
 	name = "Random APLU modkit"
+	desc = "A random Ripley customization kit, used to modify a mech's paint job."
 	cost = 200
 	containertype = /obj/structure/closet/crate/xion
 	containername = "heavy crate"
@@ -168,6 +180,7 @@
 			/obj/item/kit/paint/durand/phazon
 			)
 	name = "Random Durand exosuit modkit"
+	desc = "A random Durand customization kit, used to modify a mech's paint job."
 	containertype = /obj/structure/closet/crate/heph
 
 /datum/supply_pack/randomised/robotics/exosuit_mod/gygax
@@ -177,10 +190,12 @@
 			/obj/item/kit/paint/gygax/recitence
 			)
 	name = "Random Gygax exosuit modkit"
+	desc = "A random Gygax customization kit, used to modify a mech's paint job."
 	containertype = /obj/structure/closet/crate/heph
 
 /datum/supply_pack/robotics/jumper_cables
 	name = "Jumper kit crate"
+	desc = "A pair of jumper kits, for restarting damaged synthetics."
 	contains = list(
 			/obj/item/defib_kit/jumper_kit = 2
 			)
@@ -191,6 +206,7 @@
 
 /datum/supply_pack/robotics/restrainingbolt
 	name = "Restraining bolt crate"
+	desc = "A pair of restraining bolts and an implanter. Requires Robotics access."
 	contains = list(
 			/obj/item/implanter = 1,
 			/obj/item/implantcase/restrainingbolt = 2
@@ -202,6 +218,7 @@
 
 /datum/supply_pack/robotics/bike
 	name = "Spacebike Crate"
+	desc = "A spacebike. Drive with extreme care."
 	contains = list()
 	cost = 350
 	containertype = /obj/structure/largecrate/vehicle/bike
@@ -209,6 +226,7 @@
 
 /datum/supply_pack/robotics/quadbike
 	name = "ATV Crate"
+	desc = "An all-terrain vehicle in a crate. Can tow a trailer."
 	contains = list()
 	cost = 300
 	containertype = /obj/structure/largecrate/vehicle/quadbike
@@ -216,6 +234,7 @@
 
 /datum/supply_pack/robotics/quadtrailer
 	name = "ATV Trailer Crate"
+	desc = "A trailer for an all-terrain vehicle."
 	contains = list()
 	cost = 250
 	containertype = /obj/structure/largecrate/vehicle/quadtrailer
@@ -223,6 +242,7 @@
 
 /datum/supply_pack/robotics/mecha_gopher
 	name = "Circuit Crate (\"Gopher\" APLU)"
+	desc = "A set of standard core components for a Gopher micro-mech. Requires Robotics access."
 	contains = list(
 			/obj/item/circuitboard/mecha/gopher/main,
 			/obj/item/circuitboard/mecha/gopher/peripherals
@@ -234,6 +254,7 @@
 
 /datum/supply_pack/robotics/mecha_polecat
 	name = "Circuit Crate (\"Polecat\" APLU)"
+	desc = "A set of standard core components for a Polecat micro-mech. Requires Robotics access."
 	contains = list(
 			/obj/item/circuitboard/mecha/polecat/main,
 			/obj/item/circuitboard/mecha/polecat/peripherals,
@@ -246,6 +267,7 @@
 
 /datum/supply_pack/robotics/mecha_weasel
 	name = "Circuit Crate (\"Weasel\" APLU)"
+	desc = "A set of standard core components for a Weasel micro-mech. Requires Robotics access."
 	contains = list(
 			/obj/item/circuitboard/mecha/weasel/main,
 			/obj/item/circuitboard/mecha/weasel/peripherals,
@@ -258,6 +280,7 @@
 
 /datum/supply_pack/robotics/some_robolimbs
 	name = "Basic Robolimb Blueprints"
+	desc = "A set of standard cyberlimb blueprints, from the Morpheus, Xion, and Talon LLC catalogues. Requires Robotics access."
 	contains = list(
 			/obj/item/disk/limb/morpheus,
 			/obj/item/disk/limb/xion,
@@ -270,6 +293,7 @@
 
 /datum/supply_pack/robotics/all_robolimbs
 	name = "Advanced Robolimb Blueprints"
+	desc = "A wide selection of advanced cyberlimb blueprints. Includes hyperrealistic prosthetic designs from Vey-Medical and DSI. Requires Robotics access."
 	contains = list(
 			/obj/item/disk/limb/bishop,
 			/obj/item/disk/limb/hephaestus,

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -7,6 +7,7 @@
 
 /datum/supply_pack/sci/coolanttank
 	name = "Coolant tank crate"
+	desc = "Contains a coolant tank dispenser."
 	contains = list(/obj/structure/reagent_dispensers/coolanttank)
 	cost = 15
 	containertype = /obj/structure/closet/crate/large/aether
@@ -14,6 +15,7 @@
 
 /datum/supply_pack/sci/phoron
 	name = "Phoron research crate"
+	desc = "Assorted supplies for phoron research. Requires Toxins Storage access."
 	contains = list(
 			/obj/item/tank/phoron = 3,
 			/obj/item/tank/oxygen = 3,
@@ -30,6 +32,7 @@
 
 /datum/supply_pack/sci/exoticseeds
 	name = "Exotic seeds crate"
+	desc = "A supply of exotic seeds, for xenobotanical and hydroponics use. Requires Hydroponics access."
 	contains = list(
 			/obj/item/seeds/replicapod = 2,
 			/obj/item/seeds/ambrosiavulgarisseed = 2,
@@ -45,6 +48,7 @@
 
 /datum/supply_pack/sci/integrated_circuit_printer
 	name = "Integrated circuit printer"
+	desc = "Two portable integrated circuit printers."
 	contains = list(/obj/item/integrated_circuit_printer = 2)
 	cost = 15
 	containertype = /obj/structure/closet/crate/ward
@@ -52,13 +56,15 @@
 
 /datum/supply_pack/sci/integrated_circuit_printer_upgrade
 	name = "Integrated circuit printer upgrade - advanced designs"
+	desc = "An upgrade disk for integrated circuit printers that unlocks advanced circuit designs."
 	contains = list(/obj/item/disk/integrated_circuit/upgrade/advanced)
 	cost = 30
 	containertype = /obj/structure/closet/crate/ward
-	containername = "Integrated circuit crate"
+	containername = "Integrated circuit upgrade crate"
 
 /datum/supply_pack/sci/xenoarch
 	name = "Xenoarchaeology Tech crate"
+	desc = "A set of standard xenoarchaeological supplies. Requires Xenoarchaeology access."
 	contains = list(
 				/obj/item/pickaxe/excavationdrill,
 				/obj/item/xenoarch_multi_tool,
@@ -92,6 +98,7 @@
 
 /datum/supply_pack/sci/pred
 	name = "Dangerous Predator crate"
+	desc = "Contains a dangerous predator. Requires Xenobiology access."
 	cost = 40
 	containertype = /obj/structure/largecrate/animal/pred
 	containername = "Dangerous Predator crate"
@@ -99,6 +106,7 @@
 
 /datum/supply_pack/sci/pred_doom
 	name = "EXTREMELY Dangerous Predator crate"
+	desc = "Contains an extremely dangerous predator. Requires Xenobiology access."
 	cost = 200
 	containertype = /obj/structure/largecrate/animal/dangerous
 	containername = "EXTREMELY Dangerous Predator crate"
@@ -107,6 +115,7 @@
 
 /datum/supply_pack/sci/weretiger
 	name = "Exotic Weretiger crate"
+	desc = "Contains a \'weretiger\'. EXTREMELY DANGEROUS. Requires Xenobiology access."
 	cost = 55
 	containertype = /obj/structure/largecrate/animal/weretiger
 	containername = "Weretiger crate"

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -14,6 +14,7 @@
 
 /datum/supply_pack/randomised/security/armor
 	name = "Armor - Security armor"
+	desc = "A set of standard security armor vests, chosen at random. Requires Armory access."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/suit/storage/vest,
@@ -35,6 +36,7 @@
 
 /datum/supply_pack/security/carriersblack
 	name = "Armor - Black modular armor"
+	desc = "A set of modular black armor."
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier,
 			/obj/item/clothing/accessory/armor/armguards,
@@ -47,6 +49,7 @@
 
 /datum/supply_pack/security/carriersblue
 	name = "Armor - Blue modular armor"
+	desc = "A set of modular blue armor."
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier/blue,
 			/obj/item/clothing/accessory/armor/armguards/blue,
@@ -59,6 +62,7 @@
 
 /datum/supply_pack/security/carriersgreen
 	name = "Armor - Green modular armor"
+	desc = "A set of modular green armor."
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier/green,
 			/obj/item/clothing/accessory/armor/armguards/green,
@@ -71,6 +75,7 @@
 
 /datum/supply_pack/security/carriersnavy
 	name = "Armor - Navy modular armor"
+	desc = "A set of modular navy blue armor."
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier/navy,
 			/obj/item/clothing/accessory/armor/armguards/navy,
@@ -83,6 +88,7 @@
 
 /datum/supply_pack/security/carrierstan
 	name = "Armor - Tan modular armor"
+	desc = "A set of modular tan armor."
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier/tan,
 			/obj/item/clothing/accessory/armor/armguards/tan,
@@ -95,6 +101,7 @@
 
 /datum/supply_pack/security/armorplate
 	name = "Armor - Security light armor plate"
+	desc = "A lightweight armor insert plate."
 	contains = list(
 			/obj/item/clothing/accessory/armor/armorplate,
 			)
@@ -104,6 +111,7 @@
 
 /datum/supply_pack/security/armorplatestab
 	name = "Armor - Security stab armor plate"
+	desc = "A lightweight stabproof armor insert plate."
 	contains = list(
 			/obj/item/clothing/accessory/armor/armorplate/stab,
 			)
@@ -113,6 +121,7 @@
 
 /datum/supply_pack/security/armorplatemedium
 	name = "Armor - Security armor plate"
+	desc = "A mediumweight armor insert plate."
 	contains = list(
 			/obj/item/clothing/accessory/armor/armorplate/medium,
 			)
@@ -122,6 +131,7 @@
 
 /datum/supply_pack/security/armorplatetac
 	name = "Armor - Security medium armor plate"
+	desc = "A tactical armor insert plate."
 	contains = list(
 			/obj/item/clothing/accessory/armor/armorplate/tactical,
 			)
@@ -131,6 +141,7 @@
 
 /datum/supply_pack/randomised/security/carriers
 	name = "Armor - Surplus plate carriers"
+	desc = "A selection of random plate carriers."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/suit/armor/pcarrier,
@@ -146,6 +157,7 @@
 
 /datum/supply_pack/security/carriertags
 	name = "Armor - Plate carrier tags"
+	desc = "Various identifying tags for attachment to a plate carrier set."
 	contains = list(
 			/obj/item/clothing/accessory/armor/tag,
 			/obj/item/clothing/accessory/armor/tag/nt,
@@ -164,6 +176,7 @@
 
 /datum/supply_pack/security/helmcovers
 	name = "Armor - Helmet covers"
+	desc = "A set of helmet covers, for attachment to standard issue helmets."
 	contains = list(
 			/obj/item/clothing/accessory/armor/helmcover/blue,
 			/obj/item/clothing/accessory/armor/helmcover/blue,
@@ -180,6 +193,7 @@
 
 /datum/supply_pack/randomised/security/armorplates
 	name = "Armor - Surplus security armor plates"
+	desc = "A random selection of attachable armor insert plates."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/accessory/armor/armorplate,
@@ -199,6 +213,7 @@
 
 /datum/supply_pack/randomised/security/carrierarms
 	name = "Armor - Surplus security armguard attachments"
+	desc = "A random selection of attachable armor arm guards."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/accessory/armor/armguards,
@@ -216,6 +231,7 @@
 
 /datum/supply_pack/randomised/security/carrierlegs
 	name = "Armor - Surplus security legguard attachments"
+	desc = "A random selection of attachable armor leg guards."
 	num_contained = 5
 	contains = list(
 			/obj/item/clothing/accessory/armor/legguards,
@@ -252,6 +268,7 @@
 
 /datum/supply_pack/security/riot_gear
 	name = "Gear - Riot"
+	desc = "A pack of riot control gear: less-lethal weapons, batons, shields, and handcuffs. Requires Armory access."
 	contains = list(
 			/obj/item/melee/baton = 3,
 			/obj/item/shield/riot = 3,
@@ -267,6 +284,7 @@
 
 /datum/supply_pack/security/riot_armor
 	name = "Armor - Riot"
+	desc = "A pack of riot suppression armor. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/head/helmet/riot,
 			/obj/item/clothing/suit/armor/riot,
@@ -280,6 +298,7 @@
 
 /datum/supply_pack/security/riot_plates
 	name = "Armor - Riot plates"
+	desc = "A fully-equipped modular riot suppression suit. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/head/helmet/riot,
 			/obj/item/clothing/suit/armor/pcarrier/riot/full
@@ -301,6 +320,7 @@
 
 /datum/supply_pack/security/ablative_armor
 	name = "Armor - Ablative"
+	desc = "A full set of laser-resistant armor. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/head/helmet/laserproof,
 			/obj/item/clothing/suit/armor/laserproof,
@@ -314,6 +334,7 @@
 
 /datum/supply_pack/security/ablative_plates
 	name = "Armor - Ablative plates"
+	desc = "A fully-equipped modular laser-resistant armor suit. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/head/helmet/laserproof,
 			/obj/item/clothing/suit/armor/pcarrier/laserproof/full
@@ -325,6 +346,7 @@
 
 /datum/supply_pack/security/bullet_resistant_armor
 	name = "Armor - Ballistic"
+	desc = "A full set of ballistic-resistant armor. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/head/helmet/bulletproof,
 			/obj/item/clothing/suit/armor/bulletproof,
@@ -389,6 +411,7 @@
 
 /datum/supply_pack/security/flexitac
 	name = "Armor - Tactical Light"
+	desc = "A full set of light tactical armor. Requires Armory access."
 	containertype = /obj/structure/closet/crate/secure/saare
 	containername = "Tactical Light armor crate"
 	cost = 75
@@ -412,6 +435,7 @@
 
 /datum/supply_pack/security/securitybarriers
 	name = "Misc - Security Barriers"
+	desc = "Four quick-deployment security barriers."
 	contains = list(/obj/machinery/deployable/barrier = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/large/secure/heph
@@ -419,6 +443,7 @@
 
 /datum/supply_pack/security/securityshieldgen
 	name = "Misc - Wall shield generators"
+	desc = "Four portable wall shield generators. Requires Teleporter access."
 	contains = list(/obj/machinery/shieldwallgen = 4)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/heph
@@ -427,6 +452,7 @@
 
 /datum/supply_pack/randomised/security/holster
 	name = "Gear - Holsters"
+	desc = "Four random holsters."
 	num_contained = 4
 	contains = list(
 			/obj/item/clothing/accessory/holster,
@@ -441,6 +467,7 @@
 
 /datum/supply_pack/security/extragear
 	name = "Gear - Security surplus equipment"
+	desc = "An assortment of surplus security equipment."
 	contains = list(
 			/obj/item/storage/belt/security = 3,
 			/obj/item/clothing/glasses/sunglasses/sechud = 3,
@@ -454,6 +481,7 @@
 
 /datum/supply_pack/security/detectivegear
 	name = "Forensic - Investigation equipment"
+	desc = "Standard issue equipment for detectives and forensic investigators. Requires Forensics access."
 	contains = list(
 			/obj/item/storage/box/evidence = 2,
 			/obj/item/clothing/suit/storage/vest/detective,
@@ -482,6 +510,7 @@
 
 /datum/supply_pack/security/detectivescan
 	name = "Forensic - Scanning Equipment"
+	desc = "Additional specialist forensic equipment. Requires Forensics access."
 	contains = list(
 			/obj/item/mass_spectrometer,
 			/obj/item/reagent_scanner,
@@ -495,6 +524,7 @@
 
 /datum/supply_pack/security/detectiveclothes
 	name = "Forensic - Investigation apparel"
+	desc = "Apparel for the discerning detective (or forensics expert). Requires Forensics access."
 	contains = list(
 			/obj/item/clothing/under/det/black = 2,
 			/obj/item/clothing/under/det/grey = 2,
@@ -517,6 +547,7 @@
 
 /datum/supply_pack/security/officergear
 	name = "Gear - Officer equipment"
+	desc = "Standard issue equipment for security officers. Requires Brig access."
 	contains = list(
 			/obj/item/clothing/suit/storage/vest/officer,
 			/obj/item/clothing/head/helmet,
@@ -547,6 +578,7 @@
 
 /datum/supply_pack/security/wardengear
 	name = "Gear - " + JOB_WARDEN + " equipment"
+	desc = "Standard issue equipment for Wardens. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/suit/storage/vest/warden,
 			/obj/item/clothing/under/rank/warden,
@@ -576,6 +608,7 @@
 
 /datum/supply_pack/security/headofsecgear
 	name = "Gear - " + JOB_HEAD_OF_SECURITY + " equipment"
+	desc = "Standard issue equipment for the Head of Security. Requires Head of Security access."
 	contains = list(
 			/obj/item/clothing/head/helmet/HoS,
 			/obj/item/clothing/suit/storage/vest/hos,
@@ -603,6 +636,7 @@
 
 /datum/supply_pack/security/securityclothing
 	name = "Misc - Security uniform red"
+	desc = "A set of standard red security uniforms."
 	contains = list(
 			/obj/item/storage/backpack/satchel/sec = 2,
 			/obj/item/storage/backpack/security = 2,
@@ -621,6 +655,7 @@
 
 /datum/supply_pack/security/navybluesecurityclothing
 	name = "Misc - Security uniform navy blue"
+	desc = "A set of alternative navy blue security uniforms."
 	contains = list(
 			/obj/item/storage/backpack/satchel/sec = 2,
 			/obj/item/storage/backpack/security = 2,
@@ -642,6 +677,7 @@
 
 /datum/supply_pack/security/corporatesecurityclothing
 	name = "Misc - Security uniform corporate"
+	desc = "A set of alternative corporate black-and-red security uniforms."
 	contains = list(
 			/obj/item/storage/backpack/satchel/sec = 2,
 			/obj/item/storage/backpack/security = 2,
@@ -662,6 +698,7 @@
 
 /datum/supply_pack/security/biosuit
 	name = "Gear - Security biohazard gear"
+	desc = "Three sets of security biohazard equipment. Requires Security access."
 	contains = list(
 			/obj/item/clothing/head/bio_hood/security = 3,
 			/obj/item/clothing/under/rank/security = 3,
@@ -679,6 +716,7 @@
 
 /datum/supply_pack/security/posters
 	name = "Gear - Morale Posters"
+	desc = "Six \'morale enhancement\' posters."
 	contains = list(
 			/obj/item/poster/nanotrasen = 6
 			)
@@ -708,21 +746,9 @@
 	one_access = TRUE
 */
 
-/datum/supply_pack/security/biosuit
-	contains = list(
-			/obj/item/clothing/head/bio_hood/security = 3,
-			/obj/item/clothing/under/rank/security = 3,
-			/obj/item/clothing/suit/bio_suit/security = 3,
-			/obj/item/clothing/shoes/white = 3,
-			/obj/item/clothing/mask/gas = 3,
-			/obj/item/tank/oxygen = 3,
-			/obj/item/clothing/gloves/sterile/latex,
-			/obj/item/storage/box/gloves
-			)
-	cost = 40
-
 /datum/supply_pack/security/trackingimplant
 	name = "Implants - Tracking"
+	desc = "A set of tracking implants. Requires Security access."
 	contains = list(
 			/obj/item/storage/box/trackimp = 1
 			)
@@ -733,6 +759,7 @@
 
 /datum/supply_pack/security/chemicalimplant
 	name = "Implants - Chemical"
+	desc = "A set of chemical implants. Requires Security access."
 	contains = list(
 			/obj/item/storage/box/chemimp = 1
 			)

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -8,6 +8,7 @@
 
 /datum/supply_pack/supply/food
 	name = "Kitchen supply crate"
+	desc = "An assortment of standard kitchen supplies, fit for preparing a variety of basic meals."
 	contains = list(
 			/obj/item/reagent_containers/food/condiment/carton/flour = 6,
 			/obj/item/reagent_containers/food/drinks/milk = 3,
@@ -24,6 +25,7 @@
 
 /datum/supply_pack/supply/fancyfood
 	name = "Artisanal food delivery"
+	desc = "High-quality flour and sugar from luxury Centauri Foods brands."
 	contains = list(
 			/obj/item/reagent_containers/food/condiment/carton/flour/rustic = 6,
 			/obj/item/reagent_containers/food/condiment/carton/sugar/rustic = 6
@@ -35,6 +37,7 @@
 
 /datum/supply_pack/supply/toner
 	name = "Toner cartridges"
+	desc = "A set of six toner cartridges, for use in printers."
 	contains = list(/obj/item/toner = 6)
 	cost = 10
 	containertype = /obj/structure/closet/crate/ummarcar
@@ -42,6 +45,7 @@
 
 /datum/supply_pack/supply/janitor
 	name = "Janitorial supplies"
+	desc = "A set of standard-issue janitorial equipment."
 	contains = list(
 			/obj/item/reagent_containers/glass/bucket,
 			/obj/item/mop,
@@ -66,6 +70,7 @@
 
 /datum/supply_pack/supply/shipping
 	name = "Shipping supplies"
+	desc = "Equipment and supplies needed for shipping supplies."
 	contains = list(
 				/obj/fiftyspawner/cardboard,
 				/obj/item/packageWrap = 4,
@@ -94,12 +99,14 @@
 			/obj/item/paper_bin
 			)
 	name = "Office supplies"
+	desc = "Standard issue office supplies."
 	cost = 15
 	containertype = /obj/structure/closet/crate/ummarcar
 	containername = "Office supplies crate"
 
 /datum/supply_pack/supply/sticky_notes
 	name = "Stationery - sticky notes (50)"
+	desc = "An entire full-size crate for a single pad of sticky notes."
 	contains = list(/obj/item/sticky_pad/random)
 	cost = 10
 	containertype = /obj/structure/closet/crate/ummarcar
@@ -107,6 +114,7 @@
 
 /datum/supply_pack/supply/spare_pda
 	name = "Spare PDAs"
+	desc = "Three spare PDAs."
 	cost = 10
 	containertype = /obj/structure/closet/crate/thinktronic
 	containername = "Spare PDA crate"
@@ -114,6 +122,7 @@
 
 /datum/supply_pack/supply/minergear
 	name = "Shaft miner equipment"
+	desc = "Standard supplies for equipping miners. Requires Mining access."
 	contains = list(
 			/obj/item/storage/backpack/industrial,
 			/obj/item/storage/backpack/satchel/eng,
@@ -140,6 +149,7 @@
 //plus we have the destination tagger
 /datum/supply_pack/supply/mule
 	name = "Mulebot Crate"
+	desc = "A mulebot."
 	contains = list()
 	cost = 20
 	containertype = /obj/structure/largecrate/animal/mulebot
@@ -148,16 +158,19 @@
 
 /datum/supply_pack/supply/cargotrain
 	name = "Cargo Train Tug"
+	desc = "A cargo train tug. Useless without at least one trolley. Can tow several though."
 	contains = list(/obj/vehicle/train/engine)
 	cost = 35
 
 /datum/supply_pack/supply/cargotrailer
 	name = "Cargo Train Trolley"
+	desc = "A cargo train trolley. Useless without a tug."
 	contains = list(/obj/vehicle/train/trolley)
 	cost = 15
 
 /datum/supply_pack/explorergear
 	name= JOB_EXPLORER + " gear"
+	desc = "Standard issue equipment for Explorers. Requires EVA and Exploration access."
 	contains = list (
 					/obj/item/cataloguer,
 					/obj/item/geiger,
@@ -184,6 +197,7 @@
 
 /datum/supply_pack/pilotgear
 	name= JOB_PILOT + " gear"
+	desc = "Standard issue equipment for Pilots. Requires Pilot's access."
 	contains = list (
 					/obj/item/storage/backpack/parachute,
 					/obj/item/radio/headset/pilot,
@@ -209,6 +223,7 @@
 
 /datum/supply_pack/supply/foodcubes
 	name = "Emergency food cubes"
+	desc = "A pack of emergency food cubes. Even less appetizing than nutripaste."
 	contains = list(
 				/obj/machinery/vending/emergencyfood/filled = 1)
 	cost = 75
@@ -217,6 +232,7 @@
 
 /datum/supply_pack/pathfindergear
 	name= JOB_PATHFINDER + " gear"
+	desc = "Standard issue equipment for Away Team Pathfinders. Requires Exploration access."
 	contains = list (
 					/obj/item/cataloguer/compact/pathfinder,
 					/obj/item/geiger,

--- a/code/datums/supplypacks/supplypacks.dm
+++ b/code/datums/supplypacks/supplypacks.dm
@@ -29,6 +29,7 @@ var/list/all_supply_groups = list("Atmospherics",
 
 /datum/supply_pack
 	var/name = null
+	var/desc = "This is a placeholder description."	//information on what the crate is/contains
 	var/list/contains = list() // Typepaths, used to actually spawn the contents
 	var/list/manifest = list() // Object names, used to compile manifests
 	var/cost = null

--- a/code/datums/supplypacks/vending_refills.dm
+++ b/code/datums/supplypacks/vending_refills.dm
@@ -11,101 +11,121 @@
 /datum/supply_pack/vending_refills/snack
 	contains = list(/obj/item/refill_cartridge/autoname/food/snack)
 	name = "Getmore Chocolate Corp Vendor Refill Cartridge"
+	desc = "A refill pack for a Getmore Chocolate Corp Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/fitness
 	contains = list(/obj/item/refill_cartridge/autoname/food/fitness)
 	name = "SweatMAX Vendor Refill Cartridge"
+	desc = "A refill pack for a SweatMAX Exercise Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/weeb
 	contains = list(/obj/item/refill_cartridge/autoname/food/weeb)
 	name = "Nippon-tan Vendor Refill Cartridge"
+	desc = "A refill pack for a Nippon-tan Food Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/sol
 	contains = list(/obj/item/refill_cartridge/autoname/food/sol)
 	name = "Sol-Snacks Vendor Refill Cartridge"
+	desc = "A refill pack for a Sol-Snacks Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/snix
 	contains = list(/obj/item/refill_cartridge/autoname/food/snix)
 	name = "Snix Vendor Refill Cartridge"
+	desc = "A refill pack for a Snix Snack Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/snlvend
 	contains = list(/obj/item/refill_cartridge/autoname/food/snlvend)
 	name = "Shop-n-Large Snacks Vendor Refill Cartridge"
+	desc = "A refill pack for a Shop-n-Large Snack Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/sovietvend
 	contains = list(/obj/item/refill_cartridge/autoname/food/sovietvend)
 	name = "Ration Station Vendor Refill Cartridge"
+	desc = "A refill pack for a Ration Station."
 	cost = 10
 
 /datum/supply_pack/vending_refills/altevian
 	contains = list(/obj/item/refill_cartridge/autoname/food/altevian)
 	name = "Altevian Vendor Refill Cartridge"
+	desc = "A refill pack for an Altevian Fleet Food Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/coffee
 	contains = list(/obj/item/refill_cartridge/autoname/drink/coffee)
 	name = "Hot Drinks Vendor Refill Cartridge"
+	desc = "A refill pack for a Hot Drinks Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/cola
 	contains = list(/obj/item/refill_cartridge/autoname/drink/cola)
 	name = "Robust Softdrinks Vendor Refill Cartridge"
+	desc = "A refill pack for a Robust Softdrinks Vending Machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/sovietsoda
 	contains = list(/obj/item/refill_cartridge/autoname/drink/sovietsoda)
 	name = "BODA Vendor Refill Cartridge"
+	desc = "A refill pack for a... BODA? vending machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/bepis
 	contains = list(/obj/item/refill_cartridge/autoname/drink/bepis)
 	name = "Bepis Softdrinks Vendor Refill Cartridge"
+	desc = "A refill pack for a Bepis Softdrinks vending machine."
 	cost = 10
 
 /datum/supply_pack/vending_refills/cigarette
 	contains = list(/obj/item/refill_cartridge/autoname/cigarette)
 	name = "Cigarette Vendor Refill Cartridge"
+	desc = "A refill pack for cigarette vending machine."
 	cost = 15
 
 /datum/supply_pack/vending_refills/wardrobe
 	contains = list(/obj/item/refill_cartridge/multitype/wardrobe)
 	name = "Wardrobe Vendor Refill Cartridge"
+	desc = "A feedstock refill pack for assorted wardrobe vending machines."
 	cost = 10
 
 /datum/supply_pack/vending_refills/giftvendor
 	contains = list(/obj/item/refill_cartridge/autoname/giftvendor)
 	name = "AlliCo Baubles and Confectionaries Vendor Refill Cartridge"
+	desc = "A refill pack for AlliCo's Baubles and Confectionaries vending machine."
 	cost = 20
 
 /datum/supply_pack/vending_refills/general_food
 	contains = list(/obj/item/refill_cartridge/multitype/food = 5)
 	name = "5-Pack Food Vendor Refill Cartridges"
+	desc = "A five pack of multipurpose food vending machine refills."
 	cost = 75
 
 /datum/supply_pack/vending_refills/general_drink
 	contains = list(/obj/item/refill_cartridge/multitype/drink = 5)
 	name = "5-Pack Drink Vendor Refill Cartridges"
+	desc = "A five pack of multipurpose drink vending machine refills."
 	cost = 75
 
 /datum/supply_pack/vending_refills/general_clothing
 	contains = list(/obj/item/refill_cartridge/multitype/clothing = 5)
 	name = "5-Pack Clothing Vendor Refill Cartridges"
+	desc = "A five pack of multipurpose clothing vending machine refills."
 	cost = 75
 
 /datum/supply_pack/vending_refills/general_technical
 	contains = list(/obj/item/refill_cartridge/multitype/technical = 5)
 	name = "5-Pack Technical Vendor Refill Cartridges"
+	desc = "A five pack of multipurpose technical equipment vending machine refills."
 	cost = 75
 
 /datum/supply_pack/vending_refills/general_specialty
 	contains = list(/obj/item/refill_cartridge/multitype/specialty = 5)
 	name = "5-Pack Specialty Vendor Refill Cartridges"
+	desc = "A five pack of specialist vending machine refills."
 	cost = 150
 
 /datum/supply_pack/randomised/vending_refills/value_pack			// 5 random vendor-specific cartridges at lower average price. But why?
@@ -127,4 +147,5 @@
 					/obj/item/refill_cartridge/autoname/technical/tool,
 					/obj/item/refill_cartridge/autoname/giftvendor)
 	name = "5-pack Extra-Cheap Vendor Refill Cartridges"
+	desc = "A five pack of random, discount, surplus vending machine refills."
 	cost = 35

--- a/code/datums/supplypacks/voidsuits.dm
+++ b/code/datums/supplypacks/voidsuits.dm
@@ -9,6 +9,7 @@
 
 /datum/supply_pack/voidsuits/atmos
 	name = "Atmospheric voidsuits"
+	desc = "A pair of standard Atmospherics voidsuits. Requires Atmospherics access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/atmos = 2,
 			/obj/item/clothing/head/helmet/space/void/atmos = 2,
@@ -23,6 +24,7 @@
 
 /datum/supply_pack/voidsuits/atmos/alt
 	name = "Heavy Duty Atmospheric voidsuits"
+	desc = "A pair of heavy duty Atmospherics voidsuits. Requires Atmospherics access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/atmos/alt = 2,
 			/obj/item/clothing/head/helmet/space/void/atmos/alt = 2,
@@ -37,6 +39,7 @@
 
 /datum/supply_pack/voidsuits/engineering
 	name = "Engineering voidsuits"
+	desc = "A pair of standard Engineering voidsuits. Requires Engineering access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/engineering = 2,
 			/obj/item/clothing/head/helmet/space/void/engineering = 2,
@@ -51,6 +54,7 @@
 
 /datum/supply_pack/voidsuits/engineering/construction
 	name = "Engineering Construction voidsuits"
+	desc = "A pair of Engineering construction voidsuits. Requires Engineering access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/engineering/construction = 2,
 			/obj/item/clothing/head/helmet/space/void/engineering/construction = 2,
@@ -65,6 +69,7 @@
 
 /datum/supply_pack/voidsuits/engineering/hazmat
 	name = "Engineering Hazmat voidsuits"
+	desc = "A pair of Engineering hazmat voidsuits. Requires Engineering access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/engineering/hazmat = 2,
 			/obj/item/clothing/head/helmet/space/void/engineering/hazmat = 2,
@@ -79,6 +84,7 @@
 
 /datum/supply_pack/voidsuits/engineering/alt
 	name = "Reinforced Engineering voidsuits"
+	desc = "A pair of reinforced Engineering voidsuits. Requires Engineering access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/engineering/alt = 2,
 			/obj/item/clothing/head/helmet/space/void/engineering/alt = 2,
@@ -93,6 +99,7 @@
 
 /datum/supply_pack/voidsuits/medical
 	name = "Medical voidsuits"
+	desc = "A pair of standard Medical voidsuits. Requires Medical access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/medical = 2,
 			/obj/item/clothing/head/helmet/space/void/medical = 2,
@@ -107,6 +114,7 @@
 
 /datum/supply_pack/voidsuits/medical/emt
 	name = "Medical EMT voidsuits"
+	desc = "A pair of Medical Emergency Response voidsuits. Requires Medical access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/medical/emt = 2,
 			/obj/item/clothing/head/helmet/space/void/medical/emt = 2,
@@ -121,6 +129,7 @@
 
 /datum/supply_pack/voidsuits/medical/bio
 	name = "Medical Biohazard voidsuits"
+	desc = "A pair of Medical Biohazard Response voidsuits. Requires Medical access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/medical/bio = 2,
 			/obj/item/clothing/head/helmet/space/void/medical/bio = 2,
@@ -135,6 +144,7 @@
 
 /datum/supply_pack/voidsuits/medical/alt
 	name = "Vey-Med Autoadaptive voidsuits (humanoid)"
+	desc = "A pair of advanced Vey-Med Adaptive Medical voidsuits. Requires Medical access, fits most humanoids."
 	contains = list(
 			/obj/item/clothing/suit/space/void/medical/alt = 2,
 			/obj/item/clothing/head/helmet/space/void/medical/alt = 2,
@@ -149,6 +159,7 @@
 
 /datum/supply_pack/voidsuits/medical/alt/tesh
 	name = "Vey-Med Autoadaptive voidsuits (teshari)"
+	desc = "A pair of advanced Vey-Med Adaptive Medical voidsuits. Requires Medical access, fits teshari only."
 	contains = list(
 			/obj/item/clothing/suit/space/void/medical/alt/tesh = 2,
 			/obj/item/clothing/head/helmet/space/void/medical/alt/tesh = 2,
@@ -160,6 +171,7 @@
 
 /datum/supply_pack/voidsuits/security
 	name = "Security voidsuits"
+	desc = "A pair of standard Security voidsuits."
 	contains = list(
 			/obj/item/clothing/suit/space/void/security = 2,
 			/obj/item/clothing/head/helmet/space/void/security = 2,
@@ -170,9 +182,11 @@
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure/heph
 	containername = "Security voidsuit crate"
+	access = access_armory
 
 /datum/supply_pack/voidsuits/security/crowd
 	name = "Security Crowd Control voidsuits"
+	desc = "A pair of Security Crowd Control voidsuits. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/security/riot = 2,
 			/obj/item/clothing/head/helmet/space/void/security/riot = 2,
@@ -187,6 +201,7 @@
 
 /datum/supply_pack/voidsuits/security/alt
 	name = "Security EVA voidsuits"
+	desc = "A pair of Security EVA voidsuits. Requires Armory access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/security/alt = 2,
 			/obj/item/clothing/head/helmet/space/void/security/alt = 2,
@@ -201,6 +216,7 @@
 
 /datum/supply_pack/voidsuits/supply
 	name = "Mining voidsuits"
+	desc = "A pair of standard Mining voidsuits. Requires Mining access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/mining = 2,
 			/obj/item/clothing/head/helmet/space/void/mining = 2,
@@ -214,6 +230,7 @@
 
 /datum/supply_pack/voidsuits/supply/alt
 	name = "Frontier Mining voidsuits"
+	desc = "A pair of Frontier Mining voidsuits. Requires Mining access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/mining/alt = 2,
 			/obj/item/clothing/head/helmet/space/void/mining/alt = 2,
@@ -227,6 +244,7 @@
 
 /datum/supply_pack/voidsuits/zaddat
 	name = "Zaddat Shroud"
+	desc = "A standard zaddat shroud - a special kind of hazardous encounter suit, used by the zaddat species."
 	contains = list(
 		/obj/item/clothing/suit/space/void/zaddat = 1,
 		/obj/item/clothing/mask/gas/zaddat = 1
@@ -238,6 +256,7 @@
 
 /datum/supply_pack/voidsuits/explorer
 	name = JOB_EXPLORER + " voidsuits"
+	desc = "A pair of standard Exploration voidsuits. Requires EVA and Exploration access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/exploration = 2,
 			/obj/item/clothing/head/helmet/space/void/exploration = 2,
@@ -252,6 +271,7 @@
 
 /datum/supply_pack/voidsuits/explorer_medic
 	name = JOB_FIELD_MEDIC + " voidsuits"
+	desc = "A pair of standard Field Medic voidsuits. Requires Medical access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/exploration = 2,
 			/obj/item/clothing/head/helmet/space/void/exploration = 2,
@@ -266,6 +286,7 @@
 
 /datum/supply_pack/voidsuits/pilot
 	name = JOB_PILOT + " voidsuits"
+	desc = "A pair of standard Pilot's voidsuits. Requires Pilot's access."
 	contains = list(
 			/obj/item/clothing/suit/space/void/pilot = 1,
 			/obj/item/clothing/head/helmet/space/void/pilot = 1,
@@ -281,6 +302,7 @@
 // Surplus!
 /datum/supply_pack/voidsuits/com_mining
 	name = "Commonwealth mining voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Mining voidsuit. Requires Mining access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/mining/alt2,
 		/obj/item/clothing/head/helmet/space/void/mining/alt2
@@ -292,6 +314,7 @@
 
 /datum/supply_pack/voidsuits/com_anomaly
 	name = "Commonwealth anomaly suit"
+	desc = "A standard Commonwealth of Sol-Procyon Anomalous Materials Handling voidsuit. Requires Xenoarchaeology access."
 	contains = list(
 		/obj/item/clothing/suit/space/anomaly/alt,
 		/obj/item/clothing/head/helmet/space/anomaly/alt
@@ -303,6 +326,7 @@
 
 /datum/supply_pack/voidsuits/com_riot
 	name = "Commonwealth riot voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Riot Control voidsuit. Requires Armory access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/security/riot/alt,
 		/obj/item/clothing/head/helmet/space/void/security/riot/alt
@@ -310,10 +334,11 @@
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure
 	name = "Commonwealth riot voidsuit crate"
-	access = access_brig
+	access = access_armory
 
 /datum/supply_pack/voidsuits/com_pilot
 	name = "Commonwealth pilot voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Pilot's voidsuit. Requires Pilot's access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/pilot/alt2,
 		/obj/item/clothing/head/helmet/space/void/pilot/alt2
@@ -325,6 +350,7 @@
 
 /datum/supply_pack/voidsuits/com_medical
 	name = "Commonwealth medical voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Medical voidsuit. Requires Medical access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/medical/alt2,
 		/obj/item/clothing/head/helmet/space/void/medical/alt2
@@ -332,10 +358,11 @@
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure
 	name = "Commonwealth medical voidsuit crate"
+	access = access_medical
 
 /datum/supply_pack/voidsuits/com_explore
-
 	name = "Commonwealth exploration voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Exploration voidsuit. Requires EVA and Exploration access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/exploration/alt2,
 		/obj/item/clothing/head/helmet/space/void/exploration/alt2
@@ -347,6 +374,7 @@
 
 /datum/supply_pack/voidsuits/com_engineer
 	name = "Commonwealth engineering voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Engineering voidsuit. Requires Engineering access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/engineering/alt2,
 		/obj/item/clothing/head/helmet/space/void/engineering/alt2
@@ -358,6 +386,7 @@
 
 /datum/supply_pack/voidsuits/com_atmos
 	name = "Commonwealth atmos voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Atmospherics voidsuit. Requires Atmospherics access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/atmos/alt2,
 		/obj/item/clothing/head/helmet/space/void/atmos/alt2
@@ -369,6 +398,7 @@
 
 /datum/supply_pack/voidsuits/com_captain
 	name = "Commonwealth captain voidsuit"
+	desc = "A standard Commonwealth of Sol-Procyon Captain's voidsuit. Requires Captain's access."
 	contains = list(
 		/obj/item/clothing/suit/space/void/captain/alt,
 		/obj/item/clothing/head/helmet/space/void/captain/alt
@@ -380,6 +410,7 @@
 
 /datum/supply_pack/voidsuits/csc_breaker
 	name = "Shipbreaker's Industrial Suit (inc. jetpack)"
+	desc = "A Coyote Salvage Corporation Shipbreaker's voidsuit. Includes h-fuel jetpack."
 	contains = list(
 		/obj/item/clothing/suit/space/void/salvagecorp_shipbreaker,
 		/obj/item/clothing/head/helmet/space/void/salvagecorp_shipbreaker,

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -166,6 +166,7 @@
 		var/datum/supply_pack/P = SSsupply.supply_pack[pack_name]
 		var/list/pack = list(
 				"name" = P.name,
+				"desc" = P.desc,
 				"cost" = P.cost,
 				"group" = P.group,
 				"contraband" = P.contraband,
@@ -200,6 +201,7 @@
 				return FALSE
 			var/list/payload = list(
 				"name" = P.name,
+				"desc" = P.desc,
 				"cost" = P.cost,
 				"manifest" = uniqueList(P.manifest),
 				"ref" = "\ref[P]",

--- a/maps/~map_system/_map_selection.dm
+++ b/maps/~map_system/_map_selection.dm
@@ -5,8 +5,8 @@
 /* FOR LIVE SERVER   */
 /*********************/
 
-#define USE_MAP_TETHER
-//#define USE_MAP_STELLARDELIGHT
+//#define USE_MAP_TETHER
+#define USE_MAP_STELLARDELIGHT
 //#define USE_MAP_GROUNDBASE
 
 // Debug

--- a/maps/~map_system/_map_selection.dm
+++ b/maps/~map_system/_map_selection.dm
@@ -5,8 +5,8 @@
 /* FOR LIVE SERVER   */
 /*********************/
 
-//#define USE_MAP_TETHER
-#define USE_MAP_STELLARDELIGHT
+#define USE_MAP_TETHER
+//#define USE_MAP_STELLARDELIGHT
 //#define USE_MAP_GROUNDBASE
 
 // Debug

--- a/tgui/packages/tgui/interfaces/SupplyConsole/SupplyConsoleMenuOrder.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyConsole/SupplyConsoleMenuOrder.tsx
@@ -73,7 +73,7 @@ export const SupplyConsoleMenuOrder = (props) => {
                       color={pack.cost > supply_points ? 'red' : undefined}
                       onClick={() => act('view_crate', { crate: pack.ref })}
                     >
-                      C
+                      Info
                     </Button>
                   </Stack.Item>
                   <Stack.Item grow={1}>{pack.cost} points</Stack.Item>

--- a/tgui/packages/tgui/interfaces/SupplyConsole/types.ts
+++ b/tgui/packages/tgui/interfaces/SupplyConsole/types.ts
@@ -18,6 +18,7 @@ export type modalData = {
   text: string;
   args: {
     name: string;
+    desc: string;
     cost: number;
     manifest: string[];
     ref: string;
@@ -28,6 +29,7 @@ export type modalData = {
 
 export type supplyPack = {
   name: string;
+  desc: string;
   cost: number;
   group: string;
   contraband: BooleanLike;

--- a/tgui/packages/tgui/interfaces/SupplyConsole/viewCrateContents.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyConsole/viewCrateContents.tsx
@@ -5,7 +5,7 @@ import { Data, modalData } from './types';
 export const viewCrateContents = (modal: modalData) => {
   const { act, data } = useBackend<Data>();
   const { supply_points } = data;
-  const { name, cost, manifest, ref, random } = modal.args;
+  const { name, cost, desc, manifest, ref, random } = modal.args;
   return (
     <Section
       width="400px"
@@ -22,6 +22,7 @@ export const viewCrateContents = (modal: modalData) => {
         </Button>
       }
     >
+      {desc}
       <Section
         title={'Contains' + (random ? ' any ' + random + ' of:' : '')}
         scrollable


### PR DESCRIPTION
Adds descriptions to (almost all) supply packs that can be ordered from cargo, and changes the 'C' for 'Contents' to 'Info', which will _hopefully_ be more obvious/intuitive.

These descriptions are intended to clarify when the automated content list isn't clear, particularly if a pack contains multiples of the same item as a single-line item (just look at the inflatable barriers crate!), and to provide additional information when things might be unclear or the equipment is very specialized.

Descriptions also mention access restrictions on the crate, if any. Purely manual for now, perhaps someone with a bigger brain than me can automate it.

![image](https://github.com/user-attachments/assets/dfd91e8c-4fd3-4875-9d64-029ee7342c59)

:cl:
rscadd: adds descriptions to supply packs that are visible in the terminal when viewing the pack info
tweak: changes the 'C' icon in the terminal to show "Info"
tweak: fixes a few stray crate access restrictions that were wrongly assigned compared to others
tweak: cleans up some duplicate supply pack defs
/:cl: