### PR TITLE
Fixes duplicate structures or cleanables on maps

### DIFF
--- a/archive/maps/cynosure/cynosure-1.dmm
+++ b/archive/maps/cynosure/cynosure-1.dmm
@@ -4636,7 +4636,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/mining_main)
 "kJ" = (
@@ -17396,7 +17395,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,

--- a/archive/maps/cynosure/cynosure-1.dmm
+++ b/archive/maps/cynosure/cynosure-1.dmm
@@ -17396,7 +17396,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/surface/station/mining_main)
 "NQ" = (

--- a/archive/maps/cynosure/cynosure-2.dmm
+++ b/archive/maps/cynosure/cynosure-2.dmm
@@ -13413,7 +13413,6 @@
 "gvD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";

--- a/archive/maps/gateway_archive_vr/spacebattle.dmm
+++ b/archive/maps/gateway_archive_vr/spacebattle.dmm
@@ -2504,7 +2504,6 @@
 	name = "Dan Hedricks"
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/cruiser)
 "hn" = (

--- a/archive/maps/southern_cross/southern_cross-1.dmm
+++ b/archive/maps/southern_cross/southern_cross-1.dmm
@@ -5770,7 +5770,6 @@
 /obj/item/storage/bible,
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/clean,
 /turf/simulated/floor,
 /area/maintenance/firstdeck/foreport)

--- a/archive/maps/southern_cross/southern_cross-3.dmm
+++ b/archive/maps/southern_cross/southern_cross-3.dmm
@@ -9498,7 +9498,6 @@
 "uA" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/sif/planetuse,
 /area/surface/outpost/research/xenoresearch)

--- a/archive/maps/southern_cross/southern_cross-3.dmm
+++ b/archive/maps/southern_cross/southern_cross-3.dmm
@@ -621,7 +621,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outpost/mining_main)
 "bG" = (
@@ -6984,7 +6983,6 @@
 /area/surface/outpost/main/restroom)
 "pm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/tiled/steel_dirty{
 	outdoors = 1
@@ -9501,12 +9499,10 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/sif/planetuse,
 /area/surface/outpost/research/xenoresearch)
 "uB" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/sif/planetuse,
@@ -13101,7 +13097,6 @@
 /area/surface/outpost/research/xenoresearch/xenobiology)
 "Ck" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -13110,7 +13105,6 @@
 /turf/simulated/floor/tiled/steel/sif/planetuse,
 /area/surface/outpost/research/xenoresearch/xenobiology)
 "Cl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/tiled/steel/sif/planetuse,

--- a/maps/expedition_vr/aerostat/aerostat.dmm
+++ b/maps/expedition_vr/aerostat/aerostat.dmm
@@ -474,7 +474,6 @@
 /area/tether_away/aerostat/inside)
 "bo" = (
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating/virgo2,
 /area/tether_away/aerostat/inside)

--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -530,7 +530,6 @@
 /area/offmap/aerostat/inside/airlock/north)
 "bo" = (
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2106,7 +2105,6 @@
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2159,7 +2157,6 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/atmos)
 "fW" = (
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -2773,7 +2770,6 @@
 	name = "Xenobiology"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio_blast";
 	name = "Xenobiology Emergency Blast Door"
@@ -2852,7 +2848,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/northchamb)
@@ -3505,7 +3500,6 @@
 /area/offmap/aerostat/inside/arm/nw)
 "lt" = (
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4048,7 +4042,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -4948,7 +4941,6 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/toxins)
 "qM" = (
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -6480,7 +6472,6 @@
 	dir = 8
 	},
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -6550,7 +6541,6 @@
 "xH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -7614,7 +7604,6 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "BV" = (
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -9043,7 +9032,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "zorrenpartyroom";
@@ -9246,7 +9234,6 @@
 /area/offmap/aerostat/inside/virology)
 "IB" = (
 /obj/structure/grille,
-/obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9380,7 +9367,6 @@
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "Jd" = (
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -12572,7 +12558,6 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "Ww" = (
-/obj/structure/grille,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{

--- a/maps/expedition_vr/beach/submaps/crashedcontainmentshuttle.dmm
+++ b/maps/expedition_vr/beach/submaps/crashedcontainmentshuttle.dmm
@@ -280,7 +280,6 @@
 "bj" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/yellow,
 /area/submap/crashedcontainmentshuttle)
 "bk" = (
@@ -303,7 +302,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen/cave,
 /area/submap/crashedcontainmentshuttle)
 "bn" = (
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/black,
 /area/submap/crashedcontainmentshuttle)
@@ -328,7 +326,6 @@
 /turf/template_noop,
 /area/submap/crashedcontainmentshuttle)
 "bt" = (
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/white,
 /area/submap/crashedcontainmentshuttle)
@@ -368,7 +365,6 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/white,
 /area/submap/crashedcontainmentshuttle)

--- a/maps/offmap_vr/om_ships/bearcat.dmm
+++ b/maps/offmap_vr/om_ships/bearcat.dmm
@@ -1862,7 +1862,6 @@
 /area/shuttle/bearcat/cargo)
 "eF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8;
 	icon_state = "map"
@@ -2629,7 +2628,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/bearcat/maintenance_atmos)
 "gp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8";

--- a/maps/redgate/fantasy_dungeon.dmm
+++ b/maps/redgate/fantasy_dungeon.dmm
@@ -440,7 +440,6 @@
 "jR" = (
 /obj/machinery/light/small/torch,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/concrete,
 /area/redgate/fantasy/crypt)
 "kc" = (
@@ -2080,7 +2079,6 @@
 /area/redgate/fantasy/dark)
 "Qb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wmarble,
 /area/redgate/fantasy/dungeon)
 "Qm" = (
@@ -2239,7 +2237,6 @@
 /obj/machinery/light/small/torch{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/concrete,
 /area/redgate/fantasy/crypt)

--- a/maps/submaps/pois_vr/aerostat/Rockybase.dmm
+++ b/maps/submaps/pois_vr/aerostat/Rockybase.dmm
@@ -542,7 +542,6 @@
 "bS" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/Rockybase)
 "bT" = (
@@ -619,22 +618,18 @@
 /area/submap/virgo2/Rockybase)
 "ch" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/Rockybase)
 "ci" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/virgo2,
 /area/submap/virgo2/Rockybase)
 "cj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/material/shard,
 /turf/simulated/floor/plating/virgo2,
 /area/submap/virgo2/Rockybase)
 "ck" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/virgo2,
@@ -701,7 +696,6 @@
 /turf/simulated/floor/plating/virgo2,
 /area/submap/virgo2/Rockybase)
 "ct" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,

--- a/maps/submaps/pois_vr/aerostat/Rockybase.dmm
+++ b/maps/submaps/pois_vr/aerostat/Rockybase.dmm
@@ -631,7 +631,6 @@
 /area/submap/virgo2/Rockybase)
 "ck" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/virgo2,
 /area/submap/virgo2/Rockybase)
 "cl" = (
@@ -696,7 +695,6 @@
 /turf/simulated/floor/plating/virgo2,
 /area/submap/virgo2/Rockybase)
 "ct" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/virgo2,

--- a/maps/submaps/surface_submaps/mountains/crashedcontainmentshuttle_vr.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashedcontainmentshuttle_vr.dmm
@@ -280,7 +280,6 @@
 "bj" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/yellow,
 /area/submap/crashedcontainmentshuttle)
 "bk" = (
@@ -303,7 +302,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/crashedcontainmentshuttle)
 "bn" = (
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/black,
 /area/submap/crashedcontainmentshuttle)
@@ -328,7 +326,6 @@
 /turf/template_noop,
 /area/submap/crashedcontainmentshuttle)
 "bt" = (
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/white,
 /area/submap/crashedcontainmentshuttle)
@@ -368,7 +365,6 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/shuttle/floor/white,
 /area/submap/crashedcontainmentshuttle)

--- a/maps/submaps/surface_submaps/plains/Oldhouse_vr.dmm
+++ b/maps/submaps/surface_submaps/plains/Oldhouse_vr.dmm
@@ -195,7 +195,6 @@
 /area/submap/Oldhouse)
 "aO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
 /area/submap/Oldhouse)
 "aP" = (

--- a/maps/submaps/surface_submaps/plains/dogbase.dmm
+++ b/maps/submaps/surface_submaps/plains/dogbase.dmm
@@ -18,12 +18,10 @@
 	name = "syndicate guard dog"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
 "ay" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/tajaran,
 /obj/random/maintenance/medical,
@@ -37,7 +35,6 @@
 /obj/structure/dogbed,
 /obj/effect/decal/remains/tajaran,
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/maintenance/security,
@@ -117,7 +114,6 @@
 /area/submap/DogBase)
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
@@ -153,7 +149,6 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/bone/ribs,
 /obj/random/maintenance/research,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -175,13 +170,11 @@
 /obj/structure/dogbed,
 /obj/effect/decal/remains/unathi,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
 "kl" = (
 /obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -213,7 +206,6 @@
 /turf/simulated/floor/plating,
 /area/submap/DogBase)
 "lk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
@@ -254,7 +246,6 @@
 /area/submap/DogBase)
 "oW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/template_noop)
 "pR" = (
@@ -285,7 +276,6 @@
 /area/submap/DogBase)
 "qI" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/maintenance/security,
@@ -417,7 +407,6 @@
 "xp" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -425,7 +414,6 @@
 "yl" = (
 /obj/structure/dogbed,
 /obj/effect/decal/remains/deer,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -493,7 +481,6 @@
 "CQ" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -552,7 +539,6 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
@@ -592,7 +578,6 @@
 /area/submap/DogBase)
 "Jm" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/research,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -662,7 +647,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/submap/DogBase)
 "Ol" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone/leg,
 /mob/living/simple_mob/vore/wolf/direwolf/dog/sec{
@@ -739,7 +723,6 @@
 	name = "syndicate guard dog"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/template_noop)
 "Rz" = (
@@ -776,7 +759,6 @@
 "UY" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
@@ -787,7 +769,6 @@
 /area/submap/DogBase)
 "Vy" = (
 /obj/effect/decal/remains/unathi,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/DogBase)
@@ -863,7 +844,6 @@
 "YX" = (
 /obj/structure/dogbed,
 /obj/effect/decal/remains/deer,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/outdoors/dirt/virgo3b,

--- a/maps/submaps/surface_submaps/plains/greatwolfden.dmm
+++ b/maps/submaps/surface_submaps/plains/greatwolfden.dmm
@@ -72,7 +72,6 @@
 /area/template_noop)
 "iX" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip{
 	icon_state = "2"
 	},
@@ -262,12 +261,10 @@
 /area/submap/GreatWolfDen)
 "zV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/template_noop)
 "AG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
@@ -402,7 +399,6 @@
 "LP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -458,7 +454,6 @@
 /area/template_noop)
 "Pf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b{
 	outdoors = 0
 	},
@@ -481,7 +476,6 @@
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/GreatWolfDen)
 "Qb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
@@ -593,7 +587,6 @@
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/GreatWolfDen)
 "WY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/dirt/virgo3b,

--- a/maps/submaps/surface_submaps/plains/greatwolfden.dmm
+++ b/maps/submaps/surface_submaps/plains/greatwolfden.dmm
@@ -266,7 +266,6 @@
 /area/template_noop)
 "AG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/rocks/virgo3b,
@@ -398,7 +397,6 @@
 /area/submap/GreatWolfDen)
 "LP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
@@ -476,7 +474,6 @@
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/GreatWolfDen)
 "Qb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
 /obj/structure/ledge/ledge_stairs,

--- a/maps/submaps/surface_submaps/plains/leopardmanderden.dmm
+++ b/maps/submaps/surface_submaps/plains/leopardmanderden.dmm
@@ -183,7 +183,6 @@
 /area/template_noop)
 "nG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/grass/sif/forest/virgo3b{
 	outdoors = 0
 	},

--- a/maps/submaps/surface_submaps/plains/lonehome_vr.dmm
+++ b/maps/submaps/surface_submaps/plains/lonehome_vr.dmm
@@ -83,7 +83,6 @@
 /area/submap/lonehome)
 "ar" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/virgo3b,
 /area/submap/lonehome)
 "as" = (
@@ -125,7 +124,6 @@
 /turf/simulated/floor/tiled/white/virgo3b,
 /area/submap/lonehome)
 "ax" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/virgo3b,
 /area/submap/lonehome)
@@ -407,7 +405,6 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/virgo3b,
 /area/submap/lonehome)
 "bm" = (
@@ -450,7 +447,6 @@
 /turf/simulated/floor/wood/virgo3b,
 /area/submap/lonehome)
 "br" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/broken,
 /area/submap/lonehome)
@@ -520,7 +516,6 @@
 	info = "Seems to be filled with odd runes drawn with blood";
 	name = "Blood stained paper"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/broken,
 /area/submap/lonehome)
@@ -601,7 +596,6 @@
 	name = "Stained sheet of paper"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet/virgo3b,
 /area/submap/lonehome)
 "bN" = (
@@ -641,11 +635,9 @@
 "bS" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet/virgo3b,
 /area/submap/lonehome)
 "bT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet/virgo3b,
 /area/submap/lonehome)
@@ -954,7 +946,6 @@
 /area/submap/lonehome)
 "cM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/external/virgo3b,
 /area/submap/lonehome)
 "cN" = (
@@ -963,14 +954,12 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/external/virgo3b,
 /area/submap/lonehome)
 "cO" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/external/virgo3b,
 /area/submap/lonehome)

--- a/maps/submaps/surface_submaps/plains/methlab.dmm
+++ b/maps/submaps/surface_submaps/plains/methlab.dmm
@@ -329,7 +329,6 @@
 /area/submap/methlab)
 "BP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
 "BR" = (
@@ -431,7 +430,6 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
@@ -532,7 +530,6 @@
 "Sn" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/steeldecal/steel_decals_central5,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)

--- a/maps/submaps/surface_submaps/plains/methlab.dmm
+++ b/maps/submaps/surface_submaps/plains/methlab.dmm
@@ -234,7 +234,6 @@
 "tL" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
 "tQ" = (
@@ -295,7 +294,6 @@
 /area/submap/methlab)
 "zu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/green/virgo3b,
 /area/submap/methlab)
 "zG" = (
@@ -330,7 +328,6 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
 "BP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
@@ -435,7 +432,6 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
@@ -480,12 +476,10 @@
 "LM" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
 "LX" = (
 /obj/item/stool,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/submap/methlab)
@@ -500,7 +494,6 @@
 /area/submap/methlab)
 "Ol" = (
 /obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/green/virgo3b,
 /area/submap/methlab)
@@ -539,7 +532,6 @@
 "Sn" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/steeldecal/steel_decals_central5,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
@@ -615,7 +607,6 @@
 /area/submap/methlab)
 "Vf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled/old_tile/green/virgo3b,
 /area/submap/methlab)
@@ -626,7 +617,6 @@
 /turf/template_noop,
 /area/submap/methlab)
 "Vw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/steel_dirty,

--- a/maps/submaps/surface_submaps/plains/oldhotel.dmm
+++ b/maps/submaps/surface_submaps/plains/oldhotel.dmm
@@ -15,7 +15,6 @@
 /area/submap/oldhotel)
 "bQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile/white/virgo3b,
 /area/submap/oldhotel)
 "bW" = (
@@ -617,7 +616,6 @@
 /turf/simulated/floor/carpet/sblucarpet/virgo3b,
 /area/submap/oldhotel)
 "Wy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/virgo3b,
 /area/submap/oldhotel)

--- a/maps/submaps/surface_submaps/plains/priderock.dmm
+++ b/maps/submaps/surface_submaps/plains/priderock.dmm
@@ -68,7 +68,6 @@
 /area/submap/priderock)
 "qP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/priderock)
 "qY" = (
@@ -84,7 +83,6 @@
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/submap/priderock)
 "sr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/submap/priderock)

--- a/maps/submaps/surface_submaps/wilderness/Rockybase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Rockybase.dmm
@@ -907,7 +907,6 @@
 /area/submap/Rockybase)
 "cY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/submap/Rockybase)
 "cZ" = (
@@ -984,7 +983,6 @@
 /turf/simulated/floor/tiled,
 /area/submap/Rockybase)
 "di" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor,

--- a/maps/submaps/surface_submaps/wilderness/Rockybase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Rockybase.dmm
@@ -791,7 +791,6 @@
 "cE" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/submap/Rockybase)
 "cF" = (
@@ -895,22 +894,18 @@
 /area/submap/Rockybase)
 "cV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/submap/Rockybase)
 "cW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/submap/Rockybase)
 "cX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/material/shard,
 /turf/simulated/floor,
 /area/submap/Rockybase)
 "cY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -991,7 +986,6 @@
 "di" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor,
 /area/submap/Rockybase)
@@ -1038,7 +1032,6 @@
 /turf/simulated/floor/tiled,
 /area/submap/Rockybase)
 "dp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_mob/mechanical/combat_drone/lesser,
 /turf/simulated/floor/tiled,

--- a/maps/submaps/surface_submaps/wilderness/demonpool.dmm
+++ b/maps/submaps/surface_submaps/wilderness/demonpool.dmm
@@ -118,7 +118,6 @@
 /area/submap/DemonPool)
 "hW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/rocks{
 	outdoors = 0
 	},
@@ -226,7 +225,6 @@
 "pX" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -265,7 +263,6 @@
 /turf/simulated/floor/cult,
 /area/submap/DemonPool)
 "tq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
@@ -332,7 +329,6 @@
 	},
 /area/submap/DemonPool)
 "zU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
@@ -556,7 +552,6 @@
 "RL" = (
 /obj/structure/grille/broken/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -629,7 +624,6 @@
 	anchored = 1;
 	deployed = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0

--- a/maps/submaps/surface_submaps/wilderness/demonpool.dmm
+++ b/maps/submaps/surface_submaps/wilderness/demonpool.dmm
@@ -78,7 +78,6 @@
 "fW" = (
 /obj/structure/grille/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -98,12 +97,10 @@
 "hr" = (
 /obj/fire,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DemonPool)
 "hF" = (
 /obj/effect/gibspawner/human,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
@@ -120,7 +117,6 @@
 /turf/simulated/floor/cult,
 /area/submap/DemonPool)
 "hW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/rocks{
@@ -179,7 +175,6 @@
 /area/submap/DemonPool)
 "lV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/rocks{
 	outdoors = 0
 	},
@@ -232,7 +227,6 @@
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -273,8 +267,6 @@
 "tq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -313,7 +305,6 @@
 /area/template_noop)
 "yS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/submap/DemonPool)
 "yW" = (
@@ -336,13 +327,11 @@
 "zI" = (
 /obj/structure/grille/broken/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/DemonPool)
 "zU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
@@ -358,7 +347,6 @@
 /area/submap/DemonPool)
 "Ag" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DemonPool)
 "Ah" = (
@@ -373,7 +361,6 @@
 /turf/simulated/floor,
 /area/submap/DemonPool)
 "AF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
@@ -432,7 +419,6 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/grille/broken/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -482,7 +468,6 @@
 /mob/living/simple_mob/animal/space/bats/cult/strong{
 	faction = "demon"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
@@ -564,14 +549,12 @@
 "Ro" = (
 /obj/structure/simple_door,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/DemonPool)
 "RL" = (
 /obj/structure/grille/broken/cult,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{
@@ -646,7 +629,6 @@
 	anchored = 1;
 	deployed = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt{

--- a/maps/submaps/surface_submaps/wilderness/dogbase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/dogbase.dmm
@@ -18,12 +18,10 @@
 	name = "syndicate guard dog"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
 "ay" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/tajaran,
 /obj/random/maintenance/medical,
@@ -37,7 +35,6 @@
 /obj/structure/dogbed,
 /obj/effect/decal/remains/tajaran,
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/maintenance/security,
@@ -118,7 +115,6 @@
 /area/submap/DogBase)
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
@@ -154,7 +150,6 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/bone/ribs,
 /obj/random/maintenance/research,
 /turf/simulated/floor/outdoors/dirt,
@@ -179,13 +174,11 @@
 /obj/structure/dogbed,
 /obj/effect/decal/remains/unathi,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
 "kl" = (
 /obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt,
@@ -217,7 +210,6 @@
 /turf/simulated/floor/plating,
 /area/submap/DogBase)
 "lk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
@@ -258,7 +250,6 @@
 /area/submap/DogBase)
 "oW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/template_noop)
 "pR" = (
@@ -289,7 +280,6 @@
 /area/submap/DogBase)
 "qI" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/maintenance/security,
@@ -421,7 +411,6 @@
 "xp" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt,
@@ -429,7 +418,6 @@
 "yl" = (
 /obj/structure/dogbed,
 /obj/effect/decal/remains/deer,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt,
@@ -502,7 +490,6 @@
 "CQ" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/bone,
 /obj/random/contraband/nofail,
 /turf/simulated/floor/outdoors/dirt,
@@ -561,7 +548,6 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
@@ -601,7 +587,6 @@
 /area/submap/DogBase)
 "Jm" = (
 /obj/structure/dogbed,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/research,
 /turf/simulated/floor/outdoors/dirt,
@@ -671,7 +656,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/submap/DogBase)
 "Ol" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bone/leg,
 /mob/living/simple_mob/vore/wolf/direwolf/dog/sec{
@@ -747,7 +731,6 @@
 	name = "syndicate guard dog"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/template_noop)
 "Rz" = (
@@ -784,7 +767,6 @@
 "UY" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
@@ -795,7 +777,6 @@
 /area/submap/DogBase)
 "Vy" = (
 /obj/effect/decal/remains/unathi,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/DogBase)
@@ -871,7 +852,6 @@
 "YX" = (
 /obj/structure/dogbed,
 /obj/effect/decal/remains/deer,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/outdoors/dirt,

--- a/maps/submaps/surface_submaps/wilderness/greatwolfden.dmm
+++ b/maps/submaps/surface_submaps/wilderness/greatwolfden.dmm
@@ -259,7 +259,6 @@
 /area/template_noop)
 "AG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/rocks,
@@ -377,7 +376,6 @@
 /area/submap/GreatWolfDen)
 "LP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt,
@@ -449,7 +447,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/GreatWolfDen)
 "Qb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
 /obj/structure/ledge/ledge_stairs,

--- a/maps/submaps/surface_submaps/wilderness/greatwolfden.dmm
+++ b/maps/submaps/surface_submaps/wilderness/greatwolfden.dmm
@@ -68,7 +68,6 @@
 /area/template_noop)
 "iX" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip{
 	icon_state = "2"
 	},
@@ -255,12 +254,10 @@
 /area/submap/GreatWolfDen)
 "zV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt,
 /area/template_noop)
 "AG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
@@ -381,7 +378,6 @@
 "LP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks2,
 /obj/structure/ledge/ledge_stairs,
 /turf/simulated/floor/outdoors/dirt,
@@ -435,7 +431,6 @@
 /area/template_noop)
 "Pf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/GreatWolfDen)
 "Pl" = (
@@ -454,7 +449,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/GreatWolfDen)
 "Qb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
@@ -562,7 +556,6 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/GreatWolfDen)
 "WY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/dirt,

--- a/maps/submaps/surface_submaps/wilderness/leopardmanderden.dmm
+++ b/maps/submaps/surface_submaps/wilderness/leopardmanderden.dmm
@@ -186,7 +186,6 @@
 /area/submap/LeopardmanderDen)
 "nG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/grass/sif/forest{
 	outdoors = 0
 	},

--- a/maps/tether/submaps/underdark_pois/abandonded_outpost.dmm
+++ b/maps/tether/submaps/underdark_pois/abandonded_outpost.dmm
@@ -242,7 +242,6 @@
 /area/mine/explored/underdark)
 "bf" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored/underdark)
 "bg" = (

--- a/maps/tether/submaps/underdark_pois/phoron_rat_den.dmm
+++ b/maps/tether/submaps/underdark_pois/phoron_rat_den.dmm
@@ -39,7 +39,6 @@
 /area/mine/explored/underdark)
 "l" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/mine/explored/underdark)
 "m" = (


### PR DESCRIPTION

## About The Pull Request

Fixed a number of duplicate structures and cleanables on maps for the map linter PR. I will need the linter to be re-run once this is merges so that I can clean up what's left over easier.

## Changelog
:cl:
fix: Fixed a number of duplicate structures and cleanables on maps for the map linter PR.
/:cl:
