### PR TITLE
allows robots to "holster" guns

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -236,6 +236,7 @@
 				inv3.icon_state = "inv3 +a"
 				module_active = module_state_3
 				update_icon()
+				return
 	return
 
 //deselect_module(module) - Deselects the module slot specified by "module"

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -154,6 +154,15 @@
 				return TRUE
 	return FALSE
 
+// Checks if the activated module is of the given type
+/mob/living/silicon/robot/proc/activated_module_type_list(var/list/type_to_compare, var/explicit = FALSE)
+	if(!islist(type_to_compare))
+		return FALSE
+	for(var/type in type_to_compare)
+		if(istype(module_active, type))
+			return TRUE
+	return FALSE
+
 /mob/living/silicon/robot/proc/is_type_in_modules(var/type, var/list/modules, var/explicit = FALSE)
 	for(var/atom/module in modules)
 		if(explicit && isatom(module))
@@ -210,6 +219,7 @@
 				inv2.icon_state = "inv2"
 				inv3.icon_state = "inv3"
 				module_active = module_state_1
+				update_icon()
 				return
 		if(2)
 			if(module_active != module_state_2)
@@ -217,6 +227,7 @@
 				inv2.icon_state = "inv2 +a"
 				inv3.icon_state = "inv3"
 				module_active = module_state_2
+				update_icon()
 				return
 		if(3)
 			if(module_active != module_state_3)
@@ -224,7 +235,7 @@
 				inv2.icon_state = "inv2"
 				inv3.icon_state = "inv3 +a"
 				module_active = module_state_3
-				return
+				update_icon()
 	return
 
 //deselect_module(module) - Deselects the module slot specified by "module"
@@ -236,16 +247,19 @@
 			if(module_active == module_state_1)
 				inv1.icon_state = "inv1"
 				module_active = null
+				update_icon()
 				return
 		if(2)
 			if(module_active == module_state_2)
 				inv2.icon_state = "inv2"
 				module_active = null
+				update_icon()
 				return
 		if(3)
 			if(module_active == module_state_3)
 				inv3.icon_state = "inv3"
 				module_active = null
+				update_icon()
 				return
 	return
 

--- a/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/_sprite_datum.dm
@@ -55,39 +55,37 @@
 			if(shield && shield.active)
 				ourborg.add_overlay("[sprite_icon_state]-shield")
 
-	for(var/thing_to_check in ourborg.get_active_modules()) //We look at our active modules. Let's peep!
+	if(ourborg.activated_module_type_list(list(/obj/item/melee/robotic, /obj/item/gun/energy/robotic)))
+		for(var/thing_to_check in ourborg.get_active_modules()) //We look at our active modules. Let's peep!
 
-		//Melee Check
-		if(istype(thing_to_check, /obj/item/melee/robotic))
-			var/obj/item/melee/robotic/melee = thing_to_check
-			if(sprite_flag_check(ROBOT_HAS_MELEE_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOTIC_MELEE))
-				ourborg.add_overlay("[sprite_icon_state]-melee")
-				continue
-			if(sprite_flag_check(ROBOT_HAS_DAGGER_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOT_DAGGER))
-				ourborg.add_overlay("[sprite_icon_state]-dagger")
-				continue
-			if(sprite_flag_check(ROBOT_HAS_BLADE_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOT_BLADE))
-				ourborg.add_overlay("[sprite_icon_state]-blade")
-				continue
+			//Melee Check
+			if(istype(thing_to_check, /obj/item/melee/robotic))
+				var/obj/item/melee/robotic/melee = thing_to_check
+				if(sprite_flag_check(ROBOT_HAS_MELEE_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOTIC_MELEE))
+					ourborg.add_overlay("[sprite_icon_state]-melee")
+					continue
+				if(sprite_flag_check(ROBOT_HAS_DAGGER_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOT_DAGGER))
+					ourborg.add_overlay("[sprite_icon_state]-dagger")
+					continue
+				if(sprite_flag_check(ROBOT_HAS_BLADE_SPRITE) && melee.weapon_flag_check(COUNTS_AS_ROBOT_BLADE))
+					ourborg.add_overlay("[sprite_icon_state]-blade")
+					continue
 
-		//Gun Check
-		if(istype(thing_to_check, /obj/item/gun/energy/robotic))
-			var/obj/item/gun/energy/robotic/gun = thing_to_check
-			if(sprite_flag_check(ROBOT_HAS_GUN_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_GUN))
-				ourborg.add_overlay("[sprite_icon_state]-gun")
-				continue
-			if(sprite_flag_check(ROBOT_HAS_LASER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_LASER))
-				ourborg.add_overlay("[sprite_icon_state]-laser")
-				continue
-			if(sprite_flag_check(ROBOT_HAS_TASER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_TASER))
-				ourborg.add_overlay("[sprite_icon_state]-taser")
-				continue
-			if(sprite_flag_check(ROBOT_HAS_DISABLER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_DISABLER))
-				ourborg.add_overlay("[sprite_icon_state]-disabler")
-				continue
-		else //We are NEITHER a melee or a gun (Or whatever else you add in here in the future)
-			continue //Go on to the next.
-	return
+			//Gun Check
+			if(istype(thing_to_check, /obj/item/gun/energy/robotic))
+				var/obj/item/gun/energy/robotic/gun = thing_to_check
+				if(sprite_flag_check(ROBOT_HAS_GUN_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_GUN))
+					ourborg.add_overlay("[sprite_icon_state]-gun")
+					continue
+				if(sprite_flag_check(ROBOT_HAS_LASER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_LASER))
+					ourborg.add_overlay("[sprite_icon_state]-laser")
+					continue
+				if(sprite_flag_check(ROBOT_HAS_TASER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_TASER))
+					ourborg.add_overlay("[sprite_icon_state]-taser")
+					continue
+				if(sprite_flag_check(ROBOT_HAS_DISABLER_SPRITE) && gun.gun_flag_check(COUNTS_AS_ROBOT_DISABLER))
+					ourborg.add_overlay("[sprite_icon_state]-disabler")
+					continue
 
 /datum/robot_sprite/proc/get_belly_overlay(var/mob/living/silicon/robot/ourborg, var/size = 1, var/b_class)
 	//Size


### PR DESCRIPTION

Having guns always shown led especially in some cases to questions where robots had them merely in their bar. Now, gun sprites will only show if the activated type is any weapon.
## About The Pull Request
## Changelog
:cl:
qol: robot gun sprites will only show if any of the guns is actually in the activated slot
/:cl:
