### PR TITLE
""Antagonism"" Cleanup

### DIFF
--- a/code/modules/client/preference_setup/antagonism/02_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/02_candidacy.dm
@@ -1,21 +1,21 @@
 var/global/list/special_roles = list( //keep synced with the defines BE_* in setup.dm --rastaf
 //some autodetection here.
 // Change these to 0 if the equivalent mode is disabled for whatever reason!
-	"traitor" = 1,										// 0
-	"operative" = 1,									// 1
-	"changeling" = 1,									// 2
-	"wizard" = 1,										// 3
-	"malf AI" = 1,										// 4
-	"revolutionary" = 1,								// 5
-	"alien candidate" = 1,								// 6
+	"traitor" = 0,										// 0
+	"operative" = 0,									// 1
+	"changeling" = 0,									// 2
+	"wizard" = 0,										// 3
+	"malf AI" = 0,										// 4
+	"revolutionary" = 0,								// 5
+	"alien candidate" = 0,								// 6
 	"positronic brain" = 1,								// 7
-	"cultist" = 1,										// 8
-	"renegade" = 1,										// 9
-	"ninja" = 1,										// 10
-	"raider" = 1,										// 11
-	"diona" = 1,										// 12
-	"mutineer" = 1,										// 13
-	"loyalist" = 1,										// 14
+	"cultist" = 0,										// 8
+	"renegade" = 0,										// 9
+	"ninja" = 0,										// 10
+	"raider" = 0,										// 11
+	"diona" = 0,										// 12
+	"mutineer" = 0,										// 13
+	"loyalist" = 0,										// 14
 	"pAI candidate" = 1,								// 15
 	//VOREStation Add
 	"lost drone" = 1,									// 16

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -13,7 +13,7 @@
 	category_item_type = /datum/category_item/player_setup_item/occupation
 
 /datum/category_group/player_setup_category/appearance_preferences
-	name = "Antagonism"
+	name = "Special Roles"
 	sort_order = 4
 	category_item_type = /datum/category_item/player_setup_item/antagonism
 


### PR DESCRIPTION
## About The Pull Request

Renames the "Antagonism" tab to the more intuitive/accurate "Special Roles", and disables most of the toggles there
![image](https://github.com/user-attachments/assets/04e159d4-e87b-4867-bcb6-17f8b84d0b68)

Posibrain and pAI candidate were kept as I assume those toggles are used to ping you if someone pokes at a sleeping posibrain or pAI unit.

:cl:
tweak: renamed antagonism tag and hid most of the options there as they're not relevant for our purposes
/:cl: