### PR TITLE
adds spoiler function to statpanel

### DIFF
--- a/code/__defines/span.dm
+++ b/code/__defines/span.dm
@@ -250,3 +250,6 @@
 #define span_major_announcement_title(str) ("<span class='major_announcement_title'>" + str + "</span>")
 #define span_ooc_announcement_text(str) ("<span class='ooc_announcement_text'>" + str + "</span>")
 #define span_subheader_announcement_text(str) ("<span class='subheader_announcement_text'>" + str + "</span>")
+
+// special spans
+#define span_spoiler(str) ("<span class='spoiler'>" + str + "</span>")

--- a/code/controllers/subsystems/statpanel.dm
+++ b/code/controllers/subsystems/statpanel.dm
@@ -170,7 +170,7 @@ SUBSYSTEM_DEF(statpanels)
 	if(description_holders["antag"])
 		examine_update += span_red(span_bold("[description_holders["antag"]]")) + "<br />" //Red, malicious antag-related text
 
-	target.stat_panel.send_message("update_examine", examine_update)
+	target.stat_panel.send_message("update_examine", list("EX" = examine_update, "UPD" = target.prefs.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL))
 
 /datum/controller/subsystem/statpanels/proc/set_tickets_tab(client/target)
 	var/list/tickets = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -240,7 +240,8 @@
 		else
 			f_name += "oil-stained [name][infix]."
 
-	var/list/output = list("[icon2html(src,user.client)] That's [f_name] [suffix]", get_examine_desc())
+	var/examine_text = replacetext(get_examine_desc(), "||", "")
+	var/list/output = list("[icon2html(src,user.client)] That's [f_name] [suffix]", examine_text)
 
 	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
 		output += description_info

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -245,8 +245,6 @@
 	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
 		output += description_info
 
-	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL)
-		user.client.statpanel = "Examine" // Switch to stat panel
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, output)
 	return output
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -438,6 +438,7 @@
 
 	var/flavor_text = print_flavor_text()
 	if(flavor_text)
+		flavor_text = replacetext(flavor_text, "||", "")
 		msg += "[flavor_text]"
 
 	// VOREStation Start

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1112,8 +1112,6 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 	var/image/wing_image = get_wing_image(FALSE)
 
-	var/obj/item/organ/external/chest = organs_by_name[BP_TORSO]
-
 	if(wing_image)
 		wing_image.layer = BODY_LAYER+WING_LAYER
 		overlays_standing[WING_LAYER] = wing_image

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -517,7 +517,19 @@
 		src << browse(null, t1)
 
 	if(href_list["flavor_more"])
-		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
+		var/examine_text = splittext(flavor_text, "||")
+		var/index = 0
+		var/rendered_text = ""
+		for(var/part in examine_text)
+			if(index % 2)
+				rendered_text += span_spoiler("[part]")
+			else
+				rendered_text += "[part]"
+			index++
+		examine_text = replacetext(rendered_text, "\n", "<BR>")
+		var/datum/browser/popup = new(usr, "[name]", "[name]", 500, 300, src)
+		popup.set_content(examine_text)
+		popup.open()
 		onclose(usr, "[name]")
 	if(href_list["flavor_change"])
 		update_flavor_text()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -530,7 +530,6 @@
 		var/datum/browser/popup = new(usr, "[name]", "[name]", 500, 300, src)
 		popup.set_content(examine_text)
 		popup.open()
-		onclose(usr, "[name]")
 	if(href_list["flavor_change"])
 		update_flavor_text()
 	return ..()

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -409,3 +409,14 @@ div.notice
 .underline {
 	text-decoration: underline;
 }
+
+.spoiler{
+	background-color: gray;
+	color: transparent;
+	user-select: none;
+}
+
+.spoiler:hover{
+	background-color: inherit;
+	color: inherit;
+}

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -280,3 +280,14 @@ body.dark {
 .linkelem:hover {
 	text-decoration: underline;
 }
+
+.spoiler{
+	background-color: gray;
+	color: transparent;
+	user-select: none;
+}
+
+.spoiler:hover{
+	background-color: inherit;
+	color: inherit;
+}

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -283,7 +283,19 @@ function draw_examine() {
 	var div_content = document.createElement("div");
 	for (var i = 0; i < examine.length; i++) {
 		var parameter = document.createElement('p');
-		parameter.innerHTML = examine[i];
+		var textList = examine[i].split("||");
+		if(textList.length > 1) {
+			for(var j = 0; j < textList.length; j++) {
+				var spoilerText = document.createElement('span');
+				if(j % 2) {
+					spoilerText.className = "spoiler";
+				}
+				spoilerText.innerHTML = textList[j];
+				parameter.appendChild(spoilerText);
+			}
+		} else {
+			parameter.innerHTML = examine[i];
+		}
 		div_content.appendChild(parameter);
 	}
 	var images = div_content.querySelectorAll("img");
@@ -1051,8 +1063,8 @@ Byond.subscribeTo('add_admin_tabs', function (ht) {
 	addPermanentTab("Tickets");
 });
 
-Byond.subscribeTo('update_examine', function (S) {
-	examine = S;
+Byond.subscribeTo('update_examine', function (payload) {
+	examine = payload.EX;
 	if (examine.length > 0 && !verb_tabs.includes("Examine")) {
 		verb_tabs.push("Examine");
 		addPermanentTab("Examine")
@@ -1060,7 +1072,9 @@ Byond.subscribeTo('update_examine', function (S) {
 	if (current_tab == "Examine") {
 		draw_examine();
 	}
-	//tab_change("Examine"); //This is handled by DM code and a pref setting already
+	if(payload.UPD) {
+		tab_change("Examine");
+	}
 })
 
 Byond.subscribeTo('update_sdql2', function (S) {

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -180,5 +180,8 @@ BIG IMG.icon 			{width: 32px; height: 32px;}
 
 .pnarrate				{color: #009AB2;}
 
+.spoiler				{background-color: gray;color: transparent;user-select: none;}
+
+.spoiler:hover			{background-color: inherit;color: inherit;}
 
 </style>"}

--- a/maps/~map_system/_map_selection.dm
+++ b/maps/~map_system/_map_selection.dm
@@ -6,11 +6,11 @@
 /*********************/
 
 //#define USE_MAP_TETHER
-//#define USE_MAP_STELLARDELIGHT
+#define USE_MAP_STELLARDELIGHT
 //#define USE_MAP_GROUNDBASE
 
 // Debug
-#define USE_MAP_MINITEST
+//#define USE_MAP_MINITEST
 
 /*********************/
 /* End Map Selection */

--- a/maps/~map_system/_map_selection.dm
+++ b/maps/~map_system/_map_selection.dm
@@ -6,11 +6,11 @@
 /*********************/
 
 //#define USE_MAP_TETHER
-#define USE_MAP_STELLARDELIGHT
+//#define USE_MAP_STELLARDELIGHT
 //#define USE_MAP_GROUNDBASE
 
 // Debug
-//#define USE_MAP_MINITEST
+#define USE_MAP_MINITEST
 
 /*********************/
 /* End Map Selection */

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1427,7 +1427,22 @@ $border-width-px: $border-width * 1px;
   line-height: 0.3;
 }
 
+.psionic {
+  color: hsl(300, 50%, 40%);
+}
+
 .wingdings {
-  color: #0077ff;
+  color: hsl(212, 100%, 50%);
   font-family: Wingdings, Webdings;
+}
+
+.spoiler {
+  background-color: hsl(0, 0%, 50%);
+  color: transparent;
+  user-select: none;
+}
+
+.spoiler:hover {
+  background-color: inherit;
+  color: inherit;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1455,10 +1455,21 @@ $border-width-px: $border-width * 1px;
 }
 
 .psionic {
-  color: #993399;
+  color: hsl(300, 50%, 40%);
 }
 
 .wingdings {
-  color: #0077ff;
+  color: hsl(212, 100%, 50%);
   font-family: Wingdings, Webdings;
+}
+
+.spoiler {
+  background-color: hsl(0, 0%, 50%);
+  color: transparent;
+  user-select: none;
+}
+
+.spoiler:hover {
+  background-color: inherit;
+  color: inherit;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-vchatdark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-vchatdark.scss
@@ -1429,10 +1429,21 @@ $border-width-px: $border-width * 1px;
 }
 
 .psionic {
-  color: #993399;
+  color: hsl(300, 50%, 40%);
 }
 
 .wingdings {
-  color: #0077ff;
+  color: hsl(212, 100%, 50%);
   font-family: Wingdings, Webdings;
+}
+
+.spoiler {
+  background-color: hsl(0, 0%, 50%);
+  color: transparent;
+  user-select: none;
+}
+
+.spoiler:hover {
+  background-color: inherit;
+  color: inherit;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-vchatlight.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-vchatlight.scss
@@ -1453,10 +1453,21 @@ $border-width-px: $border-width * 1px;
 }
 
 .psionic {
-  color: #993399;
+  color: hsl(300, 50%, 40%);
 }
 
 .wingdings {
-  color: #0077ff;
+  color: hsl(212, 100%, 50%);
   font-family: Wingdings, Webdings;
+}
+
+.spoiler {
+  background-color: hsl(0, 0%, 50%);
+  color: transparent;
+  user-select: none;
+}
+
+.spoiler:hover {
+  background-color: inherit;
+  color: inherit;
 }


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
add: text surrounded by || text || will now be spoilered in the statpanel
fix: examine will be auto focussed again if the setting is enabled
/:cl:
