### PR TITLE
Fix escape pod doors status in UI displaying as error

### DIFF
--- a/tgui/packages/tgui/interfaces/EmbeddedController/EmbeddedControllerHelpers.tsx
+++ b/tgui/packages/tgui/interfaces/EmbeddedController/EmbeddedControllerHelpers.tsx
@@ -198,6 +198,7 @@ export const DockingStatus = (props: { state: string }) => {
   const dockHatch: React.JSX.Element[] = [];
 
   dockHatch['open'] = <Box color="average">OPEN</Box>;
+  dockHatch['closed'] = <Box color="good">CLOSED</Box>;
   dockHatch['unlocked'] = <Box color="average">UNSECURED</Box>;
   dockHatch['locked'] = <Box color="good">SECURED</Box>;
   return (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR simply fixes a missing state for escape pod TGUI displaying ERROR instead of CLOSED.

It won't ever display UNSECURED or SECURED unless you pass it the lock state instead (but moot in this case because it should always be SECURED).

![pod](https://github.com/user-attachments/assets/319e5b09-9173-40e3-a516-4aa5ddc9b300)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Drathek
fix: Fixed escape pod UI saying ERROR instead of CLOSED for its hatch
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
