### PR TITLE
creating areas registers them with the grav gen

### DIFF
--- a/code/game/objects/items/blueprints_vr.dm
+++ b/code/game/objects/items/blueprints_vr.dm
@@ -531,6 +531,13 @@
 	if(AO && istype(AO,/obj/item/areaeditor))
 		if(AO.uses_charges)
 			AO.charges -= 1
+
+	var/list/zLevels = using_map.station_levels.Copy()
+	for(var/datum/planet/P in SSplanets.planets)
+		zLevels -= P.expected_z_levels
+	for(var/obj/machinery/gravity_generator/main/GG in machines)
+		if(GG.z in zLevels)
+			GG.update_areas()
 	return TRUE
 
 
@@ -925,6 +932,13 @@
 	to_chat(creator, span_notice("You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered."))
 	message_admins("[key_name(creator, creator.client)] just made a new area called [newA.name] ](<A href='byond://?_src_=holder;[HrefToken()];adminmoreinfo=\ref[creator]'>?</A>) at ([creator.x],[creator.y],[creator.z] - <A href='byond://?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[creator.x];Y=[creator.y];Z=[creator.z]'>JMP</a>)",0,1)
 	log_game("[key_name(creator, creator.client)] just made a new area called [newA.name]")
+
+	var/list/zLevels = using_map.station_levels.Copy()
+	for(var/datum/planet/P in SSplanets.planets)
+		zLevels -= P.expected_z_levels
+	for(var/obj/machinery/gravity_generator/main/GG in machines)
+		if(GG.z in zLevels)
+			GG.update_areas()
 
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
🆑 
qol: when an area is created, it's now automatically registered with the grav gen as long it's in the affected levels and one no longer needs to destroy it and rebuild it. Nonetheless, for the new area to be affected, one has to restart the grav gen
/🆑 