### PR TITLE
Toggleable Recoil

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -94,6 +94,7 @@
 	var/obj/item/dnalockingchip/attached_lock
 
 	var/last_shot = 0			//records the last shot fired
+	var/recoil_mode = 0			//If the gun will hurt micros if shot or not. Disabled on Virgo, used downstream.
 
 //VOREStation Add - /tg/ icon system
 	var/charge_sections = 4
@@ -417,6 +418,18 @@
 			last_shot = world.time
 			user.hud_used.update_ammo_hud(user, src)
 			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+
+			if(recoil_mode && iscarbon(user))
+				var/mob/living/carbon/micro = user
+				var/mysize = micro.size_multiplier
+				if(recoil_mode > 0)
+					if(mysize <= 0.60)
+						micro.Weaken(1*recoil_mode)
+						if(!istype(src,/obj/item/gun/energy))
+							micro.adjustBruteLoss((5-mysize*4)*recoil_mode)
+							to_chat(micro, span_danger("You're so tiny that you drop the gun and hurt yourself from the recoil!"))
+						else
+							to_chat(micro, span_danger("You're so tiny that the pull of the trigger causes you to drop the gun!"))
 
 			if(!(target && target.loc))
 				target = targloc

--- a/code/modules/projectiles/guns/energy/particle.dm
+++ b/code/modules/projectiles/guns/energy/particle.dm
@@ -20,6 +20,7 @@
 	charge_cost = 200	//slightly more shots than lasers
 	var/safetycatch = 0 //if 1, won't let you fire in pressurised environment, rather than malfunctioning
 	var/obj/item/pressurelock/attached_safety
+	recoil_mode = 0
 
 
 /obj/item/gun/energy/particle/advanced //particle equivalent of AEG

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -11,6 +11,7 @@
 	charge_cost = 240
 	projectile_type = /obj/item/projectile/energy/phase
 	one_handed_penalty = 15
+	recoil_mode = 0
 
 /obj/item/gun/energy/phasegun/mounted
 	self_recharge = 1

--- a/code/modules/projectiles/guns/energy/pump.dm
+++ b/code/modules/projectiles/guns/energy/pump.dm
@@ -79,6 +79,7 @@
 		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam/blue, modifystate="phaserkill", charge_cost = 300),
 		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser/blue, modifystate="phaserstun", charge_cost = 100),
 	)
+	recoil_mode = 0
 
 /obj/item/gun/energy/locked/frontier/unload_ammo(var/mob/user)
 	if(recharging)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -49,6 +49,7 @@
 	battery_lock = 1
 
 	var/decl/plantgene/gene = null
+	recoil_mode = 0
 	var/obj/item/stock_parts/micro_laser/emitter
 
 	firemodes = list(

--- a/code/modules/xenobio/items/weapons.dm
+++ b/code/modules/xenobio/items/weapons.dm
@@ -52,6 +52,7 @@
 	description_fluff = "An easy to use weapon designed by NanoTrasen, for NanoTrasen. This weapon is based on the NT Mk30 NL, \
 	it's core components swaped out for a new design made to subdue lesser slime-based xeno lifeforms at a distance.  It is \
 	ineffective at stunning non-slimy lifeforms such as humanoids."
+	recoil_mode = 0
 
 /obj/item/gun/energy/taser/xeno/robot // Borg version
 	self_recharge = 1


### PR DESCRIPTION

## About The Pull Request
Makes a toggleable recoil for micros.
Disabled on Virgo, but used downstream.
## Changelog
:cl:
add: Up-ports recoil. Disabled here, but used downstream.
/:cl:
