### PR TITLE
VR pod rewrite

### DIFF
--- a/code/game/machinery/virtual_reality/ar_console.dm
+++ b/code/game/machinery/virtual_reality/ar_console.dm
@@ -15,6 +15,7 @@
 	var/produce_species = SPECIES_REPLICANT	// The default species produced. Will be overridden if randomize_species is true.
 	var/randomize_species = FALSE
 	var/list/possible_species	// Do we make the newly produced body a random species?
+	perfect_replica = TRUE //All alien VR sleepers make perfect replicas.
 
 /obj/machinery/vr_sleeper/alien/Initialize(mapload)
 	. = ..()
@@ -65,7 +66,7 @@
 	if(occupant && occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
-	occupant.loc = src.loc
+	occupant.forceMove(src)
 	occupant = null
 	for(var/atom/movable/A in src) // In case an object was dropped inside or something
 		if(A == circuit)
@@ -87,21 +88,39 @@
 	if(occupant.stat == DEAD && !occupant.client)
 		return
 
+	if(QDELETED(avatar)) //This REALLY needs to be changed to weakrefs
+		avatar = null
+
 	if(avatar && !occupant.stat)
 		to_chat(occupant,span_alien("\The [src] begins to [pick("whir","hum","pulse")] as a screen appears in front of you."))
 		if(tgui_alert(occupant, "This pod is already linked. Are you certain you wish to engage?", "Commmit?", list("Yes", "No")) != "Yes")
 			visible_message(span_alien("\The [src] pulses!"))
+			go_out(TRUE)
+			return
 
 	to_chat(occupant,span_alien("Your mind blurs as information bombards you."))
 
 	if(!avatar)
 		var/turf/T = get_turf(src)
-		avatar = new(src, produce_species)
+		if(!perfect_replica)
+			avatar = new(src, produce_species)
+		else
+			avatar = new(src, occupant.species.name)
 		if(occupant.species.name != "Promethean" && occupant.species.name != "Human" && mirror_first_occupant)
 			avatar.shapeshifter_change_shape(occupant.species.name)
 		avatar.Sleeping(6)
 
 		occupant.enter_vr(avatar)
+
+		//This handles all the 'We make it look like ourself' code.
+		if(perfect_replica)
+			avatar.species.create_organs(avatar) // Reset our organs/limbs.
+			avatar.restore_all_organs()
+			avatar.client.prefs.copy_to(avatar)
+			avatar.dna.ResetUIFrom(avatar)
+			avatar.sync_dna_traits(TRUE) // Traitgenes Sync traits to genetics if needed
+			avatar.sync_organ_dna()
+			avatar.initialize_vessel()
 
 		var/newname = sanitize(tgui_input_text(avatar, "Your mind feels foggy. You're certain your name is [occupant.real_name], but it could also be [avatar.name]. Would you like to change it to something else?", "Name change", null, MAX_NAME_LEN), MAX_NAME_LEN)
 		if (newname)


### PR DESCRIPTION

## About The Pull Request
Does some VR tweaks to make it so VR pods don't do two rejuvinate()'s back to back to apply your icon.
Allows VR pods to toggle between 'perfect replica' (default, given our playerbase) or a Virtual Reality Avatar that is a promethean.
Allows Replicant pods to replicate your appearance instead of just being a human.

Exiting VR pods properly sends a moved comsig.
## Changelog
:cl: Diana
fix: Replicant pods now let you be NOT just a human! You can be yourself!
fix: Replicant pods will no longer break movement related things.
code: VR pods and Replicant pods work a bit better on the backend
/:cl:
