### PR TITLE
Byond 516 warning message

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -60,6 +60,8 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 /mob/new_player/proc/version_warnings()
 	var/problems // string to store message to present to player as a problem
 
+	if(client.byond_version < 516) // Temporary warning whilst we transition to byond 516.
+		problems = "The server is currently transitioning to BYOND 516, and you are currently on version [client.byond_version]. If you continue to use your current version, you WILL experience UI issues, and very soon older clients will not be able to connect at all. You can update BYOND on the client homepage by switching from stable to beta, just above either the update button or where it says that you are currently up to date. For more information how to update byond, please check the wiki."
 	// TODO: Move this to a config file at some point maybe? What would the structure of that look like?
 	switch(client.byond_build)
 		// http://www.byond.com/forum/post/2711510


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a warning message if clients are older than 516, warning them that the game will soon update to version 516 and that they will experience issues in the meantime, and eventually not be able to connect at all.

This really should be merged alongside the TGUI core update, as that will cause UI issues for clients still on 515.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a warning message if clients are older than 516, warning them that the game will soon update to version 516 and that they will experience issues in the meantime, and eventually not be able to connect at all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
