### PR TITLE
Makes unabsorb chem NOT infinitely hallucinate you!

### DIFF
--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -99,7 +99,7 @@
 	M.adjustHalLoss(1)
 	if(!M.confused) M.confused = 1
 	M.confused = max(M.confused, 20)
-	M.hallucination += 15
+	M.hallucination = max(M.hallucination, 20) //This used to be += 15 resulting in INFINITE HALLUCINATION
 
 	for(var/obj/belly/B as anything in M.vore_organs)
 


### PR DESCRIPTION
Does what it said on the tin.

Doing this after someone got poisoned  with 15u of unabsorb chem and got +2000 hallucination total

I'm classifying this as a bug as 15u of unabsorbitol should NOT cause you to have 8000 seconds of hallucinations!