### PR TITLE
prvents ghosts from leaving / getting tossed out bellies in areas with BLOCK ghosts flag

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -206,7 +206,7 @@ Works together with spawning an observer, noted above.
 	if(!isturf(loc))
 		return
 	var/area/A = get_area(src)
-	if(A.flag_check(AREA_BLOCK_GHOSTS))
+	if(A.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(loc))
 		to_chat(src, span_warning("Ghosts can't enter this location."))
 		return_to_spawn()
 
@@ -462,7 +462,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//RS Port #658 Start
 	var/area/A = get_area(destination)
-	if(A?.flag_check(AREA_BLOCK_GHOSTS))
+	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination))
 		to_chat(src,span_warning("Sorry, that area does not allow ghosts."))
 		if(following)
 			stop_following()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -342,20 +342,20 @@
 	return Move(n, direct, movetime)
 
 /client
-	var/leave_belly = FALSE
+	var/is_leaving_belly = FALSE
 
 ///Process_Incorpmove
 ///Called by client/Move()
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
 	if(isbelly(mob.loc) && isobserver(mob))
-		if(leave_belly)
+		if(is_leaving_belly)
 			return
-		leave_belly = TRUE
+		is_leaving_belly = TRUE
 		if(tgui_alert(mob, "Do you want to leave your predator's belly?", "Leave belly?", list("Yes", "No")) != "Yes")
-			leave_belly = FALSE
+			is_leaving_belly = FALSE
 			return
-		leave_belly = FALSE
+	is_leaving_belly = FALSE
 	var/turf/mobloc = get_turf(mob)
 
 	switch(mob.incorporeal_move)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -341,10 +341,21 @@
 /mob/proc/SelfMove(turf/n, direct, movetime)
 	return Move(n, direct, movetime)
 
+/client
+	var/leave_belly = FALSE
+
 ///Process_Incorpmove
 ///Called by client/Move()
 ///Allows mobs to run though walls
 /client/proc/Process_Incorpmove(direct)
+	if(isbelly(mob.loc) && isobserver(mob))
+		if(leave_belly)
+			return
+		leave_belly = TRUE
+		if(tgui_alert(mob, "Do you want to leave your predator's belly?", "Leave belly?", list("Yes", "No")) != "Yes")
+			leave_belly = FALSE
+			return
+		leave_belly = FALSE
 	var/turf/mobloc = get_turf(mob)
 
 	switch(mob.incorporeal_move)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -355,7 +355,7 @@
 		if(tgui_alert(mob, "Do you want to leave your predator's belly?", "Leave belly?", list("Yes", "No")) != "Yes")
 			is_leaving_belly = FALSE
 			return
-	is_leaving_belly = FALSE
+		is_leaving_belly = FALSE
 	var/turf/mobloc = get_turf(mob)
 
 	switch(mob.incorporeal_move)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -361,10 +361,10 @@
 				if(isliving(mob) && A.flag_check(AREA_BLOCK_PHASE_SHIFT))
 					to_chat(mob, span_warning("Something blocks you from entering this location while phased out."))
 					return
-				if(isobserver(mob) && A.flag_check(AREA_BLOCK_GHOSTS))
+				if(isobserver(mob) && A.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(mob.loc))
 					to_chat(mob, span_warning("Ghosts can't enter this location."))
 					var/area/our_area = mobloc.loc
-					if(our_area.flag_check(AREA_BLOCK_GHOSTS))
+					if(our_area.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(mob.loc))
 						var/mob/observer/dead/D = mob
 						D.return_to_spawn()
 					return


### PR DESCRIPTION
🆑 
fix:fixes an issue where ghosts got kicked out of bellies in no ghost areas and prevents them from just jumping out while the pred is in that area
add: popup for ghosts upon leaving a belly to prevent accidental leaving
/:cl: 