### PR TITLE
Gloves tempfix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -380,7 +380,7 @@
 	var/mob/living/carbon/human/H = user
 
 	if(slot && slot == slot_gloves)
-		var/obj/item/clothing/gloves/G = H.gloves
+		var/obj/item/clothing/G = H.gloves
 		if(istype(G))
 			ring = H.gloves
 			if(ring.glove_level >= src.glove_level)


### PR DESCRIPTION
## About The Pull Request

Partial fix for #16929, causes the covered gloves to fall out at your feet when retracting the hardsuit gloves. Not ideal compared to properly re-equipping, but it keeps them from being permanently eaten.

## Changelog

:cl:
fix: partially fixes hardsuits eating gloves
/:cl:
