### PR TITLE
Upre adds circular saw to sciborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -712,6 +712,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/multitool(src)
 	src.modules += new /obj/item/surgical/hemostat/cyborg(src) //Synth repair
 	src.modules += new /obj/item/surgical/surgicaldrill/cyborg(src) //NIF repair
+	src.modules += new /obj/item/surgical/circular_saw/cyborg(src) // Synth limb replacement
 	src.modules += new /obj/item/reagent_containers/syringe(src)
 	src.modules += new /obj/item/reagent_containers/glass/beaker/large/borg(src)
 	src.modules += new /obj/item/storage/part_replacer(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
The latest changes to limb loss code led to situations where a sciborg was unable to do synth surgery if a stump had to be removed before replacement 

## About The Pull Request

<!-- Describe The Pull Request. -->
🆑 
qol: re-adds circular saw to sciborgs
/:cl: