### PR TITLE
Small bugfixes / clarifications

### DIFF
--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -107,7 +107,7 @@
 		if(locked && state == 0)
 			to_chat(M,span_warning("It's locked!"))
 			return
-		if(world.time - user.last_bumped <= 60)
+		if(world.time - last_bumped <= 60)
 			return
 		if(M.client)
 			if(iscarbon(M))

--- a/code/modules/client/record_updater.dm
+++ b/code/modules/client/record_updater.dm
@@ -67,7 +67,7 @@ var/global/client_record_update_lock = FALSE
 		if(COM && !QDELETED(COM))
 			COM.visible_message(span_notice("\The [COM] buzzes!"))
 			playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
-		return "Update syncronization failed (OOC: Client mob does not exist, has no mind record, or is possesssed)"
+		return "Update syncronization failed (OOC: Player mob does not exist, has no mind record, or is possesssed)"
 
 	var/client/C = M.client
 	if(!C)
@@ -76,13 +76,13 @@ var/global/client_record_update_lock = FALSE
 			playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
 		return "Update syncronization failed (OOC: Record's owner is offline)"
 
-	var/choice = tgui_alert(M, "Your [record_string] record has been updated from the a records console by [user]. Please review the changes made to your [record_string] record. Accepting these changes will SAVE your CURRENT character slot! If your new [record_string] record has errors, it is recomended to have it corrected IC instead of editing it yourself.", "Record Updated", list("Review Changes","Refuse Update"))
-	if(choice == "Refuse Update")
+	var/choice = tgui_alert(M, "Your [record_string] record has been updated from the a records console by [user]. Please review the changes made to your [record_string] record. Accepting these changes will SAVE your CURRENT character slot! If your new [record_string] record has errors, it is recomended to have it corrected IC instead of editing it yourself.", "Record Updated", list("Review Changes","DENY"))
+	if(choice == "DENY")
 		message_admins("[active.fields["name"]] refused [record_string] record update from [user] without review.")
 		if(COM && !QDELETED(COM))
 			COM.visible_message(span_notice("\The [COM] buzzes!"))
 			playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
-		return "Update syncronization failed (OOC: Client refused without review)"
+		return "Update syncronization failed (OOC: Player refused without review)"
 
 	var/datum/preferences/P = C.prefs
 	var/new_data = strip_html_simple(tgui_input_text(M,"Please review [user]'s changes to your [record_string] record before confirming. Confirming will SAVE your CURRENT character slot! If your new [record_string] record major errors, it is recomended to have it corrected IC instead of editing it yourself.","Character Preference", html_decode(active.fields["notes"]), MAX_RECORD_LENGTH, TRUE, prevent_enter = TRUE), MAX_RECORD_LENGTH)
@@ -91,13 +91,13 @@ var/global/client_record_update_lock = FALSE
 		if(COM && !QDELETED(COM))
 			COM.visible_message(span_notice("\The [COM] buzzes!"))
 			playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
-		return "Update syncronization failed (OOC: Client refused with review)"
+		return "Update syncronization failed (OOC: Player refused with review)"
 	if(!M || !M.client || !P)
-		message_admins("[active.fields["name"]]'s [record_string] record could not be updated, client disconnected.")
+		message_admins("[active.fields["name"]]'s [record_string] record could not be updated, player disconnected.")
 		if(COM && !QDELETED(COM))
 			COM.visible_message(span_notice("\The [COM] buzzes!"))
 			playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
-		return "Update syncronization failed (OOC: Client does not exist)"
+		return "Update syncronization failed (OOC: Player does not exist)"
 
 	// Update records in the consoles, remember this can happen a while after a record is closed on the console... Use cached data.
 	switch(console_path)

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -538,7 +538,7 @@
 	req_tech = list(TECH_BLUESPACE = 10, TECH_MAGNET = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
 
-/datum/design/item/mecha/teleporter
+/datum/design/item/mecha/cloak
 	name = "Cloaking Device"
 	desc = "A device that renders the exosuit invisible to the naked eye, though not to thermal detection. Uses large amounts of energy."
 	id = "mech_cloaking"


### PR DESCRIPTION
- [Fixes mech cloak having the wrong path](https://github.com/VOREStation/VOREStation/commit/a0ecd268d8dea778527b07aecd1f476ea7372173)

From Outpost21 Commit a64c3ad.


- [clarified player record console buttons](https://github.com/VOREStation/VOREStation/commit/68a16af12349dc72c969ff91f6fedbfe76cb9d24)

"Player had issue with button confusion, and reviewing the buttons they are WAY too similar. changed refuse update to DENY to ensure no at-a-glance confusion"

From Outpost 21 Commit 32bc6f7


- [simple doors use their own bump timer and not the user's](https://github.com/VOREStation/VOREStation/commit/9a4dcea8353c320afea125680c071cc4173a5ccc)

simple material doors no longer use the USER'S last bump time, and isntead use their own for locking interaction. They now open promptly when bonked into and close after some time when clicked (they are meant to be slow after all)

The bug was casued by using the user's bump time. So if youtouched anything like a wall within the last 60 ticks (including the door itself) it wouldn't open

From Outpost21 Commit 783ef0a