### PR TITLE
Fixed broken signposts in fantasy redgate

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -12,6 +12,12 @@
 		if(user.z != src.z)	return
 		user.forceMove(pick(latejoin))
 
+/obj/structure/signpost_fake
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "signpost"
+	anchored = TRUE
+	density = TRUE
+
 /obj/structure/signpostwood
 	name = "signpost"
 	desc = "It's a signpost that tells you things!"

--- a/maps/redgate/fantasy.dmm
+++ b/maps/redgate/fantasy.dmm
@@ -5104,7 +5104,7 @@
 /turf/simulated/floor/concrete,
 /area/redgate/fantasy/castle)
 "FE" = (
-/obj/structure/signpost,
+/obj/structure/signpost_fake,
 /turf/simulated/floor/outdoors/grass/seasonal,
 /area/redgate/fantasy/streets)
 "FH" = (


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed signposts that would break your character in the fantasy redgate map.

I am not sure why the forcemove of the normal signposts causes a glitch, but I don't really want them to have that ability in this map either anyway.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a new "signpost_fake" structure that looks like other sign posts, but without the teleporting functionality.
maptweak: Fixed signposts that would break your character in the fantasy redgate map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
