### PR TITLE
Sample Scooping Sanity

### DIFF
--- a/code/modules/samples/container.dm
+++ b/code/modules/samples/container.dm
@@ -27,9 +27,13 @@
 
 /obj/item/storage/sample_container/afterattack(turf/T as turf, mob/user as mob)
 	for(var/obj/item/research_sample/S in T)
-		S.loc = src
-		update_icon()
-		to_chat(user, span_notice("You scoop \the [S] into \the [src]."))
+		if(contents.len >= max_storage_space)
+			to_chat(user, span_notice("\The [src] is full!"))
+			return
+		else
+			S.loc = src
+			update_icon()
+			to_chat(user, span_notice("You scoop \the [S] into \the [src]."))
 
 //Splice research sample containers into the list of valid items for these belts *without* overriding the lists entirely
 /obj/item/storage/belt/explorer/New()

--- a/code/modules/samples/samples.dm
+++ b/code/modules/samples/samples.dm
@@ -193,9 +193,13 @@
 
 	if(istype(P, /obj/item/storage/sample_container))
 		var/obj/item/storage/sample_container/SC = P
-		src.loc = SC
-		SC.update_icon()
-		to_chat(user, span_notice("You store \the [src] in \the [SC]."))
+		if(SC.contents.len >= SC.max_storage_space)
+			to_chat(user, span_notice("\The [SC] is full!"))
+			return
+		else
+			src.loc = SC
+			SC.update_icon()
+			to_chat(user, span_notice("You store \the [src] in \the [SC]."))
 
 	if(istype(P, /obj/item/cataloguer))
 		to_chat(user, span_notice("You start to scan \the [src] with \the [P]..."))


### PR DESCRIPTION
Fixes a silly oversight with sample containers that let you scoop more samples than they could physically contain.

:cl:
fix: fixed sample containers being able to hold more samples if you use the scoop functions
/:cl: