### PR TITLE
fix orebag signals

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -207,17 +207,12 @@
 
 /obj/item/storage/bag/ore/equipped(mob/user)
 	..()
-	if(user.get_inventory_slot(src) == slot_wear_suit || slot_l_hand || slot_l_hand || slot_belt) //Basically every place they can go. Makes sure it doesn't unregister if moved to other slots.
-		user.AddComponent(/datum/component/recursive_move)
-		RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/item/storage/bag/ore/proc/autoload, user, override = TRUE)
+	user.AddComponent(/datum/component/recursive_move)
+	RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/item/storage/bag/ore/proc/autoload, user)
 
 /obj/item/storage/bag/ore/dropped(mob/user)
 	..()
-	if(user.get_inventory_slot(src) == slot_wear_suit || slot_l_hand || slot_l_hand || slot_belt) //See above. This should really be a define.
-		user.AddComponent(/datum/component/recursive_move)
-		RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/item/storage/bag/ore/proc/autoload, user, override = TRUE)
-	else
-		UnregisterSignal(user, COMSIG_OBSERVER_MOVED)
+	UnregisterSignal(user, COMSIG_OBSERVER_MOVED)
 
 /obj/item/storage/bag/ore/proc/autoload(mob/user)
 	var/obj/item/ore/O = locate() in get_turf(src)


### PR DESCRIPTION

Far from optimal, but this way, we at least unregister them and don't register them to every person who touched the bag once forever...
## About The Pull Request
## Changelog
:cl:
fix orebags registering to everyone who touched them
/:cl:
