### PR TITLE
Larger TGUI say messages

### DIFF
--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -26,7 +26,7 @@
 	/// Injury phrases to blurt out
 	var/list/hurt_phrases = list("GACK!", "GLORF!", "OOF!", "AUGH!", "OW!", "URGH!", "HRNK!")
 	/// Max message length
-	var/max_length = MAX_MESSAGE_LEN
+	var/max_length = MAX_HUGE_MESSAGE_LEN
 	/// The modal window
 	var/datum/tgui_window/window
 	/// Boolean for whether the tgui_say was opened by the user.


### PR DESCRIPTION

## About The Pull Request

Changes TGUI say to allow double the previous max characters, to match emotes that don't use TGUI say.

## Changelog
:cl:
code: Changes TGUI say to allow double the previous max characters, to match emotes that don't use TGUI say.
/:cl:
