### PR TITLE
Makes syringe guns able to fit in holsters

### DIFF
--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -69,7 +69,7 @@
 	w_class = ITEMSIZE_NORMAL
 	force = 7
 	matter = list(MAT_STEEL = 2000)
-	slot_flags = SLOT_BELT
+	slot_flags = SLOT_BELT | SLOT_HOLSTER
 
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic thunk"


### PR DESCRIPTION
Why not, it's a gun.
## About The Pull Request
Allows syringe guns to be put in holsters
## Changelog
:cl:
qol: Syringe guns can be put in holsters
/:cl:

