### PR TITLE
Extra borg overlay for more options

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -24,6 +24,7 @@
 	var/crisis //Admin-settable for combat module use.
 	var/crisis_override = 0
 	var/integrated_light_power = 6
+	var/robotdecal_on = 0
 	var/datum/wires/robot/wires
 
 	can_be_antagged = TRUE
@@ -436,6 +437,13 @@
 	lights_on = !lights_on
 	to_chat(usr, span_filter_notice("You [lights_on ? "enable" : "disable"] your integrated light."))
 	handle_light()
+	update_icon()
+
+/mob/living/silicon/robot/verb/toggle_robot_decals() // loads overlay UNDER lights.
+	set category = "Abilities.Silicon"
+	set name = "Toggle extras"
+	robotdecal_on = !robotdecal_on
+	to_chat(usr, span_filter_notice("You [robotdecal_on ? "enable" : "disable"] your extra apperances."))
 	update_icon()
 
 /mob/living/silicon/robot/verb/spark_plug() //So you can still sparkle on demand without violence.
@@ -975,6 +983,12 @@
 				var/eyes_overlay = sprite_datum.get_eyes_overlay(src)
 				if(eyes_overlay)
 					add_overlay(eyes_overlay)
+
+		if(robotdecal_on && sprite_datum.has_robotdecal_sprites)
+			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.
+				var/robotdecal_overlay = sprite_datum.get_robotdecal_overlay(src)
+				if(robotdecal_overlay)
+					add_overlay(robotdecal_overlay)
 
 		if(lights_on && sprite_datum.has_eye_light_sprites)
 			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.

--- a/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
@@ -10,6 +10,7 @@
 
 	var/has_eye_sprites = TRUE
 	var/has_eye_light_sprites = FALSE
+	var/has_robotdecal_sprites = FALSE
 	var/has_custom_open_sprites = FALSE
 	var/has_vore_belly_sprites = FALSE
 	var/has_vore_belly_resting_sprites = FALSE
@@ -113,6 +114,12 @@
 /datum/robot_sprite/proc/get_eye_light_overlay(var/mob/living/silicon/robot/ourborg)
 	if(!(ourborg.resting && has_rest_sprites))
 		return "[sprite_icon_state]-lights"
+	else
+		return
+
+/datum/robot_sprite/proc/get_robotdecal_overlay(var/mob/living/silicon/robot/ourborg)
+	if(!(ourborg.resting && has_rest_sprites))
+		return "[sprite_icon_state]-decals"
 	else
 		return
 


### PR DESCRIPTION
this adds a toggle to abilities to turn on or off an extra overlay for anything from decals to wings for borgs.
![image](https://github.com/user-attachments/assets/68d2c78c-c923-4189-97bd-1f473236a737)

note: loads overlay UNDER lights.


**how to use?**
add this to the robot sprites dm in the job modules like eye sprites.

**has_robotdecal_sprites = TRUE**

and **-decals** to the sprite in the DMI.

once in game, open abilities and click 'toggle extras' under silicon
part of a future PR for new chassis update im working on for dullahans to use wings and halos as a toggle.