### PR TITLE
Git blame ignore revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Whitespace Standardization
 7c8bb85de3ea757ea54840c24638cc271969aaff
+
+# Removes /obj/item/weapon and /obj/item/device
+55942407f2dafc3d79db9b2be4ba1073bb0b2910

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+#Ignores big formatting commits when checking blame.
+#To make use of this file by default, run 'git config blame.ignoreRevsFile .git-blame-ignore-revs'
+#in the project folder
+
+## Line ending conversions
+
+# Whitespace Standardization
+7c8bb85de3ea757ea54840c24638cc271969aaff


### PR DESCRIPTION

## About The Pull Request

This file makes specific commits disappear from the git blame, in case there were a ton of changes touching quite a lot of lines.

A good example for this is the Whitespace Standardization PR that touched hundreds of thousands of lines.
