### PR TITLE
Chem dispenser water bottle fix

### DIFF
--- a/code/modules/reagents/machinery/dispenser/dispenser2.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser2.dm
@@ -135,6 +135,10 @@
 			to_chat(user, span_warning("You don't see how \the [src] could dispense reagents into \the [RC]."))
 			return
 
+		if(istype(RC, /obj/item/reagent_containers/glass/cooler_bottle))
+			to_chat(user, span_warning("You don't see how \the [RC] could fit into \the [src]."))
+			return
+
 		container =  RC
 		user.drop_from_inventory(RC)
 		RC.loc = src


### PR DESCRIPTION
Fixed water cooler bottles (which have a volume of 2000u) being able to be placed in chemical dispensers.