### PR TITLE
Adds a persistent notes feature

### DIFF
--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -54,6 +54,8 @@
 	. += span_bold("Spawn With Backup Implant:") + " <a [pref.auto_backup_implant ? "class='linkOn'" : ""] href='byond://?src=\ref[src];toggle_implant=1'><b>[pref.auto_backup_implant ? "Yes" : "No"]</b></a><br>"
 	. += span_bold("Allow petting as robot:") + " <a [pref.borg_petting ? "class='linkOn'" : ""] href='byond://?src=\ref[src];toggle_borg_petting=1'><b>[pref.borg_petting ? "Yes" : "No"]</b></a><br>"
 	. += span_bold("Enable Stomach Sprites:") + " <a [pref.stomach_vision ? "class='linkOn'" : ""] href='byond://?src=\ref[src];toggle_stomach_vision=1'><b>[pref.stomach_vision ? "Yes" : "No"]</b></a><br>"
+	if(CONFIG_GET(flag/allow_metadata))
+		. += span_bold("Private Notes: <a href='byond://?src=\ref[src];edit_private_notes=1'>Edit</a>") + "<br>"
 
 /datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["toggle_show_in_directory"])
@@ -94,4 +96,8 @@
 	else if(href_list["toggle_stomach_vision"])
 		pref.stomach_vision = pref.stomach_vision ? 0 : 1;
 		return TOPIC_REFRESH
+	else if(href_list["edit_private_notes"])
+		var/new_metadata = sanitize(tgui_input_text(user,"Write some notes for yourself. These can be anything that is useful, whether it's character events that you want to remember or a bit of lore. Things that you would normally stick in a txt file for yourself!", "Private Notes", html_decode(pref.read_preference(/datum/preference/text/living/private_notes)), multiline = TRUE, prevent_enter = TRUE), extra = 0)
+		if(new_metadata && CanUseTopic(user))
+			pref.update_preference_by_type(/datum/preference/text/living/private_notes, new_metadata)
 	return ..();

--- a/code/modules/client/preferences/types/character/general/01_basic.dm
+++ b/code/modules/client/preferences/types/character/general/01_basic.dm
@@ -173,3 +173,14 @@
 
 /datum/preference/choiced/living/spawnpoint/apply_to_living(mob/living/target, value)
 	return // handled in job_controller
+
+/datum/preference/text/living/private_notes
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "Private_Notes"
+	maximum_value_length = MAX_MESSAGE_LEN * 4
+	can_randomize = FALSE
+
+/datum/preference/text/living/private_notes/apply_to_living(mob/living/target, value)
+	target.private_notes = value
+	return

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -10,6 +10,7 @@
 	var/custom_link = null
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER|LONG_GLIDE
 	var/hunger_rate = DEFAULT_HUNGER_FACTOR
+	var/private_notes = null
 //custom say verbs
 	var/custom_say = null
 	var/custom_ask = null

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -145,3 +145,29 @@
 	if(!choice)
 		voice_sounds_list = talk_sound
 	voice_sounds_list = get_talk_sound(choice)
+
+/mob/living/proc/save_private_notes()
+	if(usr != src)
+		return
+	if(client.prefs.real_name != real_name)
+		to_chat(usr, span_danger("Your selected character slot name is not the same as your character's name. Aborting save. Please select [real_name]'s character slot in character setup before saving."))
+		return
+	if(client.prefs.save_character())
+		to_chat(usr, span_filter_notice("Character preferences saved."))
+
+/mob/living/verb/open_private_notes()
+	set name = "Private Notes"
+	set desc = "View and edit your character's private notes, that persist between rounds!"
+	set category = "IC.Notes"
+
+	private_notes_window(usr)
+
+/mob/living/proc/set_metainfo_private_notes()
+	if(usr != src)
+		return
+	var/new_metadata = sanitize(tgui_input_text(usr,"Write some notes for yourself. These can be anything that is useful, whether it's character events that you want to remember or a bit of lore. Things that you would normally stick in a txt file for yourself! This will not be saved unless you press save in the private notes panel.", "Private Notes", html_decode(private_notes), multiline = TRUE, prevent_enter = TRUE), extra = 0)
+	if(new_metadata && CanUseTopic(usr))
+		private_notes = new_metadata
+		client.prefs.update_preference_by_type(/datum/preference/text/living/private_notes, new_metadata)
+		to_chat(usr, span_filter_notice("Private notes updated. Don't forget to save!"))
+		private_notes_window(usr)

--- a/code/modules/mob/living/private_notes.dm
+++ b/code/modules/mob/living/private_notes.dm
@@ -1,0 +1,68 @@
+/mob/living/proc/private_notes_window(mob/user)
+	if(!private_notes)
+		private_notes = " "
+		return
+	var/notes = replacetext(html_decode(src.private_notes), "\n", "<BR>")
+	var/dat = {"
+	<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
+	<html>
+		<head>
+			<style>
+				.collapsible {
+					background-color: #263d20;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.collapsible_b {
+					background-color: #3f1a1a;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.content {
+					padding: 5;
+					width: 100%;
+					background-color: #363636;
+				}
+
+				</style>
+			</head>"}
+
+	dat += {"<body><table>"}
+	if(user == src)
+		dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];save_private_notes=1' class='button'>Save Character Preferences</a>
+			</td>
+			"}
+
+	if(user == src)
+		dat += {"
+				<br>
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_private_notes=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	dat += {"
+		<br>
+		<p>[notes]</p>
+		<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1">"}
+
+	var/key = "private_notes[src.real_name]"	//Generate a unique key so we can make unique clones of windows, that way we can have more than one
+	if(src.ckey)
+		key = "[key][src.ckey]"				//Add a ckey if they have one, in case their name is the same
+
+	winclone(user, "private_notes", key)		//Allows us to have more than one OOC notes panel open
+
+	winshow(user, key, TRUE)				//Register our window
+	var/datum/browser/popup = new(user, key, "Private Notes: [src.name]", 500, 600)		//Create the window
+	popup.set_content(dat)	//Populate window contents
+	popup.open(FALSE) // Skip registring onclose on the browser pane
+	onclose(user, key, src) // We want to register on the window itself

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -213,6 +213,7 @@ var/list/ai_verbs_default = list(
 		ooc_notes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes)
 		ooc_notes_likes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_likes)
 		ooc_notes_dislikes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_dislikes)
+		private_notes = client.prefs.read_preference(/datum/preference/text/living/private_notes)
 
 	if (malf && !(mind in malf.current_antagonists))
 		show_laws()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -152,6 +152,7 @@
 		ooc_notes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes)
 		ooc_notes_likes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_likes)
 		ooc_notes_dislikes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_dislikes)
+		private_notes = client.prefs.read_preference(/datum/preference/text/living/private_notes)
 
 	src << sound('sound/effects/pai_login.ogg', volume = 75)	//VOREStation Add
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -408,6 +408,7 @@
 		ooc_notes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes)
 		ooc_notes_likes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_likes)
 		ooc_notes_dislikes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_dislikes)
+		private_notes = client.prefs.read_preference(/datum/preference/text/living/private_notes)
 		custom_link = client.prefs.custom_link
 
 /mob/living/silicon/robot/verb/namepick()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -20,6 +20,7 @@
 	ooc_notes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes)
 	ooc_notes_likes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_likes)
 	ooc_notes_dislikes = client.prefs.read_preference(/datum/preference/text/living/ooc_notes_dislikes)
+	private_notes = client.prefs.read_preference(/datum/preference/text/living/private_notes)
 	digestable = client.prefs_vr.digestable
 	devourable = client.prefs_vr.devourable
 	absorbable = client.prefs_vr.absorbable

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -292,7 +292,8 @@
 
 /mob/verb/memory()
 	set name = "Notes"
-	set category = "IC.Game"
+	set desc = "View notes stored for this round only."
+	set category = "IC.Notes"
 	if(mind)
 		mind.show_memory(src)
 	else
@@ -300,7 +301,8 @@
 
 /mob/verb/add_memory(msg as message)
 	set name = "Add Note"
-	set category = "IC.Game"
+	set desc = "Add notes stored for this round only."
+	set category = "IC.Notes"
 
 	msg = sanitize(msg)
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1194,6 +1194,12 @@
 			save_ooc_panel()
 	if(href_list["print_ooc_notes_to_chat"])
 		print_ooc_notes_to_chat()
+	if(href_list["save_private_notes"])
+		if(usr == src)
+			save_private_notes()
+	if(href_list["edit_private_notes"])
+		if(usr == src)
+			set_metainfo_private_notes()
 	return ..()
 
 /mob/living/proc/display_voreprefs(mob/user)	//Called by Topic() calls on instances of /mob/living (and subtypes) containing vore_prefs as an argument

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2983,6 +2983,7 @@
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"
 #include "code\modules\mob\living\ooc_notes.dm"
+#include "code\modules\mob\living\private_notes.dm"
 #include "code\modules\mob\living\organs.dm"
 #include "code\modules\mob\living\riding.dm"
 #include "code\modules\mob\living\say.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a new "Private Notes" option to character setup, and a new "Private Notes" verb that opens them up and allows you to see and edit them in-game in the same way as OOC Notes.

These notes are simply a block of persistent text, purely for your own viewing. The entire purpose of them is for making notes for your own use, such as adding info if you come up with lore on the fly, so that you can easily reference it in the future. You can obviously store anything in there that you'd normally put into a txt file, it's just an easy way to organise info directly tied to your character. This works on a character by character basis.

I've tried to follow the template used for OOC Notes as best I can, because I believe that shadow has updated those to be tg style prefs, so that it'll not need to be redone.

I know that there are a few instances of usr instead of user in here too, I am not sure if they are appropriate or not as I just followed the way that similar settings work. Please do poke me if that needs changing.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a new "Private Notes" option to character setup.
add: Added a new "Private Notes" verb to the IC tab.
qol: Moved memory "Note" verbs to a new Notes sub category in the IC tab alongside the new Private Notes function.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
