### PR TITLE
you can grippy the floor tiles now as borg

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -253,11 +253,12 @@
 
 /obj/item/gripper/no_use/loader //This is used to disallow building with metal.
 	name = "sheet loader"
-	desc = "A specialized loading device, designed to pick up and insert sheets of materials inside machines."
+	desc = "A specialized loading device, designed to pick up and insert sheets of materials inside machines. Also can pick up floor tiles."
 	icon_state = "gripper-sheet"
 
 	can_hold = list(
-		/obj/item/stack/material
+		/obj/item/stack/material,
+		/obj/item/stack/tile
 		)
 
 /obj/item/gripper/attack_self(mob/user as mob)


### PR DESCRIPTION

## About The Pull Request

I had this cool idea for a like, storage box of tiles that you could kinda just slurp up and store so you could redistribute them later. But then I realized that was more complex than I wanted to spend time on and all borgs needed was literally any method of interacting with stacks of floor tiles beyond visual contempt. so this is that.
## Changelog
:cl:
qol: added the ability to pick up floor tiles to the sheet loader gripper that borgs have

/:cl:
