### PR TITLE
Fixes janihud color being incorrect on mapspawn objects

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -56,7 +56,7 @@ generic_filth = TRUE means when the decal is saved, it will be switched out for 
 	hud.layer = BELOW_MOB_LAYER
 	hud.mouse_opacity = 0
 	//HUD VARIANT: Allows the hud to show up with it's normal alpha, even if the 'dirty thing' it's attached to has a low alpha (ex: dirt). If you want to disable it, simply comment out the lines between the 'HUD VARIANT' tag!
-	hud.appearance_flags = RESET_ALPHA
+	hud.appearance_flags = RESET_ALPHA | RESET_COLOR
 	hud.alpha = 255
 	//HUD VARIANT end
 	add_overlay(hud)


### PR DESCRIPTION
Up-port of [Commit f743bfd ](https://github.com/Willburd/CHOMPost21/commit/f743bfd311fda54dfc468171c85d1b2ff6a4d680#diff-c895b03877aa3e33b010354d9065bd752d8c1e810cdb309edd8d12dd4916ff82L58)by Willburd on Outpost21

- Fixes the jani hud icon turning black or red from map-spawned blood/oil by adding the RESET_COLOR flag