### PR TITLE
fix mapspawned dirt

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -47,7 +47,7 @@
 	if(our_turf && istype(our_turf) && our_turf.can_dirty)
 		our_turf.dirt = clamp(max(age ? (dirt ? dirt : 101) : our_turf.dirt, our_turf.dirt), 0, 101)
 		if(mapload && !our_turf.dirt)
-			our_turf.dirt = rand(50, 255)
+			our_turf.dirt = rand(51, 100)
 		var/calcalpha = our_turf.dirt > 50 ? min((our_turf.dirt - 50) * 5, 255) : 0
 		var/alreadyfound = FALSE
 		for (var/obj/effect/decal/cleanable/dirt/alreadythere in our_turf) //in case of multiple

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -46,6 +46,8 @@
 	var/turf/simulated/our_turf = src.loc
 	if(our_turf && istype(our_turf) && our_turf.can_dirty)
 		our_turf.dirt = clamp(max(age ? (dirt ? dirt : 101) : our_turf.dirt, our_turf.dirt), 0, 101)
+		if(mapload && !our_turf.dirt)
+			our_turf.dirt = rand (50,255)
 		var/calcalpha = our_turf.dirt > 50 ? min((our_turf.dirt - 50) * 5, 255) : 0
 		var/alreadyfound = FALSE
 		for (var/obj/effect/decal/cleanable/dirt/alreadythere in our_turf) //in case of multiple

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -47,7 +47,7 @@
 	if(our_turf && istype(our_turf) && our_turf.can_dirty)
 		our_turf.dirt = clamp(max(age ? (dirt ? dirt : 101) : our_turf.dirt, our_turf.dirt), 0, 101)
 		if(mapload && !our_turf.dirt)
-			our_turf.dirt = rand (50,255)
+			our_turf.dirt = rand(50, 255)
 		var/calcalpha = our_turf.dirt > 50 ? min((our_turf.dirt - 50) * 5, 255) : 0
 		var/alreadyfound = FALSE
 		for (var/obj/effect/decal/cleanable/dirt/alreadythere in our_turf) //in case of multiple


### PR DESCRIPTION
Ok... not only did people spawn over 4 useless dirt effects in one tile... all of them even did NOTHING... this at least allows maploaded dirt to dirty a turf...
## About The Pull Request
## Changelog
:cl:
fix: map placed dirt now applies 50 to 100 dirt
/:cl:
