### PR TITLE
CHEM DISPENSER HOTFIX [HOTFIX]

### DIFF
--- a/code/modules/reagents/holder/holder.dm
+++ b/code/modules/reagents/holder/holder.dm
@@ -18,6 +18,8 @@
 			var/datum/reagent/D = new path()
 			if(!D.name)
 				continue
+			if(D.name == REAGENT_DEVELOPER_WARNING) //We remove reagents that don't have a name from being put in the list.
+				continue
 			SSchemistry.chemical_reagents[D.id] = D
 
 /datum/reagents/Destroy()

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -3102,6 +3102,7 @@
 //Base type for alchoholic drinks containing coffee
 /datum/reagent/ethanol/coffee
 	name = REAGENT_DEVELOPER_WARNING
+	id = REAGENT_ID_DEVELOPER_WARNING
 	overdose = 45
 	allergen_type = ALLERGEN_COFFEE|ALLERGEN_STIMULANT //Contains coffee or is made from coffee
 
@@ -3359,6 +3360,7 @@
 
 /datum/reagent/ethanol/wine
 	name = REAGENT_DEVELOPER_WARNING // Unit test ignore
+	id = REAGENT_ID_DEVELOPER_WARNING
 
 /datum/reagent/ethanol/wine/champagne
 	name = REAGENT_CHAMPAGNE


### PR DESCRIPTION
## About The Pull Request
Fixes ethanol becoming 'reagent', being a 'reagent' on the chem dispenser because of ancient override code.
## Changelog
:cl:
fix: The chemmaster will no longer have ethanol turn into wine like Jesus touched it
/:cl:
