### PR TITLE
Disables the default logging of some testing procs

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -68,7 +68,9 @@
 	if(!docking_codes)
 		docking_codes = "[ascii2text(rand(65,90))][ascii2text(rand(65,90))][ascii2text(rand(65,90))][ascii2text(rand(65,90))]"
 
+	#ifdef TESTING
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")
+	#endif
 
 	LAZYADD(SSshuttles.sectors_to_initialize, src) //Queued for further init. Will populate the waypoint lists; waypoints not spawned yet will be added in as they spawn.
 	SSshuttles.process_init_queues()

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -27,7 +27,9 @@
 			if (CELL_ALIVE(map[tmp_cell]))
 				ore_turfs += tmp_cell
 
+	#ifdef TESTING
 	testing("ASGEN: Found [ore_turfs.len] ore turfs.")
+	#endif
 	var/ore_count = round(map.len/20)
 	var/door_count = 0
 	var/empty_count = 0
@@ -46,8 +48,10 @@
 			empty_count += 1
 		ore_count--
 
+	#ifdef TESTING
 	testing("ASGEN: Set [door_count] turfs to random minerals.")
 	testing("ASGEN: Set [empty_count] turfs to high-chance random minerals.")
+	#endif
 	return 1
 
 /datum/random_map/automata/cave_system/apply_to_turf(var/x,var/y)


### PR DESCRIPTION

## About The Pull Request

These 4 testing logs were cluttering up the output quite a bit, so now they have been set behind a ifdef so that can be enabled if needed.

## Changelog
:cl:
code: disabled some testing logs by default (now require -DTESTING to be set while compiling)
/:cl:
