### PR TITLE
Artifact Tweaks

### DIFF
--- a/code/__defines/xenoarcheaology.dm
+++ b/code/__defines/xenoarcheaology.dm
@@ -78,7 +78,6 @@
 /// <summary>
 /// These are the defines for what is required to ACTIVATE the artifact.
 /// </summary>
-/// TODO: Get rid of TRIGGER_PHORON/OXY/CO2/NITRO. They're unfun and tedious.
 #define TRIGGER_TOUCH 0
 #define TRIGGER_WATER 1
 #define TRIGGER_ACID 2
@@ -88,11 +87,7 @@
 #define TRIGGER_ENERGY 6
 #define TRIGGER_HEAT 7
 #define TRIGGER_COLD 8
-#define TRIGGER_PHORON 9
-#define TRIGGER_OXY 10
-#define TRIGGER_CO2 11
-#define TRIGGER_NITRO 12
-#define MAX_TRIGGER 12
+#define MAX_TRIGGER 8
 
 /// <summary>
 /// These are defines of what TYPE of artifact it is. See code/modules/xenoarcheaology/effects for each artifact.
@@ -120,4 +115,4 @@
 #define EFFECT_VAMPIRE 20
 #define EFFECT_HEALTH 21
 #define EFFECT_GENERATOR 22
-#define EFFECT_DNASWITCH 23 //Not in as of yet.
+#define EFFECT_DNASWITCH 23

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -105,3 +105,21 @@
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stock_parts/console_screen = 1,
 							/obj/item/stack/cable_coil = 5)
+
+/obj/item/circuitboard/artifact_harvester
+	name = T_BOARD("artifact harvester")
+	build_path = /obj/machinery/artifact_harvester
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 4, TECH_ENGINEERING = 2)
+	req_components = list(
+							/obj/item/stock_parts/capacitor = 5, //Yes, it's ALL capacitors. It's only purpose is to store power!
+							/obj/item/stock_parts/console_screen = 1)
+
+/obj/item/circuitboard/artifact_scanpad
+	name = T_BOARD("artifact scanpad")
+	build_path = /obj/machinery/artifact_scanpad
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 4, TECH_ENGINEERING = 2)
+	req_components = list(
+							/obj/item/stock_parts/manipulator = 1,
+							/obj/item/stock_parts/console_screen = 1)

--- a/code/modules/research/designs/xenoarch_toys.dm
+++ b/code/modules/research/designs/xenoarch_toys.dm
@@ -29,3 +29,39 @@
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 4000)
 	build_path = /obj/item/pickaxe/excavationdrill
 	sort_string = "GAAAC"
+
+/datum/design/obj/item/anobattery
+	name = "Anomaly power battery - Basic"
+	id = "anobattery"
+	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 4, TECH_ENGINEERING = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000)
+	build_path = /obj/item/anobattery
+	sort_string = "GAAAD"
+
+/datum/design/obj/item/anobattery_mid
+	name = "Anomaly power battery - Moderate"
+	id = "anobattery"
+	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 4, TECH_ENGINEERING = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 5000, MAT_SILVER = 2000) //Same object, different materials
+	build_path = /obj/item/anobattery/moderate
+	sort_string = "GAAAE"
+
+/datum/design/obj/item/anobattery_advanced
+	name = "Anomaly power battery - Advanced"
+	id = "anobattery"
+	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 6, TECH_ENGINEERING = 5, TECH_BLUESPACE = 5, TECH_DATA = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_STEEL = 2500, MAT_GLASS = 2500, MAT_SILVER = 2000, MAT_GOLD = 2500, MAT_PHORON = 2500)
+	build_path = /obj/item/anobattery/advanced
+	sort_string = "GAAAF"
+
+/datum/design/obj/item/anobattery_exotic
+	name = "Anomaly power battery - Exotic"
+	id = "anobattery"
+	req_tech = list(TECH_MATERIAL = 8, TECH_POWER = 7, TECH_ENGINEERING = 6, TECH_BLUESPACE = 6,  TECH_DATA = 6, TECH_PRECURSOR = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_PHORON = 2000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/anobattery/exotic
+	sort_string = "GAAAG"

--- a/code/modules/research/designs/xenoarch_toys.dm
+++ b/code/modules/research/designs/xenoarch_toys.dm
@@ -32,7 +32,7 @@
 
 /datum/design/obj/item/anobattery
 	name = "Anomaly power battery - Basic"
-	id = "anobattery"
+	id = "anobattery-basic"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 4, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000)
@@ -41,7 +41,7 @@
 
 /datum/design/obj/item/anobattery_mid
 	name = "Anomaly power battery - Moderate"
-	id = "anobattery"
+	id = "anobattery-moderate"
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 5000, MAT_SILVER = 2000) //Same object, different materials
@@ -50,7 +50,7 @@
 
 /datum/design/obj/item/anobattery_advanced
 	name = "Anomaly power battery - Advanced"
-	id = "anobattery"
+	id = "anobattery-advanced"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 6, TECH_ENGINEERING = 5, TECH_BLUESPACE = 5, TECH_DATA = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 2500, MAT_GLASS = 2500, MAT_SILVER = 2000, MAT_GOLD = 2500, MAT_PHORON = 2500)
@@ -59,9 +59,9 @@
 
 /datum/design/obj/item/anobattery_exotic
 	name = "Anomaly power battery - Exotic"
-	id = "anobattery"
+	id = "anobattery-exotic"
 	req_tech = list(TECH_MATERIAL = 8, TECH_POWER = 7, TECH_ENGINEERING = 6, TECH_BLUESPACE = 6,  TECH_DATA = 6, TECH_PRECURSOR = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_PHORON = 2000, MAT_DIAMOND = 2000)
+	materials = list(MAT_STEEL = 1500, MAT_GLASS = 1500, MAT_SILVER = 1500, MAT_GOLD = 1500, MAT_PHORON = 2000, MAT_DIAMOND = 2000, MAT_MORPHIUM = 2000)
 	build_path = /obj/item/anobattery/exotic
 	sort_string = "GAAAG"

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -69,7 +69,7 @@
 		my_effect.trigger = TRIGGER_TOUCH
 	else if(icon_num == 10)
 		desc = "A large alien device, there appear to be some kind of vents in the side."
-		my_effect.trigger = pick(TRIGGER_ENERGY, TRIGGER_HEAT, TRIGGER_COLD, TRIGGER_PHORON, TRIGGER_OXY, TRIGGER_CO2, TRIGGER_NITRO)
+		my_effect.trigger = pick(TRIGGER_ENERGY, TRIGGER_HEAT, TRIGGER_COLD)
 	else if(icon_num == 11)
 		name = "sealed alien pod"
 		desc = "A strange alien device."
@@ -77,7 +77,7 @@
 	else if(icon_num == 12 || icon_num == 14)
 		name = "intricately carved statue"
 		desc = "A strange statue."
-		my_effect.trigger = pick(TRIGGER_TOUCH, TRIGGER_HEAT, TRIGGER_COLD, TRIGGER_PHORON, TRIGGER_OXY, TRIGGER_CO2, TRIGGER_NITRO)
+		my_effect.trigger = pick(TRIGGER_TOUCH, TRIGGER_HEAT, TRIGGER_COLD)
 
 /obj/machinery/artifact/update_icon()
 	..()

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -190,18 +190,6 @@
 
 		if(TRIGGER_HEAT, TRIGGER_COLD) //Heat is easy to activate. Smack it with a welder. Cold? Have to cool the area.
 			. += " Activation index involves " + span_bold("precise temperature conditions.") + " Heating/Cooling the atmosphere (>[ARTIFACT_HEAT_TRIGGER]K or <[ARTIFACT_COLD_TRIGGER]K) or using a welder are potential triggers."
-
-		//Gases are separate since they are a pain in the rear to get activated and might as well let you know exactly what to do.
-		//I've been playing this game since the dawn of man and I've never seen someone bother to actually TRY to set up atmos to get these activated.
-		//Honestly, I'm slating these for removal.
-		if(TRIGGER_PHORON)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Phoron is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
-		if(TRIGGER_OXY)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Oxygen is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
-		if(TRIGGER_CO2)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Carbon Dioxide, is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
-		if(TRIGGER_NITRO)
-			. += " Activation index involves "+ span_bold("precise local atmospheric conditions.") + " Nitrous Oxide is a potential trigger. (Atmosphere must be >[ARTIFACT_GAS_TRIGGER] MOL of gas to activate device)"
 		else
 			. += " Unable to determine any data about activation trigger."
 

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -183,7 +183,7 @@
 		if(TRIGGER_TOUCH) //This one should be self explanatory.
 			. += "Activation index involves " + span_bold("physical interaction") + " with artifact surface."
 		if(TRIGGER_WATER, TRIGGER_ACID, TRIGGER_VOLATILE, TRIGGER_TOXIN) //No xenoarch would know how to activate these without code digging.
-			. += " Activation index involves " + span_bold("chemical interaction with artifact surface.") + " Water/Hydrogen, sulfuric acid, Thermite/Phoron, and toxin/toxic substances are potential triggers."
+			. += " Activation index involves " + span_bold("chemical interaction with artifact surface.") + " Water/Hydrogen, sulfuric acid, Thermite/Phoron, and toxin/toxic substances (such as lead, phoron, fertilizers, among others) are potential triggers."
 
 		if(TRIGGER_FORCE, TRIGGER_ENERGY) //Did you know multitools can activate energy artifacts?
 			. += " Activation index involves " + span_bold("forceful or energetic interaction with artifact surface.") + " Potential triggers are a pulse from a multitool or battering the artifact with a strong object."

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -269,7 +269,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 		else if(ishuman(bumped) && GetAnomalySusceptibility(bumped) >= 0.5)
 			if (my_effect.trigger == TRIGGER_TOUCH)
 				my_effect.ToggleActivate()
-				if(my_effect.activated)
+				if(my_effect.activated && my_effect.effect == EFFECT_TOUCH)
 					my_effect.DoEffectTouch(bumped)
 				warn = 1
 
@@ -288,7 +288,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 		else if(ishuman(M) && !istype(M:gloves,/obj/item/clothing/gloves))
 			if (my_effect.trigger == TRIGGER_TOUCH)
 				my_effect.ToggleActivate(M)
-				if(my_effect.activated)
+				if(my_effect.activated && my_effect.effect == EFFECT_TOUCH)
 					my_effect.DoEffectTouch(M)
 				warn = 1
 
@@ -310,7 +310,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 		if (my_effect.trigger == TRIGGER_TOUCH)
 			triggered = TRUE
 			my_effect.ToggleActivate()
-			if(my_effect.activated)
+			if(my_effect.activated && my_effect.effect == EFFECT_TOUCH)
 				my_effect.DoEffectTouch(user)
 
 	if(triggered)

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -267,7 +267,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 					my_effect.ToggleActivate()
 
 		else if(ishuman(bumped) && GetAnomalySusceptibility(bumped) >= 0.5)
-			if (my_effect.trigger == EFFECT_TOUCH)
+			if (my_effect.trigger == TRIGGER_TOUCH)
 				my_effect.ToggleActivate()
 				if(my_effect.activated)
 					my_effect.DoEffectTouch(bumped)
@@ -286,7 +286,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 					my_effect.ToggleActivate()
 
 		else if(ishuman(M) && !istype(M:gloves,/obj/item/clothing/gloves))
-			if (my_effect.trigger == EFFECT_TOUCH)
+			if (my_effect.trigger == TRIGGER_TOUCH)
 				my_effect.ToggleActivate(M)
 				if(my_effect.activated)
 					my_effect.DoEffectTouch(M)
@@ -307,7 +307,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 	var/triggered = FALSE
 
 	for(var/datum/artifact_effect/my_effect in my_effects)
-		if (my_effect.trigger == EFFECT_TOUCH)
+		if (my_effect.trigger == TRIGGER_TOUCH)
 			triggered = TRUE
 			my_effect.ToggleActivate()
 			if(my_effect.activated)

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -306,12 +306,13 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 
 	var/triggered = FALSE
 
-	for(var/datum/artifact_effect/my_effect in my_effects)
-		if (my_effect.trigger == TRIGGER_TOUCH)
-			triggered = TRUE
-			my_effect.ToggleActivate()
-			if(my_effect.activated && my_effect.effect == EFFECT_TOUCH)
-				my_effect.DoEffectTouch(user)
+	if(ishuman(user) && !istype(user:gloves,/obj/item/clothing/gloves))
+		for(var/datum/artifact_effect/my_effect in my_effects)
+			if(my_effect.trigger == TRIGGER_TOUCH)
+				triggered = TRUE
+				my_effect.ToggleActivate()
+				if(my_effect.activated && my_effect.effect == EFFECT_TOUCH)
+					my_effect.DoEffectTouch(user)
 
 	if(triggered)
 		to_chat(user, span_filter_notice(span_bold("You touch [holder].")))

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -420,10 +420,6 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 	//if any of our effects rely on environmental factors, work that out
 	var/trigger_cold = 0
 	var/trigger_hot = 0
-	var/trigger_phoron = 0
-	var/trigger_oxy = 0
-	var/trigger_co2 = 0
-	var/trigger_nitro = 0
 
 	var/turf/T = get_turf(holder)
 	var/datum/gas_mixture/env = T.return_air()
@@ -432,15 +428,6 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 			trigger_cold = 1
 		else if(env.temperature > ARTIFACT_HEAT_TRIGGER)
 			trigger_hot = 1
-
-		if(env.gas[GAS_PHORON] >= ARTIFACT_GAS_TRIGGER)
-			trigger_phoron = 1
-		if(env.gas[GAS_O2] >= ARTIFACT_GAS_TRIGGER)
-			trigger_oxy = 1
-		if(env.gas[GAS_CO2] >= ARTIFACT_GAS_TRIGGER)
-			trigger_co2 = 1
-		if(env.gas[GAS_N2] >= ARTIFACT_GAS_TRIGGER)
-			trigger_nitro = 1
 
 	for(var/datum/artifact_effect/my_effect in my_effects)
 		my_effect.artifact_id = artifact_id
@@ -453,22 +440,6 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 
 		//HEAT ACTIVATION
 		if(my_effect.trigger == TRIGGER_HEAT && (trigger_hot ^ my_effect.activated))
-			my_effect.ToggleActivate()
-
-		//PHORON GAS ACTIVATION
-		if(my_effect.trigger == TRIGGER_PHORON && (trigger_phoron ^ my_effect.activated))
-			my_effect.ToggleActivate()
-
-		//OXYGEN GAS ACTIVATION
-		if(my_effect.trigger == TRIGGER_OXY && (trigger_oxy ^ my_effect.activated))
-			my_effect.ToggleActivate()
-
-		//CO2 GAS ACTIVATION
-		if(my_effect.trigger == TRIGGER_CO2 && (trigger_co2 ^ my_effect.activated))
-			my_effect.ToggleActivate()
-
-		//NITROGEN GAS ACTIVATION
-		if(my_effect.trigger == TRIGGER_NITRO && (trigger_nitro ^ my_effect.activated))
 			my_effect.ToggleActivate()
 
 #undef HYDROGEN_PATH

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -267,12 +267,10 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 					my_effect.ToggleActivate()
 
 		else if(ishuman(bumped) && GetAnomalySusceptibility(bumped) >= 0.5)
-			if (my_effect.trigger == TRIGGER_TOUCH)
+			if (my_effect.trigger == EFFECT_TOUCH)
 				my_effect.ToggleActivate()
-				warn = 1
-
-			if (my_effect.effect == EFFECT_TOUCH)
-				my_effect.DoEffectTouch(bumped)
+				if(my_effect.activated)
+					my_effect.DoEffectTouch(bumped)
 				warn = 1
 
 	if(warn && isliving(bumped))
@@ -288,12 +286,10 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 					my_effect.ToggleActivate()
 
 		else if(ishuman(M) && !istype(M:gloves,/obj/item/clothing/gloves))
-			if (my_effect.trigger == TRIGGER_TOUCH)
-				my_effect.ToggleActivate()
-				warn = 1
-
-			if (my_effect.effect == EFFECT_TOUCH)
-				my_effect.DoEffectTouch(M)
+			if (my_effect.trigger == EFFECT_TOUCH)
+				my_effect.ToggleActivate(M)
+				if(my_effect.activated)
+					my_effect.DoEffectTouch(M)
 				warn = 1
 
 	if(warn && isliving(M))
@@ -311,14 +307,11 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 	var/triggered = FALSE
 
 	for(var/datum/artifact_effect/my_effect in my_effects)
-
-		if(my_effect.trigger == TRIGGER_TOUCH)
+		if (my_effect.trigger == EFFECT_TOUCH)
 			triggered = TRUE
 			my_effect.ToggleActivate()
-
-		if (my_effect.effect == EFFECT_TOUCH)
-			triggered = TRUE
-			my_effect.DoEffectTouch(user)
+			if(my_effect.activated)
+				my_effect.DoEffectTouch(user)
 
 	if(triggered)
 		to_chat(user, span_filter_notice(span_bold("You touch [holder].")))

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -4,19 +4,36 @@
 
 /obj/item/anobattery
 	name = "Anomaly power battery"
+	desc = "A device that is able to harness the power of anomalies!"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "anobattery0"
 	var/datum/artifact_effect/battery_effect
 	var/capacity = 500
 	var/stored_charge = 0
 
+/obj/item/anobattery/examine(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		. += "It  currently has a charge of [stored_charge] out of [capacity]"
 /obj/item/anobattery/Destroy()
 	battery_effect = null
 	..()
 
+/obj/item/anobattery/moderate
+	name = "moderate anomaly battery"
+	capacity = 1000
+
 /obj/item/anobattery/advanced
 	name = "advanced anomaly battery"
 	capacity = 3000
+
+/obj/item/anobattery/exotic
+	name = "exotic anomaly battery"
+	capacity = 10000
+
+/obj/item/anobattery/adminbus //Adminspawn only. Do not make this accessible or I will gnaw you.
+	name = "godly anomaly battery"
+	capacity = 100000000
 
 /*
 /obj/item/anobattery/New()

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -14,7 +14,7 @@
 /obj/item/anobattery/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))
-		. += "It  currently has a charge of [stored_charge] out of [capacity]"
+		. += "It currently has a charge of [stored_charge] out of [capacity]"
 /obj/item/anobattery/Destroy()
 	battery_effect = null
 	..()

--- a/code/modules/xenoarcheaology/tools/artifact_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_scanner.dm
@@ -5,3 +5,12 @@
 	icon_state = "tele0"
 	anchored = TRUE
 	density = FALSE
+	circuit = /obj/item/circuitboard/artifact_scanpad
+
+/obj/machinery/artifact_scanpad/attackby(var/obj/I as obj, var/mob/user as mob)
+	if(default_deconstruction_screwdriver(user, I))
+		return
+	if(default_deconstruction_crowbar(user, I))
+		return
+	if(default_part_replacement(user, I))
+		return

--- a/code/modules/xenoarcheaology/tools/artifact_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_scanner.dm
@@ -14,3 +14,8 @@
 		return
 	if(default_part_replacement(user, I))
 		return
+
+/obj/machinery/artifact_scanpad/Initialize()
+	. = ..()
+	default_apply_parts()
+	update_icon()


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where it was activating artifacts based on their EFFECT not their TRIGGER
Gets rid of gas activation anomalies
- Makes scanpads and harvesters craftable
- Makes harvesters upgradable
- Fixes typo in the battery ID & desc
- Fixes harvester charge logic to NOT be garbage
- Analyzer will tell you what some things that work on toxic artifacts are
## Changelog
:cl: Diana
fix: Artifacts will no longer activate via touch if their effect(strength) is set to 'touch strength' but their trigger(method of activation) is set to anything but 'touch'
fix: Touching a touch artifact to turn it off will no longer hit you with the activation effects
fix: Touching a touch artifact will now properly make it turn on
qol: Gets rid of anomalies that require gas to activate
qol: The analyzer now tells you you can dump lead (among others) to activate an artifact
qol: Artifacts will not longer activate through gloves. Small artifacts are safe to pick up now!
add: Adds more anomaly battery types craftable in science
add: Artifact harvesters and its scanpad can now be crafted and deconstructed
add: Harvester can now be upgraded, giving increased charge rate.
/:cl:
