### PR TITLE
fix pakkun and simple mob language

### DIFF
--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -11,24 +11,39 @@
 
 // Silicons can't neccessarily speak everything in their languages list
 /mob/living/silicon/set_default_language()
+	if(!LAZYLEN(speech_synthesizer_langs))
+		to_chat(src, span_warning("You can't speak any languages."))
+		return
 	var/language = tgui_input_list(usr, "Select your default language", "Available languages", speech_synthesizer_langs)
 	// Silicons have no species language usually. So let's default them to GALCOM
 	if(!language)
-		to_chat(src, span_notice("You will now speak your standard default language, common, if you do not specify a language when speaking."))
+		var/found = FALSE
 		for(var/datum/language/lang in speech_synthesizer_langs)
 			if(lang.name == LANGUAGE_GALCOM)
-				default_language = lang
+				language = lang
+				found = TRUE
 				break
+		if(!found)
+			language = speech_synthesizer_langs[1]
+	apply_default_language(language)
+
+// Simple Mobs have no species language, so fall back to their first one
+/mob/living/simple_mob/set_default_language()
+	if(!LAZYLEN(languages))languages
+		to_chat(src, span_warning("You can't speak any languages."))
 		return
+	var/language = tgui_input_list(usr, "Select your default language", "Available languages", languages)
+	if(!language)
+		language = languages[1]
 	apply_default_language(language)
 
 /mob/living/proc/apply_default_language(var/language)
-	if (only_species_language && language != GLOB.all_languages[src.species_language])
-		to_chat(src, span_notice("You can only speak your species language, [src.species_language]."))
+	if (only_species_language && language != GLOB.all_languages[species_language])
+		to_chat(src, span_notice("You can only speak your species language, [species_language]."))
 		return 0
 
-	if(language == GLOB.all_languages[src.species_language])
-		to_chat(src, span_notice("You will now speak your standard default language, [language ? language : "common"], if you do not specify a language when speaking."))
+	if(language == GLOB.all_languages[species_language])
+		to_chat(src, span_notice("You will now speak your standard default language, [language], if you do not specify a language when speaking."))
 	else if (language)
 
 		if(language && !can_speak(language))

--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -81,11 +81,13 @@
 		return
 
 	if(resting)
-		vore_selected.digest_mode = DM_UNABSORB
+		if(isbelly(vore_selected))
+			vore_selected.digest_mode = DM_UNABSORB
 		ai_holder.go_sleep()
 
 	else
-		vore_selected.digest_mode = vore_default_mode
+		if(isbelly(vore_selected))
+			vore_selected.digest_mode = vore_default_mode
 		ai_holder.go_wake()
 
 /mob/living/simple_mob/vore/pakkun/attack_hand(mob/user)


### PR DESCRIPTION
🆑 
fix: Pakkun calling vore procs before init vore had been called, this was missed in the up port
fix: simple mobs getting their language nulled
qol: improve robot language selection by defaulting to the first if they don't know galcom
/🆑 