### PR TITLE
fixes shield capacitors taking power when unanchored

### DIFF
--- a/code/modules/shieldgen/shield_capacitor.dm
+++ b/code/modules/shieldgen/shield_capacitor.dm
@@ -101,7 +101,7 @@
 	var/datum/powernet/PN
 	var/turf/T = get_turf(src)
 	var/obj/structure/cable/C = T.get_cable_node()
-	if (C)
+	if (C && anchored) //Make sure its anchored too.
 		PN = C.powernet
 
 	if (PN)


### PR DESCRIPTION

## About The Pull Request
They took power simply by existing on top of a wire node, now they need to be anchored. 


https://github.com/user-attachments/assets/2e6e8895-3204-48c2-bbe6-062ce685d1ac
## Changelog
:cl:
fix: Shield capacitors now only take power from wires when anchored to the ground.
/:cl:
