### PR TITLE
Let taurs be ridden again

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -4,7 +4,7 @@
 	do_colouration = 1 // Yes color, using tail color
 	color_blend_mode = ICON_MULTIPLY  // The sprites for taurs are designed for ICON_MULTIPLY
 
-	var/can_ride = FALSE			//whether we're real rideable taur or just in that category
+	var/can_ride = TRUE			//whether we're real rideable taur or just in that category
 	offset_x = -16
 	em_block = TRUE
 


### PR DESCRIPTION

## About The Pull Request

Fixed taurs being unable to be ridden.

The default taur file had can_ride set to FALSE, whilst the _vr override was set to TRUE. This was not carried over to the default file when they were merged.

## Changelog
:cl:
fix: Fixed taurs being unable to be ridden.
/:cl:
