### PR TITLE
Lose some weight, fatty

### DIFF
--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	anchored = TRUE
 	var/being_used = 0
+	var/weightloss_power = 1
 
 /obj/structure/fitness/punchingbag
 	name = "punching bag"
@@ -23,6 +24,7 @@
 			playsound(src, 'sound/effects/woodhit.ogg', 25, 1, -1)
 			user.do_attack_animation(src)
 			user.nutrition = user.nutrition - 5
+			user.weight -= 0.25 * weightloss_power * (0.01 * user.weight_loss)
 			to_chat(user, span_warning("You [pick(hit_message)] \the [src]."))
 
 /obj/structure/fitness/weightlifter
@@ -59,6 +61,8 @@
 		if(do_after(user, 20 + (weight * 10)))
 			playsound(src, 'sound/effects/weightdrop.ogg', 25, 1)
 			user.adjust_nutrition(weight * -10)
+			var/weightloss_enhanced = weightloss_power * (weight * 0.5)
+			user.weight -= 0.25 * weightloss_enhanced * (0.01 * user.weight_loss)
 			to_chat(user, span_notice("You lift the weights [qualifiers[weight]]."))
 			being_used = 0
 		else

--- a/code/modules/vore/weight/fitness_machines_vr.dm
+++ b/code/modules/vore/weight/fitness_machines_vr.dm
@@ -21,7 +21,7 @@
 	else //If they have enough nutrition and body weight, they can exercise.
 		user.setClickCooldown(cooldown)
 		user.adjust_nutrition(-10 * weightloss_power)
-		user.weight -= 0.025 * weightloss_power * (0.01 * user.weight_loss)
+		user.weight -= 0.25 * weightloss_power * (0.01 * user.weight_loss)
 		flick("[icon_state]2", src)
 		var/message = pick(messages)
 		to_chat(user, span_notice("[message]."))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changed fitness machines and structures to actually help you lose weight other than rapidly draining your nutrition. Machine types have had their weight loss multiplied by 10 so they no longer take 80 or 40 uses to lose 1lb. Structure types previously had no weight loss attached, they now have similar amounts to the machine types.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Changed fitness machines to drain your weight ten times faster.
balance: Changed fitness structures to drain your weight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
