### PR TITLE
Fixes taur rigsuits disappearing when dir changed

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -302,3 +302,4 @@
 	. = ..()
 	if(. && (species.tail || tail_style))
 		update_tail_showing()
+		update_inv_wear_suit()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1087,6 +1087,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			. = tail_overlay
 
 	apply_layer(tail_layer)
+	update_inv_wear_suit() //In case we have a suit that obscures our tail! Otherwise the suit disappears!
 
 //Not really once, since BYOND can't do that.
 //Update this if the ability to flick() images or make looping animation start at the first frame is ever added.

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1087,7 +1087,6 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			. = tail_overlay
 
 	apply_layer(tail_layer)
-	update_inv_wear_suit() //In case we have a suit that obscures our tail! Otherwise the suit disappears!
 
 //Not really once, since BYOND can't do that.
 //Update this if the ability to flick() images or make looping animation start at the first frame is ever added.


### PR DESCRIPTION
Previously, if a taur was wearing a rigsuit, the sprite would show up initially before proceeding to disappear the first time you changed your direction. This fixes that and makes it so your taur rigsuit sprite stays while it's on, even if you change direction.

![2024-12-28_05-13-49](https://github.com/user-attachments/assets/ed9ff263-5c08-4ca8-891a-51f9cb099317)
