### PR TITLE
Makes it so brains no longer runtime when EMP'd

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -25,6 +25,9 @@
 	qdel(dna)
 	return ..()
 
+/mob/living/carbon/brain/emp_act(severity) //Brains can't be EMP'd...
+	return
+
 /mob/living/carbon/brain/say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
 	if(istype(container, /obj/item/mmi))
 		if(issilicon(other))


### PR DESCRIPTION
## About The Pull Request

see title
Brains no longer runtime when EMP'd
## Changelog
:cl: Diana
fix: your sponge will no longer look for its nonexistent species when emp'd when outside your body
/:cl:
