### PR TITLE
Firecode Fix & Phoron Bore Adjustment

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -440,6 +440,7 @@
 				return
 
 			if(ticker == burst)
+				next_fire_time = world.time + fire_delay
 				if(muzzle_flash)
 					if(gun_light)
 						addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_light),light_brightness), burst_delay, TIMER_DELETE_ME)

--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -165,7 +165,6 @@
 	item_state = "bore"
 	wielded_item_state = "bore-wielded"
 	one_handed_penalty = 5
-	fire_delay = 20
 
 	projectile_type = /obj/item/projectile/bullet/magnetic/bore
 


### PR DESCRIPTION
## About The Pull Request
Makes firecode respect fire_delay.
Allows phoron bores to keep their unintentional attack-speed buff as a QoL for mining, which they desperately need. (Bitrunning when?)
## Changelog
:cl: Diana
fix: Guns now have their fire_delays fixed. No more rapidfire RPGs.
qol: Phoron bore gets to keep it's unintentional attack-speed buff. (Mining is in need of QoL changes, so let this be at least one of them.)
/:cl:
