### PR TITLE
Return current scale when selecting scale

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -92,7 +92,7 @@
 
 /datum/category_item/player_setup_item/vore/size/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["size_multiplier"])
-		var/new_size = tgui_input_number(user, "Choose your character's size, ranging from 25% to 200%", "Set Size", null, 200, 25)
+		var/new_size = tgui_input_number(user, "Choose your character's size, ranging from 25% to 200%", "Set Size", pref.size_multiplier*100, 200, 25)
 		if (!ISINRANGE(new_size,25,200))
 			pref.size_multiplier = 1
 			to_chat(user, span_notice("Invalid size."))


### PR DESCRIPTION
## About The Pull Request

Makes it so that the Scale prompt in Character Setup autofills with your character's current scale instead of always defaulting to the minimum possible value.

## Changelog

:cl:
qol: changing your scale under the VORE tab will autofill your *current* scale instead of defaulting to the minimum of 25
/:cl: