### PR TITLE
fix use of nonexisteing icon state

### DIFF
--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -175,7 +175,7 @@
 	name = "ore chunk"
 	desc = "A conglomerate of ore."
 	icon = 'icons/obj/mining_ore_vr.dmi'
-	icon_state = "strange"
+	icon_state = "ore2"
 	randpixel = 8
 	w_class = ITEMSIZE_SMALL
 	var/list/stored_ore = list(


### PR DESCRIPTION
🆑 
fix: invisible ore chunks
/🆑 


the strange state only exists in the xenoarch file, not in the ore file. So those turn invisible if they are not overridden by a single specific resource in the dynamic one. Using the ore2 state for now to at least show them.