### PR TITLE
splits verb and proc

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -716,10 +716,13 @@
 	return
 
 
-/mob/living/verb/Examine_OOC(mob/user = usr)
+/mob/living/verb/Examine_OOC()
 	set name = "Examine Meta-Info (OOC)"
 	set category = "OOC.Game"
 	set src in view()
+	do_examine_ooc(usr)
+
+/mob/living/proc/do_examine_ooc(mob/user)
 	//VOREStation Edit Start - Making it so SSD people have prefs with fallback to original style.
 	if(CONFIG_GET(flag/allow_metadata))
 		if(ooc_notes)

--- a/code/modules/mob/living/silicon/silicon_vr.dm
+++ b/code/modules/mob/living/silicon/silicon_vr.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/Topic(href, href_list) //For Robots and pAI's. And possibly AI's too.
 	if(href_list["ooc_notes"])
-		Examine_OOC(usr)
+		do_examine_ooc(usr)
 		return 1
 	return ..()
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1179,7 +1179,7 @@
 	if(href_list["vore_prefs"])
 		display_voreprefs(usr)
 	if(href_list["ooc_notes"])
-		Examine_OOC(usr)
+		do_examine_ooc(usr)
 	if(href_list["edit_ooc_notes"])
 		if(usr == src)
 			set_metainfo_panel(usr)


### PR DESCRIPTION
splits the ooc examine proc and verb due to some issues with that combined thing... This should work properly with ref forwarding.