### PR TITLE
fix an issue with multi borg module registers

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -1,4 +1,4 @@
-var/list/GPS_list = list()
+GLOBAL_LIST_EMPTY(GPS_list)
 
 /obj/item/gps
 	name = "global positioning system"
@@ -29,7 +29,7 @@ var/list/GPS_list = list()
 /obj/item/gps/Initialize()
 	. = ..()
 	compass = new(src)
-	GPS_list += src
+	GLOB.GPS_list += src
 	name = "global positioning system ([gps_tag])"
 	update_holder()
 	update_icon()
@@ -93,7 +93,7 @@ var/list/GPS_list = list()
 /obj/item/gps/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	is_in_processing_list = FALSE
-	GPS_list -= src
+	GLOB.GPS_list -= src
 	. = ..()
 	update_holder()
 	QDEL_NULL(compass)
@@ -199,7 +199,7 @@ var/list/GPS_list = list()
 	dat["z_level_detection"] = using_map.get_map_levels(curr.z, long_range)
 
 	var/list/gps_list = list()
-	for(var/obj/item/gps/G in GPS_list - src)
+	for(var/obj/item/gps/G in GLOB.GPS_list - src)
 
 		if(!can_track(G, dat["z_level_detection"]))
 			continue

--- a/code/modules/mob/living/silicon/robot/robot_ui_module.dm
+++ b/code/modules/mob/living/silicon/robot/robot_ui_module.dm
@@ -156,9 +156,12 @@
 /mob/living/silicon/robot/proc/apply_module(var/datum/robot_sprite/new_datum, var/new_module)
 	icon_selected = TRUE
 	var/module_type = robot_modules[new_module]
-	modtype = new_module
-	module = new module_type(src)
-	feedback_inc("cyborg_[lowertext(new_module)]",1)
+	if(modtype != new_module || !module)
+		if(module)
+			qdel(module)
+		modtype = new_module
+		module = new module_type(src)
+		feedback_inc("cyborg_[lowertext(new_module)]",1)
 	updatename()
 	hud_used.update_robot_modules_display()
 	notify_ai(ROBOT_NOTIFICATION_NEW_MODULE, module.name)

--- a/code/modules/telesci/gps_advanced.dm
+++ b/code/modules/telesci/gps_advanced.dm
@@ -36,7 +36,7 @@
 		t += "<BR><A href='byond://?src=\ref[src];advtag=1'>Set Tag</A> "
 		t += "<BR>Tag: [gps_tag]"
 
-		for(var/obj/item/gps/advanced/G in GPS_list)
+		for(var/obj/item/gps/advanced/G in GLOB.GPS_list)
 			var/turf/pos = get_turf(G)
 			var/area/gps_area = get_area(G)
 			var/tracked_gpstag = G.gps_tag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
The way single module robots have their module registered right away could lead to it being registered twice in the ui selection...
## About The Pull Request

<!-- Describe The Pull Request. -->
We now only add a new module if there is none or if it doesn't match the original, in the latter case we delete the old one

🆑 
fix: a rare case with single module locked robot subtypes having two modules
/🆑 