### PR TITLE
Removes synth damage on resleeve

### DIFF
--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -221,8 +221,8 @@
 	var/max_res_amount = 30000 //Max the thing can hold
 	var/datum/transhuman/body_record/current_project
 	var/broken = 0
-	var/burn_value = 45
-	var/brute_value = 60
+	var/burn_value = 0 //Setting these to 0, if resleeving as organic with unupgraded sleevers gives them no damage, resleeving synths with unupgraded synthfabs should not give them potentially 105 damage.
+	var/brute_value = 0
 
 /obj/machinery/transhuman/synthprinter/New()
 	..()


### PR DESCRIPTION

## About The Pull Request
Unsure if this is a polaris leftover or what, growing an organic body with a level 1 grower pod is fine for people, but a level 1 synthfab3000 will give them huge amounts of damage to the point they get built with missing limbs. 
Especially with the autosleever existing, this feels like unnecessary tedium for synths specifically.
## Changelog
:cl:
qol: Synthfabs no longer apply massive damage when unupgraded.
/:cl:
