### PR TITLE
Fixes borg slime baton sprite and enables shield on peacekeeper

### DIFF
--- a/code/modules/mob/living/silicon/robot/sprites/gooborgs.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/gooborgs.dm
@@ -174,7 +174,7 @@
 	sprite_icon = 'icons/mob/robot/gooborgs/departmental/gooborg_peacekeeper.dmi'
 	rest_sprite_options = list("Default", "Bellyup", "Sit")
 	belly_capacity_list = list("sleeper" = 2, "throat" =2)
-	sprite_flags = ROBOT_HAS_SPEED_SPRITE | ROBOT_HAS_DISABLER_SPRITE | ROBOT_HAS_TASER_SPRITE | ROBOT_HAS_LASER_SPRITE | ROBOT_HAS_MELEE_SPRITE //Baton
+	sprite_flags = ROBOT_HAS_SHIELD_SPRITE | ROBOT_HAS_SPEED_SPRITE | ROBOT_HAS_DISABLER_SPRITE | ROBOT_HAS_TASER_SPRITE | ROBOT_HAS_LASER_SPRITE | ROBOT_HAS_MELEE_SPRITE //Baton
 	module_type = "Combat"
 	icon_y = 64
 	vis_height = 64

--- a/code/modules/projectiles/guns/energy/cyborg.dm
+++ b/code/modules/projectiles/guns/energy/cyborg.dm
@@ -451,7 +451,7 @@
 	desc = "A modified stun baton designed to stun slimes and other lesser slimy xeno lifeforms for handling."
 	icon_state = "slimebaton_active"
 	item_state = "slimebaton"
-	force = 9
+	force = 10 //we like round numbers here
 	lightcolor = "#33CCFF"
 	agonyforce = 10	//It's not supposed to be great at stunning human beings.
 	hitcost = 48	//Less zap for less cost

--- a/code/modules/projectiles/guns/energy/cyborg.dm
+++ b/code/modules/projectiles/guns/energy/cyborg.dm
@@ -447,7 +447,15 @@
 		target.taunt(user)
 
 /obj/item/melee/robotic/baton/slime
-	hitcost = 200
+	name = "slimebaton"
+	desc = "A modified stun baton designed to stun slimes and other lesser slimy xeno lifeforms for handling."
+	icon_state = "slimebaton_active"
+	item_state = "slimebaton"
+	force = 9
+	lightcolor = "#33CCFF"
+	agonyforce = 10	//It's not supposed to be great at stunning human beings.
+	hitcost = 48	//Less zap for less cost
+
 
 /obj/item/melee/robotic/baton/slime/attack(mob/living/L, mob/user, hit_zone)
 	if(!istype(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Enables the  shield sprite on peacekeeper
Fixes the slime baton having the normal baton charge and sprite for borgs
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
fix: Sci borg baton no longer looks like a normal baton
fix: Peacekeeper borgs have their shield sprite enabled now
balance: sci borg baton now does ONE EXTRA DAMAGE. 9->10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
