### PR TITLE
moves entertainment radio to its own filter

### DIFF
--- a/code/__defines/chat.dm
+++ b/code/__defines/chat.dm
@@ -15,6 +15,7 @@
 #define MESSAGE_TYPE_PLOCALCHAT "plocalchat"
 #define MESSAGE_TYPE_HIVEMIND "hivemind"
 #define MESSAGE_TYPE_RADIO "radio"
+#define MESSAGE_TYPE_ENT_RADIO "entradio"
 #define MESSAGE_TYPE_NIF "nif"
 #define MESSAGE_TYPE_INFO "info"
 #define MESSAGE_TYPE_WARNING "warning"

--- a/tgui/packages/tgui-panel/chat/constants.ts
+++ b/tgui/packages/tgui-panel/chat/constants.ts
@@ -29,6 +29,7 @@ export const MESSAGE_TYPE_PLOCALCHAT = 'plocalchat';
 export const MESSAGE_TYPE_VORE = 'vore';
 export const MESSAGE_TYPE_HIVEMIND = 'hivemind';
 export const MESSAGE_TYPE_RADIO = 'radio';
+export const MESSAGE_TYPE_ENT_RADIO = 'entradio';
 export const MESSAGE_TYPE_NIF = 'nif';
 export const MESSAGE_TYPE_INFO = 'info';
 export const MESSAGE_TYPE_WARNING = 'warning';
@@ -101,6 +102,12 @@ export const MESSAGE_TYPES = [
     description: 'All departments of radio messages',
     selector:
       '.alert, .minorannounce, .syndradio, .centradio, .airadio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .supradio, .srvradio, .expradio, .radio, .deptradio, .newscaster, .resonate, .abductor, .alien, .changeling',
+  },
+  {
+    type: MESSAGE_TYPE_ENT_RADIO,
+    name: 'Enterteinment',
+    description: 'Enterteinment radio messages',
+    selector: '.entradio',
   },
   {
     type: MESSAGE_TYPE_NIF,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: people can now hide entertainment radio messages separately 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
