### PR TITLE
initial ghost spawn is important...

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -132,7 +132,7 @@
 	if(!T && length(latejoin))
 		T = pick(latejoin)			//Safety in case we cannot find the body's position
 	if(T)
-		forceMove(T)
+		forceMove(T, just_spawned = TRUE)
 	else
 		moveToNullspace()
 		to_chat(src, span_danger("Could not locate an observer spawn point. Use the Teleport verb to jump to the station map."))
@@ -455,7 +455,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	ManualFollow(M || jumpable_mobs()[mobname])
 
-/mob/observer/dead/forceMove(atom/destination)
+/mob/observer/dead/forceMove(atom/destination, direction, just_spawned = FALSE)
 	if(client?.holder)
 		return ..()
 
@@ -467,7 +467,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//RS Port #658 Start
 	var/area/A = get_area(destination)
-	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination) && !admin_ghosted)
+	if(A?.flag_check(AREA_BLOCK_GHOSTS) && !isbelly(destination) && !admin_ghosted && !just_spawned)
 		to_chat(src,span_warning("Sorry, that area does not allow ghosts."))
 		if(following)
 			stop_following()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -455,7 +455,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	ManualFollow(M || jumpable_mobs()[mobname])
 
-/mob/observer/dead/forceMove(atom/destination, direction, just_spawned = FALSE)
+/mob/observer/dead/forceMove(atom/destination, just_spawned = FALSE)
 	if(client?.holder)
 		return ..()
 


### PR DESCRIPTION
Guh, I thought that code had been tested before porting... But when a ghost is created, the first forceMove will have to pass. If it fails, we'll get a qdel loop. If someone has a better idea, suggest it... For now just ignoring the area check on the first forceMove.

🆑 
fix: a qdel loop in the ghost destroy proc
/:cl:
