### PR TITLE
Fixes telecube origin_tech

### DIFF
--- a/code/modules/artifice/telecube.dm
+++ b/code/modules/artifice/telecube.dm
@@ -24,7 +24,7 @@
 	icon = 'icons/obj/props/telecube.dmi'
 	icon_state = "cube"
 	w_class = ITEMSIZE_SMALL
-	origin_tech = list(TECH_MATERIAL = 7, TECH_POWER = 6, TECH_BLUESPACE = 7, TECH_ANOMALY = 2, TECH_PRECURSOR = 2)
+	origin_tech = list(TECH_MATERIAL = 7, TECH_POWER = 6, TECH_BLUESPACE = 7, TECH_ARCANE = 2, TECH_PRECURSOR = 2)
 
 	catalogue_data = list(/datum/category_item/catalogue/anomalous/precursor_a/telecube)
 


### PR DESCRIPTION
TECH_ANOMALY did not exist. TECH_ARCANE does.
## About The Pull Request
Fixes a typo/mistake in telecube origin
## Changelog
:cl:
fix: Telecube will give the proper tech levels now
/:cl:
