### PR TITLE
Radiation Fixes

### DIFF
--- a/code/_global_vars/traits/_traits.dm
+++ b/code/_global_vars/traits/_traits.dm
@@ -4,6 +4,16 @@
 
 // Please do note that there is absolutely no bearing on what traits are added to what subtype of `/datum`, this is just an easily referenceable list sorted by type.
 // The only thing that truly matters about traits is the code that is built to handle the traits, and where that code is located. Nothing else.
+#define NORMAL_RADIATION_RESISTANCE "Normal"
+#define RESISTANT_RADIATION_RESISTANCE "Resistant"
+#define MAJOR_RESISTANT_RADIATION_RESISTANCE "Major Resistance"
+#define IMMUNITY_RADIATION_RESISTANCE "Immunity"
+GLOBAL_LIST_INIT(radiation_levels, list(
+	NORMAL_RADIATION_RESISTANCE  = list("safe" = 50, "danger_1" = 100, "danger_2" = 300, "danger_3" = 400, "danger_4" = 1500),
+	RESISTANT_RADIATION_RESISTANCE  = list("safe" = 70, "danger_1" = 150, "danger_2" = 450, "danger_3" = 600, "danger_4" = 2250),
+	MAJOR_RESISTANT_RADIATION_RESISTANCE  = list("safe" = 150, "danger_1" = 300, "danger_2" = 600, "danger_3" = 1000, "danger_4" = 3000),
+	IMMUNITY_RADIATION_RESISTANCE  = list("safe" = 10000, "danger_1" = 10001, "danger_2" = 10002, "danger_3" = 10003, "danger_4" = 10004),
+))
 
 GLOBAL_LIST_INIT(traits_by_type, list(
 	/mob = list(

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -355,7 +355,6 @@
 			radiation -= 10 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			return
 
-		to_world("rads =  [radiation] rad_levels = [GLOB.radiation_levels[species.rad_levels]["safe"]], [GLOB.radiation_levels[species.rad_levels]["danger_1"]], [GLOB.radiation_levels[species.rad_levels]["danger_2"]], [GLOB.radiation_levels[species.rad_levels]["danger_3"]], [GLOB.radiation_levels[species.rad_levels]["danger_4"]]")
 		if (radiation < GLOB.radiation_levels[species.rad_levels]["safe"]) //Less than 1.0 Gy. No side effects.
 			radiation -= 10 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 10 * RADIATION_SPEED_COEFFICIENT //No escape from accumulated rads.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -355,11 +355,12 @@
 			radiation -= 10 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			return
 
-		if (radiation < species.rad_levels["safe"]) //Less than 1.0 Gy. No side effects.
+		to_world("rads =  [radiation] rad_levels = [GLOB.radiation_levels[species.rad_levels]["safe"]], [GLOB.radiation_levels[species.rad_levels]["danger_1"]], [GLOB.radiation_levels[species.rad_levels]["danger_2"]], [GLOB.radiation_levels[species.rad_levels]["danger_3"]], [GLOB.radiation_levels[species.rad_levels]["danger_4"]]")
+		if (radiation < GLOB.radiation_levels[species.rad_levels]["safe"]) //Less than 1.0 Gy. No side effects.
 			radiation -= 10 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 10 * RADIATION_SPEED_COEFFICIENT //No escape from accumulated rads.
 
-		else if (radiation >= species.rad_levels["safe"] && radiation < species.rad_levels["danger_1"]) //Equivalent of 1.0-2.0 Gy. Minimum stage you start seeing effects.
+		else if (radiation >= GLOB.radiation_levels[species.rad_levels]["safe"] && radiation < GLOB.radiation_levels[species.rad_levels]["danger_1"]) //Equivalent of 1.0-2.0 Gy. Minimum stage you start seeing effects.
 			damage = 1
 			radiation -= 10 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 10 * RADIATION_SPEED_COEFFICIENT
@@ -376,7 +377,7 @@
 				if(prob(1) && prob(100 * RADIATION_SPEED_COEFFICIENT)) //Rare chance of vomiting.
 					spawn vomit()
 
-		else if (radiation >= species.rad_levels["danger_1"] && radiation < species.rad_levels["danger_2"]) //Equivalent of 2.0 to 6.0 Gy. Nobody should ever be above this without extreme negligence.
+		else if (radiation >= GLOB.radiation_levels[species.rad_levels]["danger_1"] && radiation < GLOB.radiation_levels[species.rad_levels]["danger_2"]) //Equivalent of 2.0 to 6.0 Gy. Nobody should ever be above this without extreme negligence.
 			damage = 3
 			radiation -= 30 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 30 * RADIATION_SPEED_COEFFICIENT
@@ -392,7 +393,7 @@
 					to_chat(src, span_warning("You feel sick."))
 					AdjustWeakened(3)
 
-		else if (radiation >= species.rad_levels["danger_2"] && radiation < species.rad_levels["danger_3"]) //Equivalent of 6.0 to 8.0 Gy.
+		else if (radiation >= GLOB.radiation_levels[species.rad_levels]["danger_2"] && radiation < GLOB.radiation_levels[species.rad_levels]["danger_3"]) //Equivalent of 6.0 to 8.0 Gy.
 			damage = 5
 			radiation -= 50 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 50 * RADIATION_SPEED_COEFFICIENT
@@ -413,7 +414,7 @@
 					I.take_damage(damage * species.radiation_mod * RADIATION_SPEED_COEFFICIENT)
 
 
-		else if (radiation >= species.rad_levels["danger_3"] && radiation < species.rad_levels["danger_4"]) //Equivalent of 8.0 to 30 Gy.
+		else if (radiation >= GLOB.radiation_levels[species.rad_levels]["danger_3"] && radiation < GLOB.radiation_levels[species.rad_levels]["danger_4"]) //Equivalent of 8.0 to 30 Gy.
 			damage = 10
 			radiation -= 100 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 100 * RADIATION_SPEED_COEFFICIENT
@@ -443,7 +444,7 @@
 					if(istype(I)) I.add_autopsy_data("Radiation Induced Cancerous Growth", damage)
 					I.take_damage(damage * species.radiation_mod * RADIATION_SPEED_COEFFICIENT)
 
-		else if (radiation >= species.rad_levels["danger_4"]) //Above 30Gy. You had to get absolutely blasted with rads for this.
+		else if (radiation >= GLOB.radiation_levels[species.rad_levels]["danger_4"]) //Above 30Gy. You had to get absolutely blasted with rads for this.
 			damage = 30
 			radiation -= 300 * RADIATION_SPEED_COEFFICIENT * species.rad_removal_mod
 			accumulated_rads += 300 * RADIATION_SPEED_COEFFICIENT

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -236,7 +236,7 @@
 	var/list/env_traits = list()
 	var/pixel_offset_x = 0									// Used for offsetting 64x64 and up icons.
 	var/pixel_offset_y = 0									// Used for offsetting 64x64 and up icons.
-	var/rad_levels = list("safe" = 50, "danger_1" = 100, "danger_2" = 300, "danger_3" = 400, "danger_4" = 1500) //For handle_mutations_and_radiation
+	var/rad_levels = NORMAL_RADIATION_RESISTANCE		//For handle_mutations_and_radiation
 	var/rad_removal_mod = 1
 
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -347,19 +347,19 @@
 	name = "Radiation Resistance"
 	desc = "You are generally more resistant to radiation, and it dissipates faster from your body."
 	cost = 1
-	var_changes = list("radiation_mod" = 0.65, "rad_removal_mod" = 3.5, "rad_levels" = list("safe" = 70, "danger_1" = 150, "danger_2" = 450, "danger_3" = 600, "danger_4" = 2250))
+	var_changes = list("radiation_mod" = 0.65, "rad_removal_mod" = 3.5, "rad_levels" = RESISTANT_RADIATION_RESISTANCE)
 
 /datum/trait/positive/rad_resistance_extreme
 	name = "Radiation Resistance, Major"
 	desc = "You are much more resistant to radiation, and it dissipates much faster from your body."
 	cost = 2
-	var_changes = list("radiation_mod" = 0.5, "rad_removal_mod" = 5, "rad_levels" = list("safe" = 150, "danger_1" = 300, "danger_2" = 600, "danger_3" = 1000, "danger_4" = 3000))
+	var_changes = list("radiation_mod" = 0.5, "rad_removal_mod" = 5, "rad_levels" = MAJOR_RESISTANT_RADIATION_RESISTANCE)
 
 /datum/trait/positive/rad_immune
 	name = "Radiation Immunity"
 	desc = "For whatever reason, be it a more dense build or some quirk of your genetic code, your body is completely immune to radiation."
 	cost = 3
-	var_changes = list("radiation_mod" = 0.0, "rad_removal_mod" = 10, "rad_levels" = list("safe" = 10000, "danger_1" = 10001, "danger_2" = 10002, "danger_3" = 10003, "danger_4" = 10004))
+	var_changes = list("radiation_mod" = 0.0, "rad_removal_mod" = 10, "rad_levels" = IMMUNITY_RADIATION_RESISTANCE)
 
 	// Traitgenes
 	is_genetrait = TRUE


### PR DESCRIPTION

## About The Pull Request
Adjusts the way that radiation is handled via moving it from a list on the species to a global list that the species has a key for that is then cross-referenced in the list to decide what radiation resistance they have
## Changelog
:cl: Diana
code: Radiation now works differently on the backend.
fix: Enabling and disabling the radiation immunity trait no longer breaks things.
/:cl:
