### PR TITLE
Adds bloodpacks for vampiric crew to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -316,3 +316,8 @@ modular computers
 	display_name = "podzu music player"
 	path = /obj/item/walkpod
 	cost = 2
+
+/datum/gear/utility/bloodbag //For your vampiric crew!
+	display_name = "blood bag (Randomized)"
+	path = /obj/item/reagent_containers/blood/random_bloodsucker
+	cost = 1

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -109,3 +109,11 @@
 	desc = "Seems pretty useless... Maybe if there were a way to fill it?"
 	icon_state = "empty"
 	item_state = "bloodpack_empty"
+
+/obj/item/reagent_containers/blood/random_bloodsucker
+	name = "Ration BloodPack"
+	desc = "A standard issue BloodPack Ration given to crew that require blood to be sustained!"
+
+/obj/item/reagent_containers/blood/random_bloodsucker/Initialize()
+	blood_type = pick("A+", "A-", "B+", "B-", "O-", "O+", "AB+", "AB-")
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a randomized bloodpack to the utility section of the loadout for vampiric crew
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Vampiric crew now have a source of nutrition in the loadout under the Utility tab!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
