### PR TITLE
Loadout Tweaks and Additions

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -5,12 +5,12 @@
 	slot = "implant"
 	exploitable = 1
 	sort_category = "Cyberware"
-	cost = 6
+	cost = 1
 
 /datum/gear/utility/implant/tracking
 	display_name = "implant, tracking"
 	path = /obj/item/implant/tracking/weak
-	cost = 0 //VOREStation Edit. Changed cost to 0
+	cost = 0
 
 /datum/gear/utility/implant/generic
 	display_name = "implant, generic, primary"
@@ -28,16 +28,16 @@
 	..()
 	gear_tweaks += global.gear_tweak_implant_location
 
-/datum/gear/utility/implant/language
-	cost = 2
-	exploitable = 0
-
-/datum/gear/utility/implant/language/eal
+/datum/gear/utility/implant/eal
 	display_name = "vocal synthesizer, EAL"
 	description = "A surgically implanted vocal synthesizer which allows the owner to speak EAL, if they know it."
 	path = /obj/item/implant/language/eal
+	cost = 2
+	exploitable = 0
 
-/datum/gear/utility/implant/language/skrellian
+/datum/gear/utility/implant/skrellian
 	display_name = "vocal synthesizer, Skrellian"
 	description = "A surgically implanted vocal synthesizer which allows the owner to speak Common Skrellian, if they know it."
 	path = /obj/item/implant/language/skrellian
+	cost = 2
+	exploitable = 0

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems.dm
@@ -288,20 +288,6 @@
 	ckeywhitelist = list("cockatricexl")
 	character_name = list("James Holder")
 
-/datum/gear/fluff/diana_robe
-	path = /obj/item/clothing/suit/fluff/purp_robes
-	display_name = "Diana's Robes"
-	slot = slot_wear_suit
-	ckeywhitelist = list("cameron653")
-	character_name = list("Diana Kuznetsova")
-
-/datum/gear/fluff/diana_tiara
-	path = /obj/item/clothing/head/fluff/pink_tiara
-	display_name = "Diana's Tiara"
-	slot = slot_head
-	ckeywhitelist = list("cameron653")
-	character_name = list("Diana Kuznetsova")
-
 /datum/gear/fluff/aika_coat
 	path = /obj/item/clothing/suit/fluff/blue_trimmed_coat
 	display_name = "Aika's Coat"

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -546,3 +546,8 @@ Talon hats
 /datum/gear/head/eulrhat
 	display_name = "Sleek side cap"
 	path = /obj/item/clothing/head/eulrhat
+
+//Formerly my custom fluff gear, but free to use for anyone, now.
+/datum/gear/head/purple_tiara
+	display_name = "pink tourmaline tiara"
+	path = /obj/item/clothing/head/fluff/pink_tiara

--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -551,3 +551,7 @@ Talon hats
 /datum/gear/head/purple_tiara
 	display_name = "pink tourmaline tiara"
 	path = /obj/item/clothing/head/fluff/pink_tiara
+
+/datum/gear/head/pirate_hat
+	display_name = "pirate hat"
+	path = /obj/item/clothing/head/pirate

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -20,12 +20,10 @@
 /datum/gear/mask/sterile
 	display_name = "sterile mask"
 	path = /obj/item/clothing/mask/surgical
-	cost = 2
 
 /datum/gear/mask/sterile/white
 	display_name = "white sterile mask"
 	path = /obj/item/clothing/mask/surgical/white
-	cost = 2
 
 /datum/gear/mask/sterile/white/dust
 	display_name = "dust mask"
@@ -60,7 +58,6 @@
 /datum/gear/mask/gaiter
 	display_name = "neck gaiter selection"
 	path = /obj/item/clothing/accessory/gaiter
-	cost = 1
 
 /datum/gear/mask/gaiter/New()
 	..()
@@ -84,7 +81,6 @@
 /datum/gear/mask/wrestling
 	display_name = "wrestling mask"
 	path = /obj/item/clothing/mask/luchador/colorable
-	cost = 1
 
 /datum/gear/mask/wrestling/New()
 	gear_tweaks += gear_tweak_free_color_choice

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -1143,3 +1143,8 @@ Talon winter coat
 /datum/gear/suit/martianminer
 	display_name = "martian miner's coat, basic"
 	path = /obj/item/clothing/suit/storage/vest/martian_miner
+
+//Formerly my custom fluff gear, but free to use for anyone, now.
+/datum/gear/suit/purple_robes
+	display_name = "purple robes"
+	path = /obj/item/clothing/suit/fluff/purp_robes

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -4,7 +4,7 @@
 	path = /obj/item/clothing/suit/storage/apron
 	slot = slot_wear_suit
 	sort_category = "Suits and Overwear"
-	cost = 2
+	cost = 1
 
 /datum/gear/suit/apron_white
 	display_name = "apron, colorable"
@@ -825,7 +825,6 @@
 /datum/gear/suit/roles/labcoat_old
 	display_name = "labcoat selection, department, oldschool"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/old/tox
-	cost = 2
 
 /datum/gear/suit/roles/labcoat_old/New()
 	..()
@@ -1148,3 +1147,7 @@ Talon winter coat
 /datum/gear/suit/purple_robes
 	display_name = "purple robes"
 	path = /obj/item/clothing/suit/fluff/purp_robes
+
+/datum/gear/suit/pirate_coat
+	display_name = "pirate coat"
+	path = /obj/item/clothing/suit/pirate

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -504,7 +504,7 @@
 	flags_inv = HIDEJUMPSUIT|HIDETIE|HIDEHOLSTER
 
 /obj/item/clothing/head/fluff/pink_tiara
-	name = "Pink Tourmaline Tiara"
+	name = "pink tourmaline tiara"
 	desc = "A small, steel tiara with a large, pink tourmaline gem in the center."
 	icon_state = "amp"
 	body_parts_covered = 0


### PR DESCRIPTION

## About The Pull Request
Adds some items to the loadout (Pirate coat, Pirate hat, Purple Robes, Tiara)
Fixes the prices to be inline with how much pure fluff items cost (1) and outliers that give armor are 2
Fixes neural implants being stuck at 2 cost (or howver much the Language implant was) due to how overrides work.
## Changelog
:cl:
add: Adds Purple Robes and Tiara to loadout
qol: lowers cost of suit clothing fluff (This helps you identify which ones have armor and which ones don't, as some things are naturally priced higher due to their innate armor)
qol: Brings some loadout items to normal prices (increased is reserved for ones that give armor)
fix: Fixes neural implant always having 2 cost due to implant/language existing and taking priority.
qol: Neural implant only costs one loadout point, now.
add: Adds pirate coat and pirate hat to loadout. Yarr!
/:cl:
