### PR TITLE
Xenoarch Gas Tweaks

### DIFF
--- a/code/__defines/xenoarcheaology.dm
+++ b/code/__defines/xenoarcheaology.dm
@@ -1,4 +1,11 @@
 /// <summary>
+/// This is how much artifacts take to activate.
+/// </summary>
+#define ARTIFACT_GAS_TRIGGER 200 //In mols
+#define ARTIFACT_HEAT_TRIGGER 375
+#define ARTIFACT_COLD_TRIGGER 225
+
+/// <summary>
 /// These are the defines for the SMALL (can hold in hand) artifacts.
 /// </summary>
 #define ARCHAEO_BOWL 1

--- a/code/__defines/xenoarcheaology.dm
+++ b/code/__defines/xenoarcheaology.dm
@@ -1,9 +1,10 @@
 /// <summary>
 /// This is how much artifacts take to activate.
 /// </summary>
-#define ARTIFACT_GAS_TRIGGER 200 //In mols
-#define ARTIFACT_HEAT_TRIGGER 375
-#define ARTIFACT_COLD_TRIGGER 225
+#define ARTIFACT_GAS_TRIGGER 200	//In MOL
+#define ARTIFACT_HEAT_TRIGGER 375	//In Kelvin
+#define ARTIFACT_COLD_TRIGGER 225	//In Kelvin
+#define ARTIFACT_HEAT_BREAK 2500	//In Kelvin
 
 /// <summary>
 /// These are the defines for the SMALL (can hold in hand) artifacts.

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -17,6 +17,16 @@
 
 	var/datum/component/artifact_master/artifact_master = /datum/component/artifact_master
 
+/obj/machinery/artifact/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume) //If we get too hot, we burst!
+	if(exposed_temperature >= ARTIFACT_HEAT_BREAK) ///2500K
+		qdel(src)
+
+/obj/machinery/artifact/process() //Air too hot! We break!
+	var/turf/T = get_turf(src)
+	var/datum/gas_mixture/env = T.return_air()
+	if(env && env.temperature > ARTIFACT_HEAT_BREAK)
+		qdel(src)
+
 /obj/machinery/artifact/Destroy()
 	if(artifact_master)
 		var/datum/component/artifact_master/arti_mstr = artifact_master

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -36,8 +36,8 @@
 			qdel(arti_mstr)
 	. = ..()
 
-/obj/machinery/artifact/New()
-	..()
+/obj/machinery/artifact/Initialize(mapload)
+	. = ..()
 
 	if(ispath(artifact_master))
 		AddComponent(artifact_master)

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -189,19 +189,19 @@
 			. += " Activation index involves " + span_bold("forceful or energetic interaction with artifact surface.") + " Potential triggers are a pulse from a multitool or battering the artifact with a strong object."
 
 		if(TRIGGER_HEAT, TRIGGER_COLD) //Heat is easy to activate. Smack it with a welder. Cold? Have to cool the area.
-			. += " Activation index involves " + span_bold("precise temperature conditions.") + " Heating/Cooling the atmosphere (>375K or <225K) or using a welder are potential triggers."
+			. += " Activation index involves " + span_bold("precise temperature conditions.") + " Heating/Cooling the atmosphere (>[ARTIFACT_HEAT_TRIGGER]K or <[ARTIFACT_COLD_TRIGGER]K) or using a welder are potential triggers."
 
 		//Gases are separate since they are a pain in the rear to get activated and might as well let you know exactly what to do.
 		//I've been playing this game since the dawn of man and I've never seen someone bother to actually TRY to set up atmos to get these activated.
 		//Honestly, I'm slating these for removal.
 		if(TRIGGER_PHORON)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Phoron is a potential trigger. (Atmosphere must be >10% of gas to activate device)"
+			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Phoron is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
 		if(TRIGGER_OXY)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Oxygen is a potential trigger. (Atmosphere must be >10% of gas to activate device)"
+			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Oxygen is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
 		if(TRIGGER_CO2)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Carbon Dioxide, is a potential trigger. (Atmosphere must be >10% of gas to activate device)"
+			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Carbon Dioxide, is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
 		if(TRIGGER_NITRO)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Nitrous Oxide is a potential trigger. (Atmosphere must be >10% of gas to activate device)"
+			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Nitrous Oxide is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
 		else
 			. += " Unable to determine any data about activation trigger."
 

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -83,6 +83,10 @@ var/list/toxic_reagents = list(TOXIN_PATH)
  * Component System Registry.
  * Here be dragons.
  */
+/*
+ * Hi, it's me 3 years in the future
+ * Why would you do this to us
+ */
 
 /datum/component/artifact_master/proc/DoRegistry()
 //Melee Hit
@@ -108,6 +112,16 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 /*
  *
  */
+
+/datum/component/artifact_master/proc/do_unregister()
+	UnregisterSignal(holder, COMSIG_PARENT_ATTACKBY)
+	UnregisterSignal(holder, COMSIG_ATOM_EX_ACT)
+	UnregisterSignal(holder, COMSIG_ATOM_BULLET_ACT)
+	UnregisterSignal(holder, COMSIG_ATOM_ATTACK_HAND)
+	UnregisterSignal(holder, COMSIG_MOVABLE_BUMP)
+	UnregisterSignal(holder, COMSIG_ATOM_BUMPED)
+	UnregisterSignal(holder, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(holder, COMSIG_REAGENTS_TOUCH)
 
 /datum/component/artifact_master/proc/get_active_effects()
 	var/list/active_effects = list()
@@ -144,6 +158,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 		qdel(AE)
 
 /datum/component/artifact_master/Destroy()
+	do_unregister()
 	holder = null
 	for(var/datum/artifact_effect/AE in my_effects)
 		AE.master = null
@@ -152,7 +167,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 
 	STOP_PROCESSING(SSobj,src)
 
-	. = ..()
+	. = ..(silent=TRUE)
 
 /datum/component/artifact_master/proc/do_setup()
 	if(LAZYLEN(make_effects))

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -420,18 +420,18 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 	var/turf/T = get_turf(holder)
 	var/datum/gas_mixture/env = T.return_air()
 	if(env)
-		if(env.temperature < 225)
+		if(env.temperature < ARTIFACT_COLD_TRIGGER)
 			trigger_cold = 1
-		else if(env.temperature > 375)
+		else if(env.temperature > ARTIFACT_HEAT_TRIGGER)
 			trigger_hot = 1
 
-		if(env.gas[GAS_PHORON] >= 10)
+		if(env.gas[GAS_PHORON] >= ARTIFACT_GAS_TRIGGER)
 			trigger_phoron = 1
-		if(env.gas[GAS_O2] >= 10)
+		if(env.gas[GAS_O2] >= ARTIFACT_GAS_TRIGGER)
 			trigger_oxy = 1
-		if(env.gas[GAS_CO2] >= 10)
+		if(env.gas[GAS_CO2] >= ARTIFACT_GAS_TRIGGER)
 			trigger_co2 = 1
-		if(env.gas[GAS_N2] >= 10)
+		if(env.gas[GAS_N2] >= ARTIFACT_GAS_TRIGGER)
 			trigger_nitro = 1
 
 	for(var/datum/artifact_effect/my_effect in my_effects)

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -569,7 +569,7 @@
 				apply_image_decorations = TRUE
 			if(prob(25))
 				apply_material_decorations = FALSE
-			new_item = new /obj/item/telecube/randomized/mated(src.loc)
+			new_item = new /obj/item/telecube/randomized(src.loc)
 			item_type = new_item.name
 
 		if(ARCHAEO_BATTERY)


### PR DESCRIPTION
## About The Pull Request
Makes xenoarch  artifacts take more moles to trigger. No longer should activate immediately when excavated
Also fixes horrors beyond comprehension pertaining to the xenoarch gasses
Xenoarch artifacts break if they get too hot
## Changelog
:cl:
code: Makes the artifact gas trigger, artifact heat, and artifact cold activation temps defines
code: Artifacts now properly remove their signals.
balance: Artifacts now take more moles in the air to activate
balance: Artifacts break if they get WAY too hot.
fix: Fixes an error where it said % to activate artifacts. Now properly tells you it is in moles.
balance: Telecubes no longer start mated in xenoarch. This means you'll have to find two of them (and be sad the game won't let you pair them). This means you will no longer get gibbed if you're unlucky
/:cl:
