### PR TITLE
fix speechbubble and runechat position

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -368,10 +368,10 @@ var/list/runechat_image_cache = list()
 	return world.icon_size * 0.95
 
 /atom/movable/runechat_x_offset(width, height)
-	return (width - bound_width) * -0.5
+	return (width - bound_width) * -0.5 + get_oversized_icon_offsets()["x"]
 
 /atom/movable/runechat_y_offset(width, height)
-	return bound_height * 0.95
+	return bound_height * 0.95 + get_oversized_icon_offsets()["y"]
 
 /* Nothing special
 /mob/runechat_x_offset(width, height)

--- a/code/modules/tgui_input/say_modal/typing.dm
+++ b/code/modules/tgui_input/say_modal/typing.dm
@@ -13,6 +13,8 @@
 		cur_bubble_appearance = speech_bubble_appearance()
 	active_thinking_indicator = mutable_appearance('icons/mob/talk_vr.dmi', "[cur_bubble_appearance]_thinking", FLOAT_LAYER)
 	active_thinking_indicator.appearance_flags |= (RESET_COLOR|PIXEL_SCALE)
+	active_thinking_indicator.pixel_x = get_oversized_icon_offsets()["x"]
+	active_thinking_indicator.pixel_y = get_oversized_icon_offsets()["y"]
 	add_overlay(active_thinking_indicator)
 
 /** Removes the thinking indicator over the mob. */
@@ -31,6 +33,8 @@
 		cur_bubble_appearance = speech_bubble_appearance()
 	active_typing_indicator = mutable_appearance('icons/mob/talk_vr.dmi', "[cur_bubble_appearance]_typing", ABOVE_MOB_LAYER)
 	active_typing_indicator.appearance_flags |= (RESET_COLOR|PIXEL_SCALE)
+	active_typing_indicator.pixel_x = get_oversized_icon_offsets()["x"]
+	active_typing_indicator.pixel_y = get_oversized_icon_offsets()["y"]
 	add_overlay(active_typing_indicator)
 
 /** Removes the typing indicator over the mob. */


### PR DESCRIPTION
Ports a few atom helpers from TG and applies them to our speechbubbles and runechat.

🆑
fix: runechat and speechbubble position for larger than 32x32 icons
/:cl: