### PR TITLE
Makes limbs able to be chopped off with reasonable limits

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -3,9 +3,15 @@
 ****************************************************/
 
 //These control the damage thresholds for the various ways of removing limbs
-#define DROPLIMB_THRESHOLD_EDGE 5
-#define DROPLIMB_THRESHOLD_TEAROFF 2
-#define DROPLIMB_THRESHOLD_DESTROY 1
+/// <summary>
+/// Arms and legs have 80 damage, which is a good baseline to go off of.
+/// The droplimb_threshold is "Divide the limb's max health by this number"
+/// That is the damage required (in ONE hit) to tear off or destroy a limb.
+/// If the damage dealt per hit is below that, it can NOT remove limbs.
+/// </summary>
+#define DROPLIMB_THRESHOLD_EDGE 8 //For limb of 80(arm/leg) requires 10 or more damage to cut off.
+#define DROPLIMB_THRESHOLD_TEAROFF 3 //Requires 26.66 or more damage to cut off an arm/leg with a blunt object. Lower than the
+#define DROPLIMB_THRESHOLD_DESTROY 3.34 //Requires 24 damage or more to DESTROY a arm/leg with a blunt object. Blunt is going to DESTROY over just knocking something off!
 
 /obj/item/organ/external
 	name = "external"
@@ -359,12 +365,23 @@
 
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner && !is_stump())
-		if(!cannot_amputate && CONFIG_GET(flag/limbs_can_break) && (brute_dam + burn_dam) >= (max_damage * CONFIG_GET(number/organ_health_multiplier)))
+		/// <summary>
+		/// This determines if the limb is ELIGIBLE to be chopped off or not.
+		/// It checks if it's amputatable, if the config setting is set, then continues down the proc.
+		/// </summary>
+		if(!cannot_amputate && CONFIG_GET(flag/limbs_can_break))
 			//organs can come off in three cases
 			//1. If the damage source is edge_eligible and the brute damage dealt exceeds the edge threshold, then the organ is cut off.
 			//2. If the damage amount dealt exceeds the disintegrate threshold, the organ is completely obliterated.
 			//3. If the organ has already reached or would be put over it's max damage amount (currently redundant),
 			//   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
+
+			// Let's calculate how INJURED our limb is. Determines the chance the next attack will take our limb off!
+			var/damage_factor = ((max_damage*CONFIG_GET(number/organ_health_multiplier))/(brute_dam + burn_dam))*100
+			// Max_damage of 80 and brute_dam of 80? Factor = 100
+			// Max_damage of 80 and brute_dam of 40? Factor = 50
+			// Max_damage of 80 and brute_dam of 5? Factor = 5
+			// This lowers our chances of having our limb removed when it has less damage. The more damaged the limb, the higher the chance it falls off!
 
 			//Check edge eligibility
 			var/edge_eligible = 0
@@ -376,22 +393,39 @@
 				else
 					edge_eligible = 1
 
-			//VOREStation Add
 			if(nonsolid && damage >= max_damage)
 				droplimb(TRUE, DROPLIMB_EDGE)
 			else if (robotic >= ORGAN_NANOFORM && damage >= max_damage)
 				droplimb(TRUE, DROPLIMB_BURN)
-			//VOREStation Add End
-			//VOREStation Edit - We have special droplimb handling for prom/proteans
-			else if(edge_eligible && brute >= max_damage / DROPLIMB_THRESHOLD_EDGE && prob(brute))
+
+			//Math:
+			//Edge w/ 10 damage on an 80 hp limb. First hit: Prob(10) && Prob(12.5) = 1.25% Second hit: Prob(10) && Prob(25) = 2.5, etc up to 10.
+			//Edge w/ 20 damage on an 80 hp limb. First hit: Prob(20) && Prob(25)= 5% Second hit: Prob(20) && Prob(50)=10%, etc up to max 20.
+			else if(edge_eligible && brute >= max_damage / DROPLIMB_THRESHOLD_EDGE && prob(brute) && prob(damage_factor))
 				droplimb(0, DROPLIMB_EDGE)
-			else if((burn >= max_damage / DROPLIMB_THRESHOLD_DESTROY) && prob(burn*0.33))
+
+			//Math:
+			//Burn w/ 25dmg on an 80 hp limb. First hit: Prob(18.75) && Prob(31.25) = ~6% Second Hit: Prob(18.75) && Prob (62.5) =~12, etc up to 18.75
+			//Burn w/ 25dmg on a 50 hp limb. First hit: Prob(18.75) && Prob(50) = ~9% Second hit: 18.75%
+			else if((burn >= max_damage / DROPLIMB_THRESHOLD_DESTROY) && prob(burn*0.75) && prob(damage_factor))
 				droplimb(0, DROPLIMB_BURN)
-			else if((brute >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(brute)))
+
+			//Brute it special. It gets both a chance to destroy AND a chance to knock a limb off!
+			//Math:
+			//Brute w/ 25dmg on an 80 hp limb. First hit: Prob(25) && Prob (31.25) = ~8% Second Hit: ~16% etc up to 25%
+			//Brute w/ 25dmg on a 50 hp limb. First hit: Prob(25) && Prob (50) = 12.5 Second hit: 25%
+			else if((brute >= max_damage / DROPLIMB_THRESHOLD_DESTROY && prob(brute)) && prob(damage_factor))
 				droplimb(0, DROPLIMB_BLUNT)
-			//VOREStation Edit End
-			else if(brute >= max_damage / DROPLIMB_THRESHOLD_TEAROFF && prob(brute*0.33))
+
+			//This is where brute gets it SECOND chance to affect the limb! Much lower probability.
+			//This means you can add this to the above to get brute damage's TRUE drop chance IF the damage is high enough to hit BOTH the DROPLIMB_THRESHOLD_DESTROY & the DROPLIMB_THRESHOLD_TEAROFF
+			//Ex: If it hits
+			//Math:
+			//Brute w/ 25dmg on an 80 hp limb. First hit:  Prob(8.25) && Prob(31.25) = ~2.6% Second Hit: Prob(8.25) && Prob(62.5) = 5%. (This can't ACTUALLY happen with 25 damage with the current numbers, but it's an example to keep it similar to the above.)
+			//Brute w/ 25dmg on a 50 hp limb. First hit: Prob(8.25) && Prob (50) = ~4% Second hit: 8.25%
+			else if(brute >= max_damage / DROPLIMB_THRESHOLD_TEAROFF && prob(brute*0.33) && prob(damage_factor))
 				droplimb(0, DROPLIMB_EDGE)
+
 			else if(spread_dam && owner && parent && (brute_overflow || burn_overflow) && (brute_overflow >= 5 || burn_overflow >= 5) && !permutation) //No infinite damage loops.
 				var/brute_third = brute_overflow * 0.33
 				var/burn_third = burn_overflow * 0.33


### PR DESCRIPTION
Moves around limb code a bit to make cutting/destroying limbs ACTUALLY possible with damage.

Previously, destroying a limb required you to:
1. Reach the person's max_damage to even let you start having a _chance_ to destroy the limb.
2. Have to have a REALLY strong weapon to destroy/cut limbs. We're talking about a blunt weapon requiring 50 to 80 damage depending on the limb to destroy it.
3. Even IF you managed to get a weapon that could destroy a limb, you STILL had a random prob() based on the damage dealt in that blow.

This changes it so instead of requiring you to reach the limb's max_damage to start having chances to drop, it makes it so limbs have two factors: How damaged the limb currently is AND how strong the blow it. If you get shot with a 30 damage revolver in the foot, it has a lower chance of getting gibbed vs the second shot (and subsequent shots!)

This still has thresholds. You can't grab a 5 damage butterknife and chop people's limbs off. But if you step in a 30 damage beatrap, or have a 45 damage rock drop on your hand, it might actually get gibbed or knocked off!