### PR TITLE
Robot decal fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
@@ -135,7 +135,7 @@
 		return
 
 /datum/robot_sprite/proc/get_robotdecal_overlay(var/mob/living/silicon/robot/ourborg)
-	if(!(ourborg.resting && has_rest_sprites))
+	if(!(ourborg.resting && has_robotdecal_sprites))
 		return "[sprite_icon_state]-decals"
 	else
 		return


### PR DESCRIPTION
Fixes a typo
## About The Pull Request

Fixes robot decals inappropriately showing if has resting sprite was set to TRUE

## Changelog
:cl:
fix: Makes robot decals show up properly
/:cl:
