### PR TITLE
Unarmed Attack Fixes

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -148,6 +148,7 @@
 
 /datum/unarmed_attack/holopugilism
 	sparring_variant_type = /datum/unarmed_attack/holopugilism
+	is_punch = TRUE
 
 /datum/unarmed_attack/holopugilism/unarmed_override(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/zone)
 	user.do_attack_animation(src)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -267,7 +267,7 @@
 			var/real_damage = rand_damage
 			var/hit_dam_type = attack.damage_type
 			real_damage += attack.get_unarmed_damage(H)
-			if(H.gloves)
+			if(H.gloves && attack.is_punch)
 				if(istype(H.gloves, /obj/item/clothing/gloves))
 					var/obj/item/clothing/gloves/G = H.gloves
 					real_damage += G.punch_force

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -12,6 +12,7 @@
 	attack_noun = list("tendril")
 	eye_attack_text = "a tendril"
 	eye_attack_text_victim = "a tendril"
+	is_punch = TRUE
 
 /datum/unarmed_attack/claws
 	attack_name = "claws"

--- a/code/modules/mob/living/carbon/human/species/species_attack_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack_vr.dm
@@ -1,4 +1,5 @@
 /datum/unarmed_attack/bite/sharp/numbing //Is using this against someone you are truly trying to fight a bad idea? Yes. Yes it is.
+	attack_name = "numbing bite"
 	attack_verb = list("bit")
 	attack_noun = list("fangs")
 	attack_sound = 'sound/weapons/bite.ogg'


### PR DESCRIPTION
Fixes a lot of bugs with Unarmed Attack logic.

# NOTE: BY FIXING THESE BUGS, SOME GAMEPLAY FUNCTIONS WERE INHERENTLY CHANGED WITHOUT BEING MODIFIED.
Legs: Usable if hands are cuffed and mouth is muzzled
Hands: Usable if mouth is muzzled and legs are legcuffed
Mouth: Usable if legs are legcuffed and hands are cuffed.

Notes: BREAKING SOMEONE'S JAW OR DISLOCATING IT PREVENTS THEM FROM BITING.

- You can not stomp while buckled now.
- You can not kick while buckled now.
- You can not bite while buckled now.
- Fixes it so the click code can properly get to unarmed attack code now, allowing it to run it's proper checks to see if you can attack or not instead of just always returning false.
- Changes some vars from 0 to FALSE where indicated.
- Gets rid of some needless = FALSE when it was already on the parent
- Fixes gloves increasing damage on anything other than punches.
## About The Pull Request
## Changelog
:cl: Diana
fix: You are prevented from stomping while buckled now.
fix: You are prevented from kicking while buckled now.
fix: You are prevented from biting while buckled now.
fix: Fixes gloves increasing damage on anything other than punches.
fix: Fixes it so the click code can properly get to unarmed attack code now, allowing it to run it's proper checks to see if you can attack or not instead of just always returning false.
code: Changes some vars from 0 to FALSE where indicated.
code: Gets rid of some needless = FALSE when it was already on the parent
/:cl:
