### PR TITLE
small wheelchairs can now be used by teshari (and everyone else)

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -34,10 +34,12 @@
 /obj/structure/bed/chair/wheelchair/can_buckle_check(mob/living/M, forced = FALSE)
 	. = ..()
 	if(.)
+		// We don't even USE mob sizes really... Monkeys are the only 'small' mobs that come to mind.
+		// Teshari and prometheans have both have their mob sizes ripped from them (because frankly, the implementation led to some exploity things)
 		if(M.mob_size < min_mob_buckle_size)
 			to_chat(M, span_warning("You are too small to use \the [src]."))
 			. = FALSE
-		else if(M.mob_size >= max_mob_buckle_size)
+		else if(M.mob_size > max_mob_buckle_size)
 			to_chat(M, span_warning("You are too large to use \the [src]."))
 			. = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
So mob_size mechanics used to be part of Polaris's own vorecode that was separate to ours, but it's kinda unused now.

This Makes it so if you're the 'max_mob_buckle_size' of a wheelchair you can actually use it since it was doing if >= then deny instead of if > then deny

This should probably be changed to use our own size mechanics and cut people off from using it at a certain size but eh...That's for another PR. This is just fixing the bug currently within the code.

This means that anyone can use small wheelchairs (
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
fix: Teshari can now use small wheelchairs (and so can others)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
