### PR TITLE
Fixes some bugs pertaining to breath code

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -150,6 +150,11 @@ The box in your backpack has an oxygen tank and gas mask in it."
 	name = "Choking (No Sleeping Gas)"
 	desc = "You're not getting enough sleeping gas. Find some good air before you pass out!"
 	icon_state = "not_enough_tox"
+
+/obj/screen/alert/not_enough_atmos
+	name = "Choking (No Breath)"
+	desc = "The atmosphere around you lacks any form of breathable air! Find some good air before you pass out!"
+	icon_state = "not_enough_oxy"
 //End gas alerts
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -568,10 +568,10 @@
 			if(!L.is_bruised() && prob(8))
 				rupture_lung()
 
-		throw_alert("pressure", /obj/screen/alert/lowpressure)
+		throw_alert("oxy", /obj/screen/alert/not_enough_atmos)
 		return 0
 	else
-		clear_alert("pressure")
+		clear_alert("oxy")
 
 	var/safe_pressure_min = species.minimum_breath_pressure // Minimum safe partial pressure of breathable gas in kPa
 
@@ -585,11 +585,6 @@
 			safe_pressure_min *= 1.5
 		else if(L.is_bruised())
 			safe_pressure_min *= 1.25
-		else if(breath)
-			if(breath.total_moles < BREATH_MOLES / 10 || breath.total_moles > BREATH_MOLES * 5)
-				if(is_below_sound_pressure(get_turf(src)))	//No more popped lungs from choking/drowning
-					if (prob(8))
-						rupture_lung()
 
 	var/safe_exhaled_max = 10
 	var/safe_toxins_max = 0.2
@@ -637,6 +632,8 @@
 	if(inhale_pp < safe_pressure_min)
 		if(prob(20))
 			spawn(0) emote("gasp")
+		if(is_below_sound_pressure(get_turf(src)) && prob(8))	//No more popped lungs from choking/drowning
+			rupture_lung()
 
 		var/ratio = inhale_pp/safe_pressure_min
 		// Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)


### PR DESCRIPTION

## About The Pull Request

Fixes a bug with breath code where your lungs would rupture.
Fixes the alert when you're suffocating in space to show you're suffocating, not that the pressure is low.

## Changelog
:cl:
fix: Fixes spontaneous rupture of lungs when breathing otherwise adequate amounts of air
fix: The proper alert will now show up when you're suffocating in space.
/:cl: