### PR TITLE
Adds a trait to reduce natural negative chem reaction for certain spe…cies

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -50,6 +50,9 @@
 	var/lleill_energy = 200
 	var/lleill_energy_max = 200
 
+	// Mitigating natural (induced by species tag) allergies trait
+	var/reduced_negative_chem_reaction = FALSE
+
 /datum/species/unathi
 	vore_belly_default_variant = "L"
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1414,3 +1414,10 @@
 	cost = 0
 	var_changes = list("mudking" = TRUE)
 	custom_only = FALSE
+
+/datum/trait/neutral/reduced_neg_reaction
+	name = "Reduced Natural Chem Reaction"
+	desc = "Certain natural negative reactions of your species to chemicals are reduced. You're hardier than average in that regard!"
+	cost = 0
+	var_changes = list("reduced_negative_chem_reaction" = TRUE)
+	allowed_species = list(SPECIES_UNATHI)

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -356,6 +356,7 @@
 		effective_dose *= 2
 
 	if(alien == IS_UNATHI)
+		var/datum/species/S = M.get_species()
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))
 				M.emote("yawn")
@@ -366,7 +367,10 @@
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)
 		else
-			M.Sleeping(20)
+			if(S && S.reduced_negative_chem_reaction)
+				M.Weaken(10)
+			else
+				M.Sleeping(20)
 			M.drowsyness = max(M.drowsyness, 60)
 
 /datum/reagent/nutriment/mayo
@@ -1081,6 +1085,7 @@
 
 	if(alien == IS_UNATHI)
 		if(sugary == TRUE)
+			var/datum/species/S = M.get_species()
 			if(effective_dose < 2)
 				if(effective_dose == metabolism * 2 || prob(5))
 					M.emote("yawn")
@@ -1091,7 +1096,10 @@
 					M.Weaken(2)
 				M.drowsyness = max(M.drowsyness, 20)
 			else
-				M.Sleeping(20)
+				if(S && S.reduced_negative_chem_reaction)
+					M.Weaken(10)
+				else
+					M.Sleeping(20)
 				M.drowsyness = max(M.drowsyness, 60)
 
 /datum/reagent/drink/juice/lemon
@@ -2051,6 +2059,7 @@
 		effective_dose *= 2
 
 	if(alien == IS_UNATHI)
+		var/datum/species/S = M.get_species()
 		if(effective_dose < 2)
 			if(effective_dose == metabolism * 2 || prob(5))
 				M.emote("yawn")
@@ -2061,7 +2070,10 @@
 				M.Weaken(2)
 			M.drowsyness = max(M.drowsyness, 20)
 		else
-			M.Sleeping(20)
+			if(S && S.reduced_negative_chem_reaction)
+				M.Weaken(10)
+			else
+				M.Sleeping(20)
 			M.drowsyness = max(M.drowsyness, 60)
 
 /datum/reagent/drink/milkshake/chocoshake


### PR DESCRIPTION
## About The Pull Request

Currently only for unathi and only affects their reactions to sugary things. Could theoretically later be expanded to other species using inheirent chemical reactions like that. This isn't really a major balance change, because the drinks still incapacitate unathi, they just don't completely prevent any interactability anymore once you hit the 'sleepy' stage if you take the trait.

## Changelog

:cl:
add: A new trait for unathi to replace reactions to sugar from forced sleep with extra hard weakness instead
/:cl:
