### PR TITLE
Fixes swarm enemies behaving like walls when dead

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
@@ -125,7 +125,7 @@
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_mob/animal/giant_spider/CanPass(atom/movable/mover, turf/target)
-	if(isliving(mover) && !istype(mover, /mob/living/simple_mob/animal/giant_spider) && mover.density == TRUE)
+	if(isliving(mover) && !istype(mover, /mob/living/simple_mob/animal/giant_spider) && mover.density == TRUE && stat != DEAD)
 		return FALSE
 	return ..()
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
@@ -95,7 +95,7 @@
 
 // This is so carps can swarm
 /mob/living/simple_mob/animal/space/carp/CanPass(atom/movable/mover, turf/target)
-	if(isliving(mover) && !istype(mover, /mob/living/simple_mob/animal/space/carp) && mover.density == TRUE)
+	if(isliving(mover) && !istype(mover, /mob/living/simple_mob/animal/space/carp) && mover.density == TRUE && stat != DEAD)
 		return FALSE
 	return ..()
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -554,7 +554,11 @@
 	else
 		var/mob/living/L = target
 		if(!direct_target)
-			if(L.lying)
+			// Swarms are special scuffed critters. They must have density FALSE to swarm, but then they don't get hit.
+			// So we'll check before, just in case. Lying might gives a chance to dodge, however.
+			if(L.GetComponent(/datum/component/swarming) && L.stat != DEAD && !L.lying)
+				return TRUE
+			if(!L.density)
 				return FALSE
 	return TRUE
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -554,7 +554,7 @@
 	else
 		var/mob/living/L = target
 		if(!direct_target)
-			if(!L.density)
+			if(L.lying)
 				return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Fixes an oversight that made the corpses have density. Additionally, projectiles will now check if the target is lying down instead of checking for density, allowing to shoot at swarm enemies without the need to click on them individually.

## Changelog
:cl: Guti
fix: Fixed swarm mobs becoming walls on death
code: Slightly changed projectile code to check for lying down mobs instead of their density
/:cl:
