### PR TITLE
Add a button to set gender of simplemobs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -11,6 +11,7 @@
 	. = ..()
 	add_verb(src, /mob/living/simple_mob/proc/set_name)
 	add_verb(src, /mob/living/simple_mob/proc/set_desc)
+	add_verb(src, /mob/living/simple_mob/proc/set_gender)
 
 	if(copy_prefs_to_mob)
 		login_prefs()
@@ -72,6 +73,15 @@
 	newdesc = sanitizeSafe(tgui_input_text(src,"Set your description. Max 4096 chars.", "Description set","", prevent_enter = TRUE), MAX_MESSAGE_LEN)
 	if(newdesc)
 		desc = newdesc
+
+/mob/living/simple_mob/proc/set_gender()
+	set name = "Set Gender"
+	set desc = "Set your gender."
+	set category = "Abilities.Settings"
+	var/newgender
+	newgender = tgui_input_list(src, "Please select a gender:", "Set Gender", list(FEMALE, MALE, NEUTER, PLURAL))
+	if(newgender)
+		gender = newgender
 
 /mob/living/simple_mob/vore/aggressive
 	mob_bump_flag = HEAVY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a button that allows players to set the gender of simplemobs they possess (Affects emotes and a few other things)

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Add a button to set gender of simplemobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
