### PR TITLE
Fixes the 'attach organ' synthetic surgery.

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -238,6 +238,8 @@
 ///////////////////////////////////////////////////////////////
 
 /datum/surgery_step/robotics/fix_organ_robotic //For artificial organs
+
+	priority = 2
 	surgery_name = "Fix Robotic Organ"
 	allowed_tools = list(
 	/obj/item/stack/nanopaste = 100,		\
@@ -371,6 +373,8 @@
 ///////////////////////////////////////////////////////////////
 
 /datum/surgery_step/robotics/attach_organ_robotic
+
+	priority = 2
 	surgery_name = "Attach Robotic Organ"
 	allowed_procs = list(IS_SCREWDRIVER = 100)
 


### PR DESCRIPTION
Some priority changes have been applied to some synth surgeries that were also found in the organic surgeries. This fixes the bug where you attack a person instead of attaching the organ.

Tested very aggressively trying to break it and couldn't.

🆑
fix: Fixed a bug that made attaching fbp organs inconsistent.
/:cl: