### PR TITLE
Makes firefighter hats not useless in fires

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -60,6 +60,7 @@
 	min_pressure_protection = 0.5 * ONE_ATMOSPHERE
 	max_pressure_protection = 20 * ONE_ATMOSPHERE
 	body_parts_covered = HEAD|FACE|EYES
+	heat_protection = HEAD
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	flash_protection = FLASH_PROTECTION_MODERATE


### PR DESCRIPTION
Firefighter hats didn't have heat_protection = HEAD This resulted in them doing...Nothing.

The "emergency fire helmet" found in emergency lockers DID have this heat protection, however!