### PR TITLE
Tweak tgui-say colors for me and subtle

### DIFF
--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -25,12 +25,12 @@ $_channel_map: (
   'ITV': #8a8a8a,
   // Modes
   'LOOC': #3a9696,
-  'Me': #5975da,
+  'Me': #485fce,
   'OOC': #cca300,
   'Radio': #1ecc43,
   'Say': #a4bad6,
   'Whis': #7c7fd9,
-  'Subtle': #6366bd
+  'Subtle': #c52076
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
Before:
![https://i.tigercat2000.net/2025/01/dreamseeker_6gY7zs7iJI.png](https://i.tigercat2000.net/2025/01/dreamseeker_6gY7zs7iJI.png)
![https://i.tigercat2000.net/2025/01/dreamseeker_s377Z2DZo9.png](https://i.tigercat2000.net/2025/01/dreamseeker_s377Z2DZo9.png)

After:
![https://i.tigercat2000.net/2025/01/dreamseeker_SdjM09Kqvw.png](https://i.tigercat2000.net/2025/01/dreamseeker_SdjM09Kqvw.png)
![https://i.tigercat2000.net/2025/01/dreamseeker_lGWaikohVu.png](https://i.tigercat2000.net/2025/01/dreamseeker_lGWaikohVu.png)

(Ignore the weird text overlap, it's a 516 bug I haven't fixed yet)

:cl:
tweak: Tgui-say colors adjusted for better contrast
/:cl: