### PR TITLE
Makes the game no longer try to see if your heart is vital before letting you rip it out of yourself (and a few others)

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -32,7 +32,7 @@
 	name = "Random Items"
 	desc = "Buys you as many random items you can afford. Convenient packaging NOT included."
 
-/datum/uplink_item/item/badassery/random_many/cost(obj/item/uplink/U, var/telecrystals)
+/datum/uplink_item/item/badassery/random_many/cost(obj/item/uplink/U, telecrystals)
 	return max(1, telecrystals)
 
 /datum/uplink_item/item/badassery/random_many/get_goods(var/obj/item/uplink/U, var/loc, var/mob/M)

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -5,7 +5,7 @@
 	category = /datum/uplink_category/telecrystals
 	blacklisted = 1
 
-/datum/uplink_item/item/telecrystal/get_goods(var/obj/item/uplink/U, var/loc, var/mob/M)
+/datum/uplink_item/item/telecrystal/get_goods(obj/item/uplink/U, loc, mob/M)
 	return new /obj/item/stack/telecrystal(loc, cost(U, M.mind.tcrystals))
 
 /datum/uplink_item/item/telecrystal/one

--- a/code/datums/uplink/telecrystals.dm
+++ b/code/datums/uplink/telecrystals.dm
@@ -35,5 +35,5 @@
 /datum/uplink_item/item/telecrystal/all
 	name = "Telecrystals - Empty Uplink"
 
-/datum/uplink_item/item/telecrystal/all/cost(obj/item/uplink/U, mob/M)
-	return max(1, M.mind.tcrystals)
+/datum/uplink_item/item/telecrystal/all/cost(obj/item/uplink/U, tcrystals)
+	return max(1, tcrystals)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -103,7 +103,7 @@ var/datum/uplink/uplink = new()
 *	Physical Uplink Entries		*
 *                           	*
 ********************************/
-/datum/uplink_item/item/buy(var/obj/item/uplink/U, var/mob/user)
+/datum/uplink_item/item/buy(obj/item/uplink/U, mob/user)
 	var/obj/item/I = ..()
 	if(!I)
 		return
@@ -117,7 +117,7 @@ var/datum/uplink/uplink = new()
 		A.put_in_any_hand_if_possible(I)
 	return I
 
-/datum/uplink_item/item/get_goods(var/obj/item/uplink/U, var/loc, var/mob/user)
+/datum/uplink_item/item/get_goods(obj/item/uplink/U, loc, mob/user)
 	var/obj/item/I = new path(loc)
 	return I
 
@@ -154,7 +154,7 @@ var/datum/uplink/uplink = new()
 	var/crate_path = /obj/structure/largecrate
 	var/list/paths = list()	// List of paths to be spawned into the crate.
 
-/datum/uplink_item/crated/get_goods(var/obj/item/uplink/U, var/loc)
+/datum/uplink_item/crated/get_goods(obj/item/uplink/U, loc, mob/user)
 	var/obj/L = new crate_path(get_turf(loc))
 
 	L.adjust_scale(rand(9, 12) / 10, rand(9, 12) / 10)	// Some variation in the crate / locker size.

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -75,7 +75,7 @@ var/datum/uplink/uplink = new()
 
 	return TRUE
 
-/datum/uplink_item/proc/cost(obj/item/uplink/U, mob/M)
+/datum/uplink_item/proc/cost(var/obj/item/uplink/U, var/telecrystals)
 	. = item_cost
 	if(U)
 		. = U.get_item_cost(src, .)
@@ -84,7 +84,7 @@ var/datum/uplink/uplink = new()
 	return desc
 
 // get_goods does not necessarily return physical objects, it is simply a way to acquire the uplink item without paying
-/datum/uplink_item/proc/get_goods(var/obj/item/uplink/U, var/loc, mob/user)
+/datum/uplink_item/proc/get_goods(var/obj/item/uplink/U, var/loc, var/mob/user)
 	return FALSE
 
 /datum/uplink_item/proc/log_icon()

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -174,7 +174,7 @@
 				"items" = (category == selected_cat ? list() : null)
 			)
 		for(var/datum/uplink_item/item in category.items)
-			var/cost = item.cost(src, user) || "???"
+			var/cost = item.cost(src, user.mind.tcrystals) || "???"
 			cat["items"] += list(list(
 				"name" = item.name,
 				"cost" = cost,

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -22,7 +22,7 @@ var/datum/uplink_random_selection/all_uplink_selection = new/datum/uplink_random
 	items = list()
 	all_items = list()
 
-/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, obj/item/uplink/U, var/list/bought_items, var/items_override = 0)
+/datum/uplink_random_selection/proc/get_random_item(var/telecrystals, var/obj/item/uplink/U, var/list/bought_items, var/items_override = 0)
 	var/const/attempts = 50
 
 	for(var/i = 0; i < attempts; i++)

--- a/code/game/objects/items/weapons/storage/egg_vr.dm
+++ b/code/game/objects/items/weapons/storage/egg_vr.dm
@@ -35,8 +35,8 @@
 		animate_shake()
 		drop_contents()
 		icon = open_egg_icon
-		if(user.transforming)
-			user.transforming = FALSE
+		if(user.transforming) //this is actually godawful and transforming should never be used as it skips life ticks
+			user.transforming = FALSE //but if something does still use transforming (Bad, please do not.), we want it to be removed from them.
 
 /obj/item/storage/vore_egg/unathi
 	name = "unathi egg"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1847,21 +1847,19 @@
 /mob/living/carbon/human/get_mob_riding_slots()
 	return list(back, head, wear_suit)
 
-/mob/living/carbon/human/verb/lay_down_left()
-	set name = "Rest-Left"
+/mob/living/carbon/human/verb/flip_lying()
+	set name = "Flip Resting Direction"
+	set category = "Abilities.General"
+	set desc = "Switch your horizontal direction while prone."
 
-	rest_dir = 1
-	resting = !resting
-	to_chat(src, span_notice("You are now [resting ? "resting" : "getting up"]."))
-	update_canmove()
+	if(stat || paralysis || weakened || stunned || world.time < last_special)
+		to_chat(src, span_warning("You can't do that in your current state."))
+		return
 
-/mob/living/carbon/human/verb/lay_down_right()
-	set name = "Rest-Right"
-
-	rest_dir = 0
-	resting = !resting
-	to_chat(src, span_notice("You are now [resting ? "resting" : "getting up"]."))
-	update_canmove()
+	if(isnull(rest_dir))
+		rest_dir = FALSE
+	rest_dir = !rest_dir
+	update_transform(TRUE)
 
 /mob/living/carbon/human/get_digestion_nutrition_modifier()
 	return species.digestion_nutrition_modifier

--- a/code/modules/mob/living/carbon/human/human_modular_limbs.dm
+++ b/code/modules/mob/living/carbon/human/human_modular_limbs.dm
@@ -58,7 +58,7 @@
 // Checks the organ list for limbs meeting a predicate. Way overengineered for such a limited use
 // case but I can see it being expanded in the future if meat limbs or doona limbs use it.
 /mob/living/carbon/human/proc/get_modular_limbs(var/return_first_found = FALSE, var/validate_proc)
-	for(var/obj/item/organ/external/E as anything in organs)
+	for(var/obj/item/organ/external/E in organs)
 		if(!validate_proc || call(E, validate_proc)(src) > MODULAR_BODYPART_INVALID)
 			LAZYADD(., E)
 			if(return_first_found)
@@ -66,7 +66,7 @@
 	// Prune children so we can't remove every individual component of an entire prosthetic arm
 	// piece by piece. Technically a circular dependency here would remove the limb entirely but
 	// if there's a parent whose child is also its parent, there's something wrong regardless.
-	for(var/obj/item/organ/external/E as anything in .)
+	for(var/obj/item/organ/external/E in .)
 		if(length(E.children))
 			. -= E.children
 

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1133,12 +1133,13 @@
 		to_chat(src, "You don't have enough space to spin a cocoon!")
 		return
 
+	if(buckled ||stat || paralysis || weakened || stunned || world.time < last_special) //No tongue flicking while stunned.
+		to_chat(src, span_warning("You can't do that in your current state."))
+		return
+
 	if(do_after(src, 25, exclusive = TASK_USER_EXCLUSIVE))
 		var/obj/item/storage/vore_egg/bugcocoon/C = new(loc)
 		forceMove(C)
-		transforming = TRUE
-		var/datum/tgui_module/appearance_changer/cocoon/V = new(src, src)
-		V.tgui_interact(src)
 
 		var/mob_holder_type = src.holder_type || /obj/item/holder
 		C.w_class = src.size_multiplier * 4 //Egg size and weight scaled to match occupant.
@@ -1149,6 +1150,8 @@
 		C.update_transform()
 		//egg_contents -= src
 		C.contents -= src
+		var/datum/tgui_module/appearance_changer/cocoon/V = new(src, src)
+		V.tgui_interact(src)
 
 /mob/living/carbon/human/proc/water_stealth()
 	set name = "Dive under water / Resurface"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -77,20 +77,6 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	update_icon_special()
 
 /mob/living/carbon/human/update_transform(var/instant = FALSE)
-	/* VOREStation Edit START
-	// First, get the correct size.
-	var/desired_scale_x = icon_scale_x
-	var/desired_scale_y = icon_scale_y
-
-	desired_scale_x *= species.icon_scale_x
-	desired_scale_y *= species.icon_scale_y
-
-	for(var/datum/modifier/M in modifiers)
-		if(!isnull(M.icon_scale_x_percent))
-			desired_scale_x *= M.icon_scale_x_percent
-		if(!isnull(M.icon_scale_y_percent))
-			desired_scale_y *= M.icon_scale_y_percent
-	*/
 	var/desired_scale_x = size_multiplier * icon_scale_x
 	var/desired_scale_y = size_multiplier * icon_scale_y
 	desired_scale_x *= species.icon_scale_x
@@ -102,7 +88,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	appearance_flags |= PIXEL_SCALE
 	if(fuzzy)
 		appearance_flags &= ~PIXEL_SCALE
-	//VOREStation Edit End
+		center_offset = 0
 
 	// Regular stuff again.
 	var/matrix/M = matrix()
@@ -116,32 +102,23 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		if(tail_style?.can_loaf && resting) // Only call these if we're resting?
 			update_tail_showing()
 			M.Scale(desired_scale_x, desired_scale_y)
+			M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1)) //CHOMPEdit
 		else
+			M.Scale(desired_scale_x, desired_scale_y)
+			if(isnull(rest_dir))
+				rest_dir = pick(FALSE, TRUE)
 			if(rest_dir)
-				if(rest_dir < 0)
-					M.Turn(-90)
-					rest_dir = 0
-				else
-					M.Turn(90)
-					rest_dir = 0
+				M.Translate((1 / desired_scale_x * -4) + (desired_scale_x * cent_offset), 0)
+				M.Turn(-90)
 			else
-				var/randn = rand(1, 2)
-				if(randn <= 1) // randomly choose a rotation
-					M.Turn(-90)
-				else
-					M.Turn(90)
-			if(species.icon_height == 64)
-				M.Translate(13,-22)
-			else
-				M.Translate(1,-6)
-			M.Scale(desired_scale_y, desired_scale_x)
-		M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1))
+				M.Translate((1 / desired_scale_x * 4) - (desired_scale_x * cent_offset), 0)
+				M.Turn(90)
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else
-		M.Scale(desired_scale_x, desired_scale_y)//VOREStation Edit
+		M.Scale(desired_scale_x, desired_scale_y)
 		M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1))
-		if(tail_style?.can_loaf) // VOREStation Edit: Taur Loafing
-			update_tail_showing() // VOREStation Edit: Taur Loafing
+		if(tail_style?.can_loaf)
+			update_tail_showing()
 		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
 
 	if(instant)

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -608,6 +608,8 @@
 		return
 
 	ui = SStgui.try_update_ui(user, src, ui)
+	if(!owner || !owner.species) //We tried to update our UI and no longer have an owner!
+		return
 	if(!ui)
 		owner.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(owner, COMSIG_OBSERVER_MOVED, PROC_REF(update_active_camera_screen), TRUE)
@@ -994,8 +996,7 @@
 	customize_usr = TRUE
 
 /datum/tgui_module/appearance_changer/cocoon/tgui_status(mob/user, datum/tgui_state/state)
-	//if(!istype(owner.loc, /obj/item/storage/vore_egg/bugcocoon))
-	if(!owner.transforming)
+	if(!istype(owner.loc, /obj/item/holder/micro))
 		return STATUS_CLOSE
 	return ..()
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -837,6 +837,10 @@
 	set category = "Abilities.General"
 	set desc = "Toggle your glowing on/off!"
 
+	if(stat || paralysis || weakened || stunned || world.time < last_special)
+		to_chat(src, span_warning("You can't do that in your current state."))
+		return
+
 	//I don't really see a point to any sort of checking here.
 	//If they're passed out, the light won't help them. Same with buckled. Really, I think it's fine to do this whenever.
 	glow_toggle = !glow_toggle
@@ -867,6 +871,10 @@
 	set name = "Eat Trash"
 	set category = "Abilities.Vore"
 	set desc = "Consume held garbage."
+
+	if(stat || paralysis || weakened || stunned || world.time < last_special)
+		to_chat(src, span_warning("You can't do that in your current state."))
+		return
 
 	if(!vore_selected)
 		to_chat(src,span_warning("You either don't have a belly selected, or don't have a belly!"))


### PR DESCRIPTION
## About The Pull Request
see title
Fixes a runtime where the game would repeatedly check if you could remove your internal organs safely
See changelog for rest of the fixes
## Changelog
:cl: Diana
fix: You no longer check if you can remove your internal organs to throw them at people
fix: You can no longer become immortal via cocoon weaver
fix: Cocoon weaver now properly makes a TGUI window and keeps it.
qol: Replaces face-left and face-right with a 'change facing' verb from Chomp for when you're laying down.
fix: You can no longer change facing direction, toggle glow, 
fix: Spin cocoon can no longer be used while buckled which caused space time reality to break 
code: Upgrades update_icons to work better and support change-facing
fix: You can no longer cause telecrystal inflation
code: Gets a few things standardized by having the base /proc/ have /var and its children being normal.
/:cl:
