### PR TITLE
Bodyscanner Eject Fix

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -127,7 +127,7 @@
 	if (occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
-	occupant.loc = src.loc
+	occupant.forceMove(src.loc) // was occupant.loc = src.loc, but that doesn't trigger exit(), and thus recursive radio listeners forwarded messages to the occupant as if they were still inside it for the rest of the round! OP21 #5f88307 Port
 	occupant = null
 	update_icon() //icon_state = "body_scanner_1" //VOREStation Edit - Health display for consoles with light and such.
 	SStgui.update_uis(src)


### PR DESCRIPTION
Ports OP21 Commit #5f88307 from [here](https://github.com/Willburd/CHOMPost21/commit/5f883073708601a623602430a49bc276727f32ef#diff-dd320788377dda7ec09e68296cc798fc74a16413b4bf2e3fa8ea281fd3a92b57R130)

- Fixes bodyscanners not moving you using the proper movement proc and resulting in some weird interactions under certain circumstances.


From downstream:
The bodyscanner stores permanent references to any mob that enters it. This is because mobs don't move out of the bodyscanner, they had their loc set manually.

THis means it never runs the code that removes the occupants from its recursive radio messaging list. So if you have any radio next to a scanner, and people talking on those channels. that mob can hear that radio for the rest of the shift.

This is not normally encountered because medical radios are by default set to itnernal medical comms, which no one uses.