### PR TITLE
Update minimum compiler version in __byond_version_compat.dm

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -8,11 +8,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 516
-#define MIN_COMPILER_BUILD 1656
+#define MIN_COMPILER_BUILD 1657
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 516.1656 or higher
+#error You need version 516.1657 or higher
 #endif
 
 // Keep savefile compatibilty at minimum supported level

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=516
-export BYOND_MINOR=1656
+export BYOND_MINOR=1657
 
 # Macro Count
 export MACRO_COUNT=8


### PR DESCRIPTION
## About The Pull Request
This is now set to the minimum of 516.1657 which is at least the most stable version for the clients to use.

## Changelog
:cl:
code: updated the minimum compiler version of the project
/:cl:
