### PR TITLE
Add Somatoray Mode to Remove Reagents

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -236,6 +236,17 @@
 		if(prob(mutchance))
 			yield_mod = min(10,yield_mod+rand(1,2))
 			return
+	else if(istype(Proj, /obj/item/projectile/energy/floraprune))
+		var/obj/item/projectile/energy/floraprune/GP = Proj
+		mutchance *= GP.lasermod
+		if(prob(mutchance) && seed)
+			var/c = safepick(seed.chems)
+			if(length(seed.chems) > 1 && c)
+				var/turf/T = get_turf(loc)
+				seed = seed.diverge()
+				T.visible_message(span_infoplain(span_bold("\The [seed.display_name]") + " quivers!"))
+				seed.chems -= c
+			return
 
 	..()
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -56,6 +56,7 @@
 		list(mode_name="induce mutations", projectile_type=/obj/item/projectile/energy/floramut, modifystate="floramut"),
 		list(mode_name="increase yield", projectile_type=/obj/item/projectile/energy/florayield, modifystate="florayield"),
 		list(mode_name="induce specific mutations", projectile_type=/obj/item/projectile/energy/floramut/gene, modifystate="floramut"),
+		list(mode_name="prune reagents", projectile_type=/obj/item/projectile/energy/floraprune, modifystate="floramut"),
 		)
 
 /obj/item/gun/energy/floragun/Initialize()
@@ -121,6 +122,7 @@
 	var/obj/item/projectile/energy/floramut/gene/G = .
 	var/obj/item/projectile/energy/florayield/GY = .
 	var/obj/item/projectile/energy/floramut/GM = .
+	var/obj/item/projectile/energy/floraprune/GP = .
 	// Inserting the upgrade level of the gun to the projectile as there isn't a better way to do this.
 	if(istype(G))
 		G.gene = gene
@@ -129,6 +131,8 @@
 		GY.lasermod = emitter.rating
 	else if(istype(GM))
 		GM.lasermod = emitter.rating
+	else if(istype(GP))
+		GP.lasermod = emitter.rating
 
 /obj/item/gun/energy/meteorgun
 	name = "meteor gun"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -221,6 +221,32 @@
 	else
 		return 1
 
+/obj/item/projectile/energy/floraprune
+	name = "delta somatoray"
+	icon_state = "energy2"
+	fire_sound = 'sound/effects/stealthoff.ogg'
+	damage = 0
+	damage_type = TOX
+	nodamage = 1
+	check_armour = "energy"
+	light_range = 2
+	light_power = 0.5
+	light_color = "#FFFFFF"
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/monochrome_laser
+	var/lasermod = 0
+	hud_state = "electrothermal"
+
+/obj/item/projectile/energy/floraprune/on_hit(var/atom/target, var/blocked = 0)
+	var/mob/living/M = target
+	if(ishuman(target)) //Make plantpeople thin, seeing as we're removing reagents from actual plants
+		var/mob/living/carbon/human/H = M
+		if((H.species.flags & IS_PLANT) && (M.nutrition < 500))
+			M.adjust_nutrition(-3s0)
+	else if (istype(target, /mob/living/carbon/))
+		M.show_message(span_blue("The radiation beam dissipates harmlessly through your body."))
+	else
+		return 1
+
 
 /obj/item/projectile/beam/mindflayer
 	name = "flayer ray"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -241,7 +241,7 @@
 	if(ishuman(target)) //Make plantpeople thin, seeing as we're removing reagents from actual plants
 		var/mob/living/carbon/human/H = M
 		if((H.species.flags & IS_PLANT) && (M.nutrition < 500))
-			M.adjust_nutrition(-3s0)
+			M.adjust_nutrition(-30)
 	else if (istype(target, /mob/living/carbon/))
 		M.show_message(span_blue("The radiation beam dissipates harmlessly through your body."))
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
### What was added?
Adds a new mode to the somatoray: 'Pruning mode', which removes a random reagent from a plant.
### Why was it added?
By allowing the somatoray to remove a random reagent, a bit more breathing room can be made for splicing interesting plants due to fruit only holding 60 units of reagents, especially with exotic seeds, which often mostly contain a mix of very useful/interesting and completely useless reagents.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Reagent-removing 'Pruning mode' to the floral somatoray
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
