### PR TITLE
fixes mmi holders making 2 brainmobs on re-inserton of MMIs in FBPs

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -46,12 +46,15 @@
 		stored_mmi = null
 	return ..()
 
-/obj/item/organ/internal/mmi_holder/New(var/mob/living/carbon/human/new_owner, var/internal)
+/obj/item/organ/internal/mmi_holder/New(var/mob/living/carbon/human/new_owner, var/internal, var/obj/item/mmi/installed)
 	..(new_owner, internal)
 	var/mob/living/carbon/human/dummy/mannequin/M = new_owner
 	if(istype(M))
 		return
-	stored_mmi = new brain_type(src)
+	if(installed)
+		stored_mmi = installed
+	else
+		stored_mmi = new brain_type(src)
 	sleep(-1)
 	update_from_mmi()
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -491,20 +491,18 @@
 	var/obj/item/mmi/M = tool
 	// VOREstation edit begin - Select the proper mmi holder subtype based on the brain inserted
 	var/obj/item/organ/internal/mmi_holder/holder = null
+	user.drop_from_inventory(M)
+	M.loc = holder
 	if(istype(M,/obj/item/mmi/digital/posibrain/nano))
-		holder = new /obj/item/organ/internal/mmi_holder/posibrain/nano(target, 1)
+		holder = new /obj/item/organ/internal/mmi_holder/posibrain/nano(target, 1, M)
 	else if(istype(M,/obj/item/mmi/digital/posibrain))
-		holder = new /obj/item/organ/internal/mmi_holder/posibrain(target, 1)
+		holder = new /obj/item/organ/internal/mmi_holder/posibrain(target, 1, M)
 	else if(istype(M,/obj/item/mmi/digital/robot))
-		holder = new /obj/item/organ/internal/mmi_holder/robot(target, 1)
+		holder = new /obj/item/organ/internal/mmi_holder/robot(target, 1, M)
 	else
-		holder = new /obj/item/organ/internal/mmi_holder(target, 1) // Fallback to old behavior if organic MMI or if no subtype exists.
-	//VOREstation edit end
+		holder = new /obj/item/organ/internal/mmi_holder(target, 1, M) // Fallback to old behavior if organic MMI or if no subtype exists.
+    //VOREstation edit end
 	target.internal_organs_by_name["brain"] = holder
-	user.drop_from_inventory(tool)
-	tool.loc = holder
-	holder.stored_mmi = tool
-	holder.update_from_mmi()
 
 	if(M.brainmob && M.brainmob.mind)
 		M.brainmob.mind.transfer_to(target)


### PR DESCRIPTION
title, This is why doing *flip after re-installing ones brain sometimes freezes their life ticks forever. Thanks Kash.

🆑
fix: Re-inserting MMIs inside of FBPs does not make a second brainmob, making you twice as smart anymore.
/:cl: