### PR TITLE
hides death messages in protected areas when dying in a belly

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -82,10 +82,12 @@
 	callHook("death", list(src, gibbed))
 
 	if(mind)
-		// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // VOREStation Edit - We don't use SSgame_master yet.
-		for(var/mob/observer/dead/O in mob_list)
-			if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))
-				to_chat(O, span_deadsay(span_bold("[src]") + " has died in " + span_bold("[get_area(src)]")  + ". [ghost_follow_link(src, O)] "))
+		var/area/A = get_area(src)
+		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)))
+			// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // VOREStation Edit - We don't use SSgame_master yet.
+			for(var/mob/observer/dead/O in mob_list)
+				if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))
+					to_chat(O, span_deadsay(span_bold("[src]") + " has died in " + span_bold("[get_area(src)]")  + ". [ghost_follow_link(src, O)] "))
 
 	if(!gibbed && species.death_sound)
 		playsound(src, species.death_sound, 80, 1, 1)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -83,7 +83,7 @@
 
 	if(mind)
 		var/area/A = get_area(src)
-		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)) && isbelly(src.loc))
+		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)) && isbelly(loc))
 			// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // VOREStation Edit - We don't use SSgame_master yet.
 			for(var/mob/observer/dead/O in mob_list)
 				if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -83,7 +83,7 @@
 
 	if(mind)
 		var/area/A = get_area(src)
-		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)))
+		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)) && isbelly(src.loc))
 			// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // VOREStation Edit - We don't use SSgame_master yet.
 			for(var/mob/observer/dead/O in mob_list)
 				if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))


### PR DESCRIPTION
Might need some discussion, but not every ghost in game has to see if someone dies in a belly within a drom

This will hide the death message if someone dies inside a belly within an area that has the AREA_BLOCK_SUIT_SENSORS flag

🆑 
qol: death messages to ghosts within bellies are now hidden in areas that block suit sensors
/🆑 