### PR TITLE
Fixes feysight runtime

### DIFF
--- a/code/modules/mob/_modifiers/feysight.dm
+++ b/code/modules/mob/_modifiers/feysight.dm
@@ -13,12 +13,14 @@
 /datum/modifier/feysight/on_applied()
 	holder.see_invisible = 60
 	holder.see_invisible_default = 60
-	holder.plane_holder.set_vis(VIS_GHOSTS,TRUE)
+	holder.vis_enabled += VIS_GHOSTS
+	holder.recalculate_vis()
 
 /datum/modifier/feysight/on_expire()
 	holder.see_invisible_default = initial(holder.see_invisible_default)
 	holder.see_invisible = holder.see_invisible_default
-	holder.plane_holder.set_vis(VIS_GHOSTS,FALSE)
+	holder.vis_enabled -= VIS_GHOSTS
+	holder.recalculate_vis()
 
 /datum/modifier/feysight/can_apply(var/mob/living/L)
 	if(L.stat)


### PR DESCRIPTION
- Fixes runtime where it would attempt to set_vis on a non-existant plane_holder if mobs was exposed to the artifact

Thanks to Kashgul for the fix