### PR TITLE
Digitigrade for hanner and replicants

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -721,6 +721,9 @@ var/list/preferences_datums = list()
 
 	character.digitigrade = selected_species.digi_allowed ? digitigrade : 0
 
+	for(var/obj/item/clothing/O in character.contents)
+		O.handle_digitigrade(character)
+
 	character.dna.ResetUIFrom(character)
 	character.force_update_limbs()
 	character.regenerate_icons()

--- a/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
@@ -20,6 +20,8 @@
 	min_age = 18
 	max_age = 200
 
+	digi_allowed = TRUE
+
 	//Specific abilities
 
 	burn_mod = 0.8 //Slightly resistant to fire

--- a/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
+++ b/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
@@ -14,6 +14,7 @@
 	siemens_coefficient = 1.5 //Don't get electrocuted
 
 	secondary_langs = list()	// None by default
+	digi_allowed = TRUE
 
 	has_organ = list(
 		O_HEART =		/obj/item/organ/internal/heart/replicant/rage/crew,


### PR DESCRIPTION
Added the option for hanner and replicants to use digitigrade legs.

Changed the total reform ability to account for clothing to match the sprites to the leg type of the new form.

Why not proteans and prommies? Proteans use prosthetic legs that do not change appearance based on the digitigrade option. Prometheans do work with digitigrade legs but they currently do not match the opacity of the rest of the body.