### PR TITLE
More xenoarch tweaks

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -365,3 +365,14 @@ var/global/list/selectable_footstep = list(
 	"Light Claw" = FOOTSTEP_MOB_TESHARI,
 	"Slither" = FOOTSTEP_MOB_SLITHER,
 )
+
+// Put any artifact effects that are duplicates, unique, or otherwise unwated in here! This prevents them from spawning via RNG.
+var/global/list/blacklisted_artifact_effects = list(
+	/datum/artifact_effect/gas/sleeping,
+	/datum/artifact_effect/gas/oxy,
+	/datum/artifact_effect/gas/carbondiox,
+	/datum/artifact_effect/gas/fuel,
+	/datum/artifact_effect/gas/nitro,
+	/datum/artifact_effect/gas/phoron,
+	/datum/artifact_effect/extreme
+)

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -36,8 +36,8 @@
 	..()
 
 	master = newmaster
-	effect = rand(0, MAX_EFFECT)
-	trigger = rand(0, MAX_TRIGGER)
+	effect = rand(EFFECT_TOUCH, MAX_EFFECT) //This can be overwritten per artifact, in case you want one to only be touch, aura, or pulse!
+	trigger = rand(TRIGGER_TOUCH, MAX_TRIGGER) //Same for this! You can make artifacts that can ONLY be activated through XYZ!
 
 	if(effect_icon && effect_state)
 		if(effect_state == "sparkles")

--- a/code/modules/xenoarcheaology/effect_master.dm
+++ b/code/modules/xenoarcheaology/effect_master.dm
@@ -183,7 +183,7 @@ var/list/toxic_reagents = list(TOXIN_PATH)
 
 /datum/component/artifact_master/proc/generate_effects()
 	while(effect_generation_chance > 0)
-		var/chosen_path = pick(subtypesof(/datum/artifact_effect) - /datum/artifact_effect/extreme)
+		var/chosen_path = pick(subtypesof(/datum/artifact_effect) - blacklisted_artifact_effects)
 		if(effect_generation_chance >= 100)	// If we're above 100 percent, just cut a flat amount and add an effect.
 			var/datum/artifact_effect/AE = new chosen_path(src)
 			if(istype(holder, AE.req_type))

--- a/code/modules/xenoarcheaology/effects/atmospheric.dm
+++ b/code/modules/xenoarcheaology/effects/atmospheric.dm
@@ -11,21 +11,32 @@
 
 /datum/artifact_effect/gas/New()
 	..()
+	effect = EFFECT_AURA
 	if(random)
-		effect = pick(EFFECT_TOUCH, EFFECT_AURA)
+		//effect = pick(EFFECT_TOUCH, EFFECT_AURA) //Changed to just AURA for now.
 		gas_type = pick(GAS_CO2, GAS_N2, GAS_N2O, GAS_O2, GAS_PHORON, GAS_VOLATILE_FUEL) //the only way you will EVER see volatile fuel.
 
 /datum/artifact_effect/gas/DoEffectTouch(var/mob/user)
 	var/atom/holder = get_master_holder()
-	if(holder)
-		var/turf/holder_loc = holder.loc
+	if(holder) //We should always have a holder.
+		var/turf/holder_loc
+		if(istype(holder, /obj/item/anobattery)) //We then check if we're in a battery. If so, cool!
+			holder = holder.loc //Our holder is now the battery!
+			if(istype(holder, /obj/item/anodevice)) //This is just a sanity check. Technically, you COULD remove this and just have two holder = holder.loc in a row, but... Let's not do that
+				holder = holder.loc
+		holder_loc = holder.loc  //Finally, we set the holder_loc proper.
 		if(isturf(holder_loc))
 			holder_loc.assume_gas(gas_type, rand(2, 15)) //You can spam touch this, so it's lesser.
 
 /datum/artifact_effect/gas/DoEffectAura()
 	var/atom/holder = get_master_holder()
 	if(holder)
-		var/turf/holder_loc = holder.loc
+		var/turf/holder_loc
+		if(istype(holder, /obj/item/anobattery))
+			holder = holder.loc
+			if(istype(holder, /obj/item/anodevice))
+				holder = holder.loc
+		holder_loc = holder.loc
 		if(isturf(holder_loc))
 			holder_loc.assume_gas(gas_type, rand(25, 50))
 

--- a/code/modules/xenoarcheaology/effects/temperature.dm
+++ b/code/modules/xenoarcheaology/effects/temperature.dm
@@ -11,7 +11,7 @@
 
 /datum/artifact_effect/temperature/New()
 	..()
-	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
+	effect = EFFECT_AURA //pick(EFFECT_TOUCH, EFFECT_AURA) //Changed to just aura for now.
 	temp_change = pick(COLD, HOT)
 	if(temp_change == HOT)
 		target_temp = rand(300, 3000)
@@ -19,7 +19,7 @@
 		target_temp = rand (0, 150)
 	effect_type = EFFECT_TEMPERATURE
 
-/datum/artifact_effect/temperature/DoEffectTouch(var/mob/user)
+/datum/artifact_effect/temperature/DoEffectTouch(var/mob/user) //This still exists in case you VV it.
 	var/atom/holder = get_master_holder()
 	if(holder)
 		to_chat(user, span_blue("A chill passes up your spine!"))
@@ -34,6 +34,19 @@
 				env.temperature = max(env.temperature - temp_coef, 0)
 
 /datum/artifact_effect/temperature/DoEffectAura()
+	var/atom/holder = get_master_holder()
+	if(holder)
+		var/datum/gas_mixture/env = holder.loc.return_air()
+		if(env)
+			var/temp_coef = 1 //The closer they are, the harder it is to cause a change.
+			if(temp_change == HOT && env.temperature < target_temp)
+				temp_coef = ((target_temp)/(env.temperature+1)) //TT = 300. ET = 250. TC = ~1 || TT = 3000. ET = 300 TT = 10. We multiply by 10 below to speed it up.
+				env.temperature = max(env.temperature + temp_coef*10, 0)
+			else if(temp_change == COLD && env.temperature > target_temp)
+				temp_coef = (env.temperature/(target_temp+1)) //ET = 300, TT = 25. TC = 12. Next: ET=288 TT = 25, TC = 11.52. ETC.
+				env.temperature = max(env.temperature - temp_coef, 0)
+
+/datum/artifact_effect/temperature/DoEffectPulse(atom/holder) //Same as aura. Could probably be increased to be stronger with effect_range but eh, we don't want people to insta freeze/fry theirselves.
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/datum/gas_mixture/env = holder.loc.return_air()

--- a/code/modules/xenoarcheaology/effects/temperature.dm
+++ b/code/modules/xenoarcheaology/effects/temperature.dm
@@ -46,7 +46,7 @@
 				temp_coef = (env.temperature/(target_temp+1)) //ET = 300, TT = 25. TC = 12. Next: ET=288 TT = 25, TC = 11.52. ETC.
 				env.temperature = max(env.temperature - temp_coef, 0)
 
-/datum/artifact_effect/temperature/DoEffectPulse(atom/holder) //Same as aura. Could probably be increased to be stronger with effect_range but eh, we don't want people to insta freeze/fry theirselves.
+/datum/artifact_effect/temperature/DoEffectPulse() //Same as aura. Could probably be increased to be stronger with effect_range but eh, we don't want people to insta freeze/fry theirselves.
 	var/atom/holder = get_master_holder()
 	if(holder)
 		var/datum/gas_mixture/env = holder.loc.return_air()


### PR DESCRIPTION
## About The Pull Request
Fixes some more things with xenoarch.
Makes the gas and temp artifacts no longer spammable.
Makes gas artifacts no longer flood the artifact pool
## Changelog
:cl: Diana
fix: Xenoarch gas effects will no longer have a 1/3 chance of not working when spawned in.
fix: Gas artifacts no longer overpopulate the artifact pool
qol: Gas artifacts and temperature artifacts can no longer be 'spam-toggled' and will instead only be aura artifacts.
code: Made a global blacklist for artifacts that should not spawn in global_lists.dm
/:cl:
