### PR TITLE
Makes tritium no longer slime jelly

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -285,7 +285,7 @@
 
 /datum/reagent/hydrogen/tritium
 	name = REAGENT_TRITIUM
-	id = REAGENT_ID_SLIMEJELLY
+	id = REAGENT_ID_TRITIUM
 	description = "A radioactive isotope of hydrogen. It has two extra neutrons, and shares all other chemical characteristics with hydrogen."
 
 /datum/reagent/lithium/lithium6


### PR DESCRIPTION
## About The Pull Request
Tritium isn't slime jelly any more

how did this happen

## Changelog

:cl:
fix: Tritium no longer acts as slime jelly
/:cl: