### PR TITLE
Disabled legs trait

### DIFF
--- a/code/__defines/dna.dm
+++ b/code/__defines/dna.dm
@@ -49,6 +49,7 @@
 #define BLIND 0x1
 #define MUTE  0x2
 #define DEAF  0x4
+#define SPINE 0x8
 
 /* Traitgenes (Blocks have finally been retired, huzzah!
 // The way blocks are handled badly needs a rewrite, this is horrible.

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -333,8 +333,9 @@
 
 		occupantData["blind"] = (H.sdisabilities & BLIND)
 		occupantData["nearsighted"] = (H.disabilities & NEARSIGHTED)
-		occupantData["husked"] = (HUSK in H.mutations) // VOREstation edit
-		occupantData = attempt_vr(src, "get_occupant_data_vr", list(occupantData, H)) //VOREStation Insert
+		occupantData["brokenspine"] = (H.disabilities & SPINE)
+		occupantData["husked"] = (HUSK in H.mutations)
+		occupantData = attempt_vr(src, "get_occupant_data_vr", list(occupantData, H))
 	data["occupant"] = occupantData
 
 	return data

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -350,7 +350,7 @@
 /obj/item/dnainjector/set_trait/nonconduct/disable
 	disabling = TRUE
 */
-/obj/item/dnainjector/set_trait/badlegs // brokenspine
-	trait_path = /datum/trait/negative/disability_badlegs
-/obj/item/dnainjector/set_trait/badlegs/disable
+/obj/item/dnainjector/set_trait/damagedspine // brokenspine
+	trait_path = /datum/trait/negative/disability_damagedspine
+/obj/item/dnainjector/set_trait/damagedspine/disable
 	disabling = TRUE

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -350,3 +350,7 @@
 /obj/item/dnainjector/set_trait/nonconduct/disable
 	disabling = TRUE
 */
+/obj/item/dnainjector/set_trait/badlegs // brokenspine
+	trait_path = /datum/trait/negative/disability_badlegs
+/obj/item/dnainjector/set_trait/badlegs/disable
+	disabling = TRUE

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -73,7 +73,7 @@
 	if (istype(buckled, /obj/structure/bed))
 		return
 
-	var/limb_pain
+	var/limb_pain = FALSE
 	for(var/limb_tag in list("l_leg","r_leg","l_foot","r_foot"))
 		var/obj/item/organ/external/E = organs_by_name[limb_tag]
 		if(!E || !E.is_usable())
@@ -111,7 +111,8 @@
 			if(limb_pain)
 				emote("scream")
 			custom_emote(1, "collapses!")
-		Weaken(5) //can't emote while weakened, apparently.
+		if(!(lying || resting)) // stops permastun with SPINE sdisability
+			Weaken(5) //can't emote while weakened, apparently.
 
 /mob/living/carbon/human/proc/handle_grasp()
 	if(!l_hand && !r_hand)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
@@ -207,3 +207,16 @@
 	disability=CENSORED
 	activation_message="You feel less rude..."
 	primitive_expression_messages=list("BEEPS!")
+
+/datum/trait/negative/disability_damagedspine
+	name = "Lumbar Impairment"
+	desc = "Due to neurological damage, you are unable to use your legs. Collapsing to the ground as soon as you try to stand. You should check the loadout menu for something to assist you."
+	cost = -3
+	custom_only = FALSE
+
+	is_genetrait = TRUE
+	hidden = FALSE
+	activity_bounds = DNA_HARDER_BOUNDS // Shouldn't be easy for genetics to find this
+
+	sdisability=SPINE
+	activation_message="Your legs shake..."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
@@ -213,6 +213,7 @@
 	desc = "Due to neurological damage, you are unable to use your legs. Collapsing to the ground as soon as you try to stand. You should check the loadout menu for something to assist you."
 	cost = -3
 	custom_only = FALSE
+	can_take = ORGANICS
 
 	is_genetrait = TRUE
 	hidden = FALSE

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -154,6 +154,16 @@
 			owner.custom_pain("A jolt of pain surges through your [name]!",1)
 			owner.Weaken(5)
 
+/obj/item/organ/external/leg/is_usable() // We only do legs, otherwise the stance_damage will be 8 instead of 4, meaning crutches do nothing as they only negate 4
+	if(robotic == ORGAN_FLESH && owner.sdisabilities & SPINE)
+		return FALSE
+	. = ..()
+
+/obj/item/organ/external/leg/organ_can_feel_pain()
+	if(robotic < ORGAN_ROBOT && owner.sdisabilities & SPINE)
+		return FALSE
+	. = ..()
+
 /obj/item/organ/external/leg/right
 	organ_tag = BP_R_LEG
 	name = "right leg"
@@ -197,6 +207,11 @@
 		if(prob(.))
 			owner.custom_pain("A jolt of pain surges through your [name]!",1)
 			owner.Weaken(5)
+
+/obj/item/organ/external/foot/organ_can_feel_pain()
+	if(robotic < ORGAN_ROBOT && owner.sdisabilities & SPINE)
+		return FALSE
+	. = ..()
 
 /obj/item/organ/external/foot/right
 	organ_tag = BP_R_FOOT

--- a/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainAbnormalities.tsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainAbnormalities.tsx
@@ -11,6 +11,7 @@ export const BodyScannerMainAbnormalities = (props: { occupant: occupant }) => {
     occupant.blind ||
     occupant.colourblind ||
     occupant.nearsighted ||
+    occupant.brokenspine ||
     occupant.hasVirus ||
     occupant.husked;
 

--- a/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
@@ -22,6 +22,7 @@ export const abnormalities: (string | ((occupant: occupant) => string))[][] = [
     (occupant) => 'Photoreceptor abnormalities detected.',
   ],
   ['nearsighted', 'average', (occupant) => 'Retinal misalignment detected.'],
+  ['brokenspine', 'average', (occupant) => 'Lumbar spine impairement.'],
   [
     'humanPrey',
     'average',

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -31,6 +31,7 @@ export type occupant = {
   intOrgan: internalOrgan[];
   blind: BooleanLike;
   nearsighted: BooleanLike;
+  brokenspine: BooleanLike;
   livingPrey: number;
   humanPrey: number;
   objectPrey: number;


### PR DESCRIPTION

## About The Pull Request

Adds a genetrait disability that prevents the use of your legs, they also don't feel any pain if they are organic/assisted. Full prosthetics will restore functionality. Intended for players who want to stop pretending their legs do not work, and want a genuine experience.
Gives three trait points.
## Changelog
:cl: Will
add: Adds a new trait 'Lumbar Impairment' which makes you incapable of utilizing your legs.
/:cl:
