### PR TITLE
Antique Antimatter Core RTG 

### DIFF
--- a/code/game/gamemodes/events/black_hole.dm
+++ b/code/game/gamemodes/events/black_hole.dm
@@ -17,6 +17,11 @@
 		qdel(src)
 		return
 
+	if(prob(5))
+		visible_message(span_warning("\The [src] fizzles out and collapses."))
+		qdel(src)
+		return
+
 	//DESTROYING STUFF AT THE EPICENTER
 	for(var/mob/living/M in orange(1,src))
 		qdel(M)
@@ -105,3 +110,6 @@
 		var/base_turf = get_base_turf_by_area(src)
 		if(ST.type != base_turf)
 			ST.ChangeTurf(base_turf)
+
+/obj/effect/bhole/ex_act(strength) // Don't get destroyed by explosions. Why would we?
+	return

--- a/code/modules/power/port_gen_vr.dm
+++ b/code/modules/power/port_gen_vr.dm
@@ -523,3 +523,47 @@
 		add_overlay("alteviangen-fuel-66")
 	else if(sheets > 0)
 		add_overlay("alteviangen-fuel-33")
+
+/obj/machinery/power/rtg/antimatter_core
+	name = "\improper Antique Anti-Matter Reactor"
+	desc = "Reacts hydrogen and anti-hydrogen with a phoron moderator to produce near limitless power! The magnetic fields are prone to easily rupturing, so the reactor design never took off."
+	icon = 'icons/am_engine.dmi'
+	icon_state = "core_on"
+	power_gen = 1000000 // 1MW
+	irradiate = FALSE // Green energy!
+	can_buckle = FALSE
+	plane = ABOVE_MOB_PLANE
+	layer = ABOVE_MOB_LAYER
+
+/obj/machinery/power/rtg/antimatter_core/Initialize(mapload)
+	. = ..()
+	set_light(3, 6, "#66FFFF")
+
+/obj/machinery/power/rtg/antimatter_core/proc/asplod()
+	visible_message(span_danger("\The [src] ruptures!"), span_danger("You hear a loud reverberating bang!"))
+	var/turf/T = get_turf(src)
+	qdel(src)
+	if(T)
+		empulse(T, 12, 14, 16, 18)
+		explosion(T, 7, 12, 18, 20)
+		SSradiation.radiate(T, 200)
+		new /obj/effect/bhole(T)
+
+/obj/machinery/power/rtg/antimatter_core/blob_act(obj/structure/blob/B)
+	return
+
+/obj/machinery/power/rtg/antimatter_core/ex_act()
+	asplod()
+
+/obj/machinery/power/rtg/antimatter_core/fire_act(exposed_temperature, exposed_volume)
+	return
+
+/obj/machinery/power/rtg/antimatter_core/tesla_act()
+	..() //extend the zap
+	asplod()
+
+/obj/machinery/power/rtg/antimatter_core/bullet_act(obj/item/projectile/Proj)
+	. = ..()
+	if(istype(Proj) && !Proj.nodamage && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)) && Proj.damage >= 20)
+		log_and_message_admins("[ADMIN_LOOKUPFLW(Proj.firer)] triggered an antimatter core explosion at [x],[y],[z] via projectile.", Proj.firer)
+		asplod()


### PR DESCRIPTION
## About The Pull Request
After a failed attempt to recode the ancient antimatter reactor engine, it was discovered that both versions of the engines pale in comparison to modern engine code. Both would need complete rebuilds and new art to be appealing to players. The antimatter core already acts like an rtg, except with worse fuel mechanics.

![antiquecore](https://github.com/user-attachments/assets/6c857e65-f220-4849-ba3f-20ab60f1c1b0)

## Changelog
Instead of rebuilding the antimatter engines, I repurposed the unused DMI for an rtg with a similar explosion to the old antimatter core. Keeping the sprite around, and referencing how it never caught on as a major engine. Intended for mapper POI use. It has no support objects, and only requires a wire beneath it. It cannot be constructed, deconstructed, or moved.

Explodes into a wandering mini-singularity, and also causes a giant blast with a radioactive emp. The blackhole event object was also something unused.  It causes objects to be pulled toward it and ex_act()s them. Eventually fizzles our and vanishes. Not intended to turn into a true singularity.

:cl:
add: Added Antimatter core RTG for POIs
/:cl: