### PR TITLE
More xenoarch artifact tweaks

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -644,14 +644,14 @@ var/list/mining_overlay_cache = list()
 		var/pain = 0
 		if(prob(50))
 			pain = 1
-		for(var/mob/living/M in range(src, 200))
+		for(var/mob/living/M in range(src, 5)) //Let's only hit people nearby us.
 			to_chat(M, span_danger("[pick("A high-pitched [pick("keening","wailing","whistle")]","A rumbling noise like [pick("thunder","heavy machinery")]")] somehow penetrates your mind before fading away!"))
 			if(pain)
 				flick("pain",M.pain)
 			M.flash_eyes()
 			if(prob(50))
 				M.Stun(5)
-			M.make_jittery(1000) //SHAKY
+			M.make_jittery(50) //SHAKY this used to be 1000(seizure) but I toned it to 50 to be less aggressive.
 		if(prob(25))
 			excavate_find(prob(25), finds[1])
 	else if(rand(1,500) == 1)

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -20,6 +20,8 @@
 
 	// The last time the effect was toggled.
 	var/last_activation = 0
+	// If we can start activated or not!
+	var/can_start_activated = TRUE
 
 /datum/artifact_effect/Destroy()
 	master = null //Master still exists even if our effect gets destroyed. No need to qdel_null.
@@ -62,6 +64,8 @@
 			//large range, long charge time
 			chargelevelmax = rand(20, 120)
 			effectrange = rand(20, 100) //VOREStation Edit - Map size.
+	if(can_start_activated && prob(50))
+		ToggleActivate() //50% chance for us to be activated!
 
 /datum/artifact_effect/proc/ToggleActivate(var/reveal_toggle = 1)
 	//so that other stuff happens first
@@ -192,6 +196,7 @@
 			. += " Activation index involves " + span_bold("precise temperature conditions.") + " Heating/Cooling the atmosphere (>[ARTIFACT_HEAT_TRIGGER]K or <[ARTIFACT_COLD_TRIGGER]K) or using a welder are potential triggers."
 		else
 			. += " Unable to determine any data about activation trigger."
+	. += "<br>"
 
 //returns 0..1, with 1 being no protection and 0 being fully protected
 /proc/GetAnomalySusceptibility(var/mob/living/carbon/human/H)

--- a/code/modules/xenoarcheaology/effects/atmospheric.dm
+++ b/code/modules/xenoarcheaology/effects/atmospheric.dm
@@ -5,6 +5,7 @@
 	var/random = TRUE
 	effect_type = EFFECT_GAS
 	effect = EFFECT_AURA
+	can_start_activated = FALSE //This is set to FALSE so we do NOT CREATE IMMEDIATE HELLFIRES
 
 	effect_color = "#a5a5a5"
 

--- a/code/modules/xenoarcheaology/finds/finds.dm
+++ b/code/modules/xenoarcheaology/finds/finds.dm
@@ -1,7 +1,7 @@
 /datum/find
 	var/find_type = 0				//random according to the digsite type
 	var/excavation_required = 0		//random 10 - 190
-	var/view_range = 40				//how close excavation has to come to show an overlay on the turf
+	var/view_range = 200			//how close excavation has to come to show an overlay on the turf
 	var/prob_delicate = 0			//probability it requires an active suspension field to not insta-crumble. Set to 0 to nullify the need for suspension field.
 
 /datum/find/New(var/digsite, var/exc_req)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes destroying artifacts less punishing (if hit with long range)
Makes artifacts have a coinflip's chance to spawn active (to mitigate the 'sterility' that was noted due to xenoarch artifacts not starting active anymore) This EXCLUDES gas artifacts, to prevent hellfires.
Makes artifact deposits always visible, to mitigate people accidentally destroying them without intent of doing such.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Artifacts now have a coinflip's chance of spawning active when unearthed (EXCLUDING gas artifacts)
qol: Artifacts are always visible at any depth now.
qol: Artifacts no longer apply a Z wide spawn, it will only apply effects for those within a small range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
