### PR TITLE
Augment Adjustments & Fixes

### DIFF
--- a/code/game/objects/items/weapons/augment_items.dm
+++ b/code/game/objects/items/weapons/augment_items.dm
@@ -5,6 +5,7 @@
 	desc = "A surprisingly non-descript item, integrated into its user. You probably shouldn't be seeing this."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "augment_box"
+	embed_chance = -1
 
 
 /obj/item/melee/augment/blade

--- a/code/modules/organs/internal/augment.dm
+++ b/code/modules/organs/internal/augment.dm
@@ -30,6 +30,8 @@
 	var/aug_cooldown = 30 SECONDS
 	var/cooldown = null
 
+	description_fluff = "If attempting to implant a compatible augment into a synthetic limb, the limb must be screwdrivered open and then modified with a multitool before insertion can begin."
+
 /obj/item/organ/internal/augment/Initialize()
 	. = ..()
 	setup_radial_icon()

--- a/code/modules/organs/internal/augment/armmounted.dm
+++ b/code/modules/organs/internal/augment/armmounted.dm
@@ -16,7 +16,7 @@
 
 	target_slot = slot_l_hand
 
-	target_parent_classes = list(ORGAN_FLESH, ORGAN_ASSISTED)
+	target_parent_classes = list(ORGAN_FLESH, ORGAN_ROBOT)
 
 	integrated_object_type = /obj/item/gun/energy/laser/mounted/augment
 

--- a/code/modules/organs/internal/augment/bio.dm
+++ b/code/modules/organs/internal/augment/bio.dm
@@ -84,7 +84,7 @@
 
 	parent_organ = BP_GROIN
 
-	target_parent_classes = list(ORGAN_FLESH, ORGAN_ASSISTED)
+	target_parent_classes = list(ORGAN_FLESH, ORGAN_ROBOT)
 
 	aug_cooldown = 2 MINUTES
 

--- a/code/modules/research/designs/implants.dm
+++ b/code/modules/research/designs/implants.dm
@@ -105,7 +105,7 @@
 
 /datum/design/item/internal/augment/bioaugment/thermalshades
 	desc = "A large implant that fits into a subject's eyes. It allows them to see through walls."
-	id = "surge_implant"
+	id = "thermal_implant"
 	req_tech = list(TECH_BIO = 7, TECH_MATERIAL = 4, TECH_POWER = 7, TECH_ENGINEERING = 7, TECH_COMBAT = 5, TECH_ILLEGAL = 2)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_PHORON = 10000, MAT_GOLD = 2000, MAT_DIAMOND = 10000, MAT_SILVER = 4000, MAT_TITANIUM = 1000) //this is thermals. this is expensive, yo.
 	build_path = /obj/item/organ/internal/augment/bioaugment/thermalshades

--- a/code/modules/research/designs/implants.dm
+++ b/code/modules/research/designs/implants.dm
@@ -20,3 +20,93 @@
 	req_tech = list(TECH_ILLEGAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/implantcase/freedom
 	sort_string = "MFAAB"
+
+/datum/design/item/organ/internal/augment/armmounted/hand
+	desc = "An augment that fits neatly into the hand, useful for determining the usefulness of an object for research."
+	id = "research_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand
+	sort_string = "JVACE"
+
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/multiple
+	desc = "A large implant that fits into a subject's arm. It deploys an array of tools by some painful means."
+	id = "tool_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/multiple
+	sort_string = "JVACI"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/multiple/medical
+	desc = "A large implant that fits into a subject's arm. It deploys an array of tools by some painful means."
+	id = "surgical_implant"
+	req_tech = list(TECH_BIO = 6, TECH_MATERIAL = 4)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/multiple/medical
+	sort_string = "JVACJ"
+
+
+/datum/design/item/organ/internal/augment/armmounted/hand/blade
+	desc = "A large implant that fits into a subject's hand. It deploys a bladed weapon."
+	id = "blade_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 4, TECH_COMBAT = 4)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand/blade
+	sort_string = "JVACK"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/blade
+	desc = "A large implant that fits into a subject's arm. It deploys a large, bladed weapon."
+	id = "armblade_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 5, TECH_COMBAT = 6)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 1000, MAT_GOLD = 2000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/blade
+	sort_string = "JVACL"
+
+/datum/design/item/organ/internal/augment/armmounted/hand/sword
+	desc = "A large implant that fits into a subject's hand. It deploys a large, energetic weapon."
+	id = "sword_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 6, TECH_COMBAT = 6, TECH_ENGINEERING = 5, TECH_ILLEGAL = 2)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 1000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand/sword
+	sort_string = "JVACM"
+
+/datum/design/item/organ/internal/augment/armmounted/dartbow
+	desc = "A large implant that fits into a subject's arm. It creates a dartbow when activated."
+	id = "dartbow_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 4, TECH_COMBAT = 6, TECH_ILLEGAL = 3)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_PHORON = 4000, MAT_GOLD = 4000, MAT_DIAMOND = 6000)
+	build_path = /obj/item/organ/internal/augment/armmounted/dartbow
+	sort_string = "JVACN"
+
+/datum/design/item/organ/internal/augment/armmounted/taser
+	desc = "A large implant that fits into a subject's arm. It turns into a taser when activated."
+	id = "taser_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 4, TECH_COMBAT = 4)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 2000, MAT_GOLD = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/taser
+	sort_string = "JVACO"
+
+/datum/design/item/organ/internal/augment/armmounted/laser
+	desc = "A large implant that fits into a subject's arm. It turns into a laser when activated."
+	id = "laser_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 4, TECH_COMBAT = 6)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 6000, MAT_GOLD = 4000, MAT_DIAMOND = 4000, MAT_PHORON = 2000)
+	build_path = /obj/item/organ/internal/augment/armmounted
+	sort_string = "JVACP"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/surge
+	desc = "A large implant that fits into a subject's arm. It floods the subject with stimulants to speed them up."
+	id = "surge_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 4, TECH_POWER = 4)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_PHORON = 1000, MAT_GOLD = 2000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/surge
+	sort_string = "JVACQ"
+
+/datum/design/item/internal/augment/bioaugment/thermalshades
+	desc = "A large implant that fits into a subject's eyes. It allows them to see through walls."
+	id = "surge_implant"
+	req_tech = list(TECH_BIO = 7, TECH_MATERIAL = 4, TECH_POWER = 7, TECH_ENGINEERING = 7, TECH_COMBAT = 5, TECH_ILLEGAL = 2)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_PHORON = 10000, MAT_GOLD = 2000, MAT_DIAMOND = 10000, MAT_SILVER = 4000, MAT_TITANIUM = 1000) //this is thermals. this is expensive, yo.
+	build_path = /obj/item/organ/internal/augment/bioaugment/thermalshades
+	sort_string = "JVACR"

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -69,6 +69,41 @@
 // Open Hatch Surgery
 ///////////////////////////////////////////////////////////////
 
+/datum/surgery_step/robotics/insertion_preparation
+	surgery_name = "Rewire Internals"
+	allowed_tools = list(
+		/obj/item/multitool = 100
+	)
+
+	min_duration = 30
+	max_duration = 40
+
+/datum/surgery_step/robotics/insertion_preparation/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		return affected && affected.open == 1
+
+/datum/surgery_step/robotics/insertion_preparation/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(span_filter_notice("[user] starts to modify the wiring in [target]'s [affected.name] with \the [tool]."),
+	span_filter_notice("You start to modify the wiring in [target]'s [affected.name] with \the [tool]."))
+	..()
+
+/datum/surgery_step/robotics/insertion_preparation/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(span_notice("[user] modifies the wiring in [target]'s [affected.name] with \the [tool]."), \
+	 span_notice("You modify the wiring in [target]'s [affected.name] with \the [tool]."))
+	affected.open = 2
+
+/datum/surgery_step/robotics/insertion_preparation/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(span_warning("[user]'s [tool.name] slips, failing to modify the wiring in [target]'s [affected.name]."),
+	span_warning("Your [tool] slips, failing to modify the wiring in [target]'s [affected.name]."))
+
+///////////////////////////////////////////////////////////////
+// Open Hatch Surgery
+///////////////////////////////////////////////////////////////
+
 /datum/surgery_step/robotics/open_hatch
 	surgery_name = "Open Hatch"
 	allowed_tools = list(


### PR DESCRIPTION
## About The Pull Request
kind of part 1 of 2 of augments? I plan to add more organic augments involving modifiers and fleshbending and stuff but that's for another day.

TL;DR: Science gets a bunch of new augment toys that take high tech.

Fixes a longstanding bug with augments where they could not be inserted into robotic limbs due to having the wrong target parent class (Was doing ORGAN_ASSISTED instead of ORGAN_ROBOT)

Adds a new 'surgery step' to allow for the insertion of them as using the crowbar set the stage to 3 instead of 2, meaning you couldn't do the internal/replace_organ step unless stage was set to 2.

Fixes bladed augments from embedding

Makes a LOT of the augments actually craftable now.

## Changelog
:cl:
fix: Fixes a bug where augments could not be inserted into robotic limbs. The step is now screwdriver->multitool to insert them
fix: Melee augments can no longer embed inside someone
add: A lot of the augments are now craftable in science, requiring high tech levels and lots of resources for them.
/:cl:
