### PR TITLE
Fixes bug where micro camera would not reset

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -107,14 +107,14 @@ var/list/holder_mob_icon_cache = list()
 /obj/item/holder/proc/dump_mob()
 	if(!held_mob)
 		return
-	if (held_mob.loc == src || isnull(held_mob.loc)) //VOREStation edit
+	if (held_mob.loc == src || isnull(held_mob.loc))
 		held_mob.transform = original_transform
-		held_mob.update_transform() //VOREStation edit
+		held_mob.update_transform()
 		held_mob.vis_flags = original_vis_flags
-		held_mob.forceMove(get_turf(src))
 		held_mob.reset_view(null)
+		held_mob.forceMove(get_turf(src))
 		held_mob = null
-	invisibility = INVISIBILITY_ABSTRACT //VOREStation edit
+	invisibility = INVISIBILITY_ABSTRACT
 
 /obj/item/holder/throw_at(atom/target, range, speed, thrower)
 	if(held_mob)


### PR DESCRIPTION
## About The Pull Request
Fixes [bug](https://github.com/CHOMPStation2/CHOMPStation2/blob/66be8fe717a9478dc2931fe418f887465a0074fa/code/modules/mob/holder.dm#L107-L128) where the camera would not reset when micros were dropped
Even though forcemove was BEFORE reset_view codewise, it was being performed AFTER reset_view 
## Changelog
:cl:
fix: Micro cameras will now properly reset when micros are dropped
/:cl:
