### PR TITLE
Fixes rat health

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse.dm
@@ -150,10 +150,11 @@
 	icon_state = "mouse_rat"
 	icon_rest = "mouse_rat_sleep"
 	holder_type = /obj/item/holder/mouse/rat
+	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive
+
+/mob/living/simple_mob/animal/passive/mouse/rat/strong // In case you still want to be a jerk to your players for some reason.
 	maxHealth = 20
 	health = 20
-
-	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive
 
 /mob/living/simple_mob/animal/passive/mouse/operative
 	name = "mouse operative"


### PR DESCRIPTION
## About The Pull Request

Rats should not have 20hp. I know they're rats, but that's like 5-8 punches because of how weak player melee is. You can still one hit kill them by picking them up and whipping them at a wall but that's a really goofy and dumb work-around. Their high health and difficulty clicking on them makes them incredibly not fun to encounter in maintenance tunnels in downstreams.

But if you feel like being a dick to your players or want to swarm some very unfortunate bastard with a thousand biting little rats in a scene straight out of Dishonored, there is now a strong variant that keeps the 20hp.

~~Todo: A smite feature for admins to swarm people with rats.~~ no I'm not actually doing that (but it would be funny)

## Changelog
:cl:
balance: Rat health reduced to 5, same as mice
add: Strong rat variant
/:cl:
