### PR TITLE
Turret & Sound Optimizations

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -1,3 +1,40 @@
+/atom/movable/proc/get_mob()
+	if(buckled_mobs) return buckled_mobs.Copy()
+
+/obj/mecha/get_mob()
+	return occupant
+
+/obj/vehicle_old/train/get_mob()
+	return buckled_mobs
+
+/mob/get_mob()
+	return src
+
+/mob/living/bot/mulebot/get_mob()
+	if(load && istype(load, /mob/living))
+		return list(src, load)
+	return src
+
+/proc/mobs_in_view(range, source)
+	var/list/mobs = list()
+	for(var/atom/movable/AM in view(range, source))
+		var/M = AM.get_mob()
+		if(M)
+			mobs += M
+
+	return mobs
+
+/// This gets a list of mobs ALL around us as if we had xray vision and can see through walls.
+/// Currently only used in portable_turret.dm if you wish to see an example of how to use it.
+/proc/mobs_in_xray_view(range, source)
+	var/list/mobs = list()
+	for(var/atom/movable/AM in orange(range, source))
+		var/M = AM.get_mob()
+		if(M)
+			mobs += M
+
+	return mobs
+
 /proc/random_hair_style(gender, species = SPECIES_HUMAN)
 	var/h_style = "Bald"
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -14,10 +14,6 @@
 	var/sound/S = sound(get_sfx(soundin))
 	var/maxdistance = (world.view + extrarange) * 2  //VOREStation Edit - 3 to 2
 	var/list/listeners = player_list.Copy()
-	if(!ignore_walls) //these sounds don't carry through walls
-		for(var/mob/listen in listeners)
-			if(!(get_turf(listen) in hear(maxdistance,source)))
-				listeners -= listen
 	for(var/mob/M as anything in listeners)
 		if(!M || !M.client)
 			continue
@@ -27,11 +23,16 @@
 		var/area/A = T.loc
 		if((A.flag_check(AREA_SOUNDPROOF) || area_source.flag_check(AREA_SOUNDPROOF)) && (A != area_source))
 			continue
-		var/distance = get_dist(T, turf_source)
+		//var/distance = get_dist(T, turf_source) Save get_dist for later because it's more expensive
 
-		if(distance <= maxdistance)
-			if(T && T.z == turf_source.z)
-				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, pressure_affected, S, preference, volume_channel)
+		if(!T || T.z != turf_source.z) //^ +1
+			continue
+		if(get_dist(T, turf_source) > maxdistance)
+			continue
+		if(!ignore_walls && !can_see(turf_source, T, length = maxdistance * 2))
+			continue
+
+		M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, pressure_affected, S, preference, volume_channel)
 
 /mob/proc/check_sound_preference(list/preference)
 	if(!islist(preference))
@@ -64,7 +65,7 @@
 	vol *= client.get_preference_volume_channel(VOLUME_CHANNEL_MASTER)
 	S.volume = vol
 
-	if(vary)
+	if(vary || frequency)
 		if(frequency)
 			S.frequency = frequency
 		else
@@ -308,8 +309,6 @@ var/list/bodyfall_sound = list('sound/effects/bodyfall1.ogg','sound/effects/body
 var/list/teppi_sound = list('sound/voice/teppi/gyooh1.ogg', 'sound/voice/teppi/gyooh2.ogg', 'sound/voice/teppi/gyooh3.ogg',  'sound/voice/teppi/gyooh4.ogg', 'sound/voice/teppi/gyooh5.ogg', 'sound/voice/teppi/gyooh6.ogg', 'sound/voice/teppi/snoot1.ogg', 'sound/voice/teppi/snoot2.ogg')
 var/list/talk_sound = list('sound/talksounds/a.ogg','sound/talksounds/b.ogg','sound/talksounds/c.ogg','sound/talksounds/d.ogg','sound/talksounds/e.ogg','sound/talksounds/f.ogg','sound/talksounds/g.ogg','sound/talksounds/h.ogg')
 var/list/emote_sound = list('sound/talksounds/me_a.ogg','sound/talksounds/me_b.ogg','sound/talksounds/me_c.ogg','sound/talksounds/me_d.ogg','sound/talksounds/me_e.ogg','sound/talksounds/me_f.ogg')
-
-//Goon sounds
 var/list/goon_speak_one_sound = list('sound/talksounds/goon/speak_1.ogg', 'sound/talksounds/goon/speak_1_ask.ogg', 'sound/talksounds/goon/speak_1_exclaim.ogg')
 var/list/goon_speak_two_sound = list('sound/talksounds/goon/speak_2.ogg', 'sound/talksounds/goon/speak_2_ask.ogg', 'sound/talksounds/goon/speak_2_exclaim.ogg')
 var/list/goon_speak_three_sound = list('sound/talksounds/goon/speak_3.ogg', 'sound/talksounds/goon/speak_3_ask.ogg', 'sound/talksounds/goon/speak_3_exclaim.ogg')

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1501,3 +1501,12 @@
 			robotact?.update_static_data_for_all_viewers()
 
 	. = ..()
+
+/// This proc checks to see if a borg has access to whatever they're interacting with
+/obj/proc/siliconaccess(mob/user)
+	var/mob/living/silicon/robot/R = user
+	if(istype(R))
+		return check_access(R.idcard)
+	if(issilicon(user))
+		return TRUE
+	return FALSE


### PR DESCRIPTION
All of the below taken from Chomp PR here https://github.com/CHOMPStation2/CHOMPStation2/pull/8088
### Optimizes portable turrets & Sound


- Optimizes the chomp adjustment further by changing mobs_in_xray_view to mobs_in_view. 
Reason: mobs_in_xray_view was adding mobs that were out of sight (behind walls) to the target list and trying to do pathfinding to shoot them. If you had 20 mobs around a PoI with turrets, it'd use a LOT of CPU needlessly.  This honestly seems like it was a bug with how much CPU it'd use.

- Also adds in Chomp's /mobs.dm helpers as they're helpful for future use and further optimization

- Replaces for( listeners) with a check that sees if a listener is ALSO a hearer

- Makes it so even if there is no vary, if the sound has a frequency it uses the frequency it has set for playsound_local