### PR TITLE
Fixes lateload wire loading

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define	NOREACT					(1<<6)	// Reagents don't react inside this container.
 #define OVERLAY_QUEUED			(1<<7)// Atom queued to SSoverlay for COMPILE_OVERLAYS
 #define IS_BUSY					(1<<8)	// Atom has a TASK_TARGET_EXCLUSIVE do_after with it as the target.
+#define ATOM_INITIALIZED		(1<<31) // Atom has been initialized. Using a flag instead of a variable saves ~25mb total.
 
 //Flags for items (equipment) - Used in /obj/item/var/item_flags
 #define THICKMATERIAL			(1<<0)	// Prevents syringes, parapens and hyposprays if equipped to slot_suit or slot_head.

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -114,6 +114,7 @@
 #define AREA_BLOCK_SUIT_SENSORS		0x800	// If suit sensors are blocked in the area.
 #define AREA_BLOCK_TRACKING			0x1000	// If camera tracking is blocked in the area.
 #define AREA_BLOCK_GHOST_SIGHT		0x2000	// If an area blocks sight for ghosts
+// The 0x80000000 is blocked by INITIALIZED, do NOT use it!
 
 // OnTopic return values
 #define TOPIC_NOACTION 0

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -75,7 +75,7 @@
 ///type and all subtypes should always immediately call Initialize in New()
 #define INITIALIZE_IMMEDIATE(X) ##X/New(loc, ...){\
 	..();\
-	if(!initialized) {\
+	if(!(flags & ATOM_INITIALIZED)) {\
 		args[1] = TRUE;\
 		SSatoms.InitAtom(src, args);\
 	}\

--- a/code/__defines/turfs.dm
+++ b/code/__defines/turfs.dm
@@ -8,6 +8,7 @@
 #define TURF_HAS_CORNERS        128
 #define TURF_IS_FRAGILE         256
 #define TURF_ACID_IMMUNE        512
+// The 0x80000000 is blocked by INITIALIZED, do NOT use it!
 
 //Used for floor/wall smoothing
 #define SMOOTH_NONE 0	//Smooth only with itself

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -39,14 +39,14 @@ SUBSYSTEM_DEF(atoms)
 		created_atoms = list()
 		count = atoms.len
 		for(var/atom/A as anything in atoms)
-			if(!A.initialized)
+			if(!(A.flags & ATOM_INITIALIZED))
 				if(InitAtom(A, mapload_arg))
 					atoms -= A
 				CHECK_TICK
 	else
 		count = 0
 		for(var/atom/A in world) // This must be world, since this operation adds all the atoms to their specific lists.
-			if(!A.initialized)
+			if(!(A.flags & ATOM_INITIALIZED))
 				InitAtom(A, mapload_arg)
 				++count
 				CHECK_TICK
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(atoms)
 
 	if(!A)	//possible harddel
 		qdeleted = TRUE
-	else if(!A.initialized)
+	else if(!(A.flags & ATOM_INITIALIZED))
 		BadInitializeCalls[the_type] |= BAD_INIT_DIDNT_INIT
 
 	return qdeleted || QDELING(A)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -39,7 +39,7 @@
 	//Detective Work, used for the duplicate data points kept in the scanners
 	var/list/original_atom
 	// Track if we are already had initialize() called to prevent double-initialization.
-	var/initialized = FALSE
+	//var/initialized = FALSE // using the atom flags
 
 	/// Last name used to calculate a color for the chatmessage overlays
 	var/chat_color_name
@@ -91,9 +91,9 @@
 /atom/proc/Initialize(mapload, ...)
 	if(QDELETED(src))
 		stack_trace("GC: -- [type] had initialize() called after qdel() --")
-	if(initialized)
+	if(flags & ATOM_INITIALIZED) //CHOMPEdit moved initialized to flag
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
-	initialized = TRUE
+	flags |= ATOM_INITIALIZED //CHOMPEdit moved initialized to flag
 	return INITIALIZE_HINT_NORMAL
 
 /atom/Destroy()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -15,7 +15,7 @@
 	var/list/blend_objects = newlist() // Objects which to blend with
 	var/list/noblend_objects = newlist() //Objects to avoid blending with (such as children of listed blend objects.
 
-/obj/structure/Initialize()
+/obj/structure/Initialize(mapload)
 	. = ..()
 	if(climbable)
 		verbs += /obj/structure/proc/climb_on

--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -57,7 +57,7 @@
 	activated = 1
 	for(var/obj/effect/wingrille_spawn/other in neighbours)
 		if(!other.activated) other.activate()
-	if(initialized && !QDELETED(src))
+	if((flags & ATOM_INITIALIZED) && !QDELETED(src))
 		qdel(src)
 
 /obj/effect/wingrille_spawn/proc/handle_window_spawn(var/obj/structure/window/W)

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -21,7 +21,7 @@ var/list/floor_decals = list()
 // abstract handler that explicitly doesn't invoke any obj behavior.
 /obj/effect/floor_decal/Initialize()
 	add_to_turf_decals()
-	initialized = TRUE
+	flags |= ATOM_INITIALIZED
 	return INITIALIZE_HINT_QDEL
 
 // This is a separate proc from initialize() to facilitiate its caching and other stuff.  Look into it someday.
@@ -1254,4 +1254,3 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal/arrows
 	name = "floor arrows"
 	icon_state = "arrows"
-

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -7,7 +7,7 @@
 
 /turf/unsimulated/Initialize(mapload)
 	if(skip_init)
-		initialized = TRUE
+		flags |= ATOM_INITIALIZED
 		return INITIALIZE_HINT_NORMAL
 	. = ..()
 
@@ -17,7 +17,6 @@
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
 	dynamic_lighting = FALSE
-	initialized = FALSE
 
 /turf/unsimulated/fake_space/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/unsimulated/sky_vr.dm
+++ b/code/game/turfs/unsimulated/sky_vr.dm
@@ -8,7 +8,6 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "sky_slow"
 	dir = SOUTH
-	initialized = FALSE
 	var/does_skyfall = TRUE
 	var/list/skyfall_levels
 

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -15,11 +15,12 @@
 	var/discard_prob = 0 // If non-zero, there is a chance that the map seeding algorithm will skip this template when selecting potential templates to use.
 
 /datum/map_template/New(path = null, rename = null)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
 	if(path)
 		mappath = path
 	if(mappath)
-		spawn(1)
-			preload_size(mappath)
+		preload_size(mappath)
 	if(rename)
 		name = rename
 
@@ -46,7 +47,6 @@
 	var/list/turf/turfs = block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
 	                   			locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
 	for(var/turf/B as anything in turfs)
-		atoms += B
 		areas |= B.loc
 		for(var/A in B)
 			atoms += A
@@ -57,7 +57,7 @@
 	atoms |= areas
 
 	admin_notice(span_danger("Initializing newly created atom(s) in submap."), R_DEBUG)
-	SSatoms.InitializeAtoms(atoms)
+	SSatoms.InitializeAtoms(areas + turfs + atoms)
 
 	admin_notice(span_danger("Initializing atmos pipenets and machinery in submap."), R_DEBUG)
 	SSmachines.setup_atmos_machinery(atmos_machines)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -94,7 +94,7 @@
 		var/new_type = pickweight(sk_types)
 
 		new new_type(loc)
-		initialized = TRUE
+		flags |= ATOM_INITIALIZED
 		return INITIALIZE_HINT_QDEL
 
 	if(icon_state == "map_example")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -25,7 +25,7 @@
 /mob/new_player/New()
 	mob_list += src
 	add_verb(src, /mob/proc/insidePanel)
-	initialized = TRUE // Explicitly don't use Initialize().  New players join super early and use New()
+	flags |= ATOM_INITIALIZED // Explicitly don't use Initialize().  New players join super early and use New()
 
 
 /mob/new_player/Destroy()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -89,7 +89,7 @@ var/list/possible_cable_coil_colours = list(
 /obj/structure/cable/white
 	color = COLOR_WHITE
 
-/obj/structure/cable/Initialize()
+/obj/structure/cable/Initialize(mapload)
 	. = ..()
 
 	// ensure d1 & d2 reflect the icon_state for entering and exiting cable
@@ -158,6 +158,9 @@ var/list/possible_cable_coil_colours = list(
 	return 1
 
 /obj/structure/cable/update_icon()
+	 // We rely on the icon state for the wire Initialize(), prevent any updates to the icon before init passed
+	if(!(flags & ATOM_INITIALIZED))
+		return
 	icon_state = "[d1]-[d2]"
 	alpha = invisibility ? 127 : 255
 

--- a/maps/expedition_vr/beach/_beach.dm
+++ b/maps/expedition_vr/beach/_beach.dm
@@ -70,7 +70,7 @@
 	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_BEACH_CAVE, world.maxx, world.maxy)
 	new /datum/random_map/noise/ore/beachmine(null, 1, 1, Z_LEVEL_BEACH_CAVE, 64, 64)*/
 
-	initialized = TRUE
+	flags |= ATOM_INITIALIZED
 	return INITIALIZE_HINT_QDEL
 
 // Two mob spawners that are placed on the map that spawn some mobs!

--- a/maps/expedition_vr/space/_debrisfield.dm
+++ b/maps/expedition_vr/space/_debrisfield.dm
@@ -45,7 +45,7 @@
 	name = "away mission initializer - debrisfield"
 
 /obj/away_mission_init/debrisfield/Initialize()
-	initialized = TRUE
+	flags |= ATOM_INITIALIZED
 	return INITIALIZE_HINT_QDEL
 
 /area/tether_away/debrisfield

--- a/maps/offmap_vr/common_offmaps.dm
+++ b/maps/offmap_vr/common_offmaps.dm
@@ -488,7 +488,7 @@
 
 	if(!LAZYLEN(mobs_to_pick_from))
 		error("Mob spawner at [x],[y],[z] ([get_area(src)]) had no mobs_to_pick_from set on it!")
-		initialized = TRUE
+		flags |= ATOM_INITIALIZED
 		return INITIALIZE_HINT_QDEL
 	START_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Ok this was a little tricky, loadload wires use ChangeTurf which then updates the invisibility, modifying the icon state. Currently all of our map edited wires rely on the icon state. In the future, we maybe should overhaul the entire wire mapping. But for now, we'll deny any icon updates until the cable passed Initialize

🆑 
fix: lateloaded map template cables failing initialize with their proper attributes
/🆑 