### PR TITLE
Trait Adjustments

### DIFF
--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -237,7 +237,7 @@
 
 // Injectors for all original genes and some new ones
 /obj/item/dnainjector/set_trait/anxiety	// stutter
-	trait_path = /datum/trait/negative/disability_anxiety
+	trait_path = /datum/trait/neutral/disability_nervousness
 /obj/item/dnainjector/set_trait/anxiety/disable
 	disabling = TRUE
 
@@ -245,12 +245,12 @@
 	trait_path = /datum/trait/positive/superpower_noprints
 /obj/item/dnainjector/set_trait/noprints/disable
 	disabling = TRUE
-
+/* //VOREStation Note: tourettes Disabled on VS
 /obj/item/dnainjector/set_trait/tourettes // tour
 	trait_path = /datum/trait/negative/disability_tourettes
 /obj/item/dnainjector/set_trait/tourettes/disable
 	disabling = TRUE
-
+*/ //VOREStation Note: tourettes Disabled on VS
 /obj/item/dnainjector/set_trait/cough // cough
 	trait_path = /datum/trait/negative/disability_cough
 /obj/item/dnainjector/set_trait/cough/disable
@@ -290,12 +290,12 @@
 	trait_path = /datum/trait/neutral/coldadapt
 /obj/item/dnainjector/set_trait/coldadapt/disable
 	disabling = TRUE
-
+/* //VOREStation Note: Disabled on VS
 /obj/item/dnainjector/set_trait/xray // xraymut
 	trait_path = /datum/trait/positive/superpower_xray
 /obj/item/dnainjector/set_trait/xray/disable
 	disabling = TRUE
-
+*/ //VOREStation Note: Disabled on VS
 /obj/item/dnainjector/set_trait/deaf // deafmut
 	trait_path = /datum/trait/negative/disability_deaf
 /obj/item/dnainjector/set_trait/deaf/disable

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -245,12 +245,12 @@
 	trait_path = /datum/trait/positive/superpower_noprints
 /obj/item/dnainjector/set_trait/noprints/disable
 	disabling = TRUE
-/* //VOREStation Note: tourettes Disabled on VS
+/* //VOREStation Note: TRAITGENETICS - tourettes Disabled on VS
 /obj/item/dnainjector/set_trait/tourettes // tour
 	trait_path = /datum/trait/negative/disability_tourettes
 /obj/item/dnainjector/set_trait/tourettes/disable
 	disabling = TRUE
-*/ //VOREStation Note: tourettes Disabled on VS
+*/ //VOREStation Note: TRAITGENETICS - tourettes Disabled on VS
 /obj/item/dnainjector/set_trait/cough // cough
 	trait_path = /datum/trait/negative/disability_cough
 /obj/item/dnainjector/set_trait/cough/disable
@@ -290,12 +290,12 @@
 	trait_path = /datum/trait/neutral/coldadapt
 /obj/item/dnainjector/set_trait/coldadapt/disable
 	disabling = TRUE
-/* //VOREStation Note: Disabled on VS
+/* //VOREStation Note: TRAITGENETICS - Disabled on VS
 /obj/item/dnainjector/set_trait/xray // xraymut
 	trait_path = /datum/trait/positive/superpower_xray
 /obj/item/dnainjector/set_trait/xray/disable
 	disabling = TRUE
-*/ //VOREStation Note: Disabled on VS
+*/ //VOREStation Note: TRAITGENETICS - Disabled on VS
 /obj/item/dnainjector/set_trait/deaf // deafmut
 	trait_path = /datum/trait/negative/disability_deaf
 /obj/item/dnainjector/set_trait/deaf/disable

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -381,7 +381,7 @@
 	var/mob/living/protie = src
 	if(temporary_form)
 		protie = temporary_form
-	//VoreStation Note: Catslug through Dullahan are commented out (Disabled) intentionally, as the ability to have mob icons as a protean is unwanted as of 19-3-2025. Nonetheless, the sprites have been tested and are completely functional at the current moment. If desired to re-enable downstream or at a later time, simply remove the comment tags starting at catslug and ending at Dullahan. These should honestly be split into two lists ('basic_forms' and 'advanced_forms') with a proper toggle instead of commenting it out, but that's for a later date.  
+	//VOREStation Note: Catslug through Dullahan are commented out (Disabled) intentionally, as the ability to have mob icons as a protean is unwanted as of 19-3-2025. Nonetheless, the sprites have been tested and are completely functional at the current moment. If desired to re-enable downstream or at a later time, simply remove the comment tags starting at catslug and ending at Dullahan. These should honestly be split into two lists ('basic_forms' and 'advanced_forms') with a proper toggle instead of commenting it out, but that's for a later date.
 	var/list/icon_choices = list(
 			"Primary" = image(icon = 'icons/mob/species/protean/protean.dmi', icon_state = "primary"),
 			"Highlight" = image(icon = 'icons/mob/species/protean/protean.dmi', icon_state = "highlight"),

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
@@ -59,8 +59,8 @@
 	cost = -2
 	custom_only = FALSE
 
-	is_genetrait = FALSE 	//VOREStation Note: Disabled on VS
-	hidden = TRUE			//VOREStation Note: Disabled on VS
+	is_genetrait = FALSE 	//VOREStation Note: TRAITGENETICS - Disabled on VS
+	hidden = TRUE			//VOREStation Note: TRAITGENETICS - Disabled on VS
 
 	disability=TOURETTES
 	activation_message="You twitch."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
@@ -59,25 +59,12 @@
 	cost = -2
 	custom_only = FALSE
 
-	is_genetrait = TRUE
-	hidden = FALSE
+	is_genetrait = FALSE 	//VOREStation Note: Disabled on VS
+	hidden = TRUE			//VOREStation Note: Disabled on VS
 
 	disability=TOURETTES
 	activation_message="You twitch."
 	primitive_expression_messages=list("twitches and chitters.")
-
-/datum/trait/negative/disability_anxiety
-	name = "Anxiety Disorder"
-	desc = "You have extreme anxiety, often stuttering words."
-	cost = -1
-	custom_only = FALSE
-
-	is_genetrait = TRUE
-	hidden = FALSE
-
-	disability=NERVOUS
-	activation_message="You feel nervous."
-	primitive_expression_messages=list("anxiously chitters.")
 
 /* Replaced by /datum/trait/negative/blindness
 /datum/trait/negative/disability_blind
@@ -175,8 +162,8 @@
 	cost = -4
 	custom_only = FALSE
 
-	is_genetrait = TRUE
-	hidden = FALSE
+	is_genetrait = FALSE	//VOREStation Note: Disabled on VS
+	hidden = TRUE			//VOREStation Note: Disabled on VS
 
 	disability=DETERIORATE
 	activation_message="You feel sore..."
@@ -194,19 +181,6 @@
 	disability=GIBBING
 	activation_message="You feel bloated..."
 	primitive_expression_messages=list("shudders.","gasps.","chokes.")
-
-/datum/trait/negative/disability_censored
-	name = "Censored"
-	desc = "You are unable to speak profanity. To an excessive degree..."
-	cost = -1
-	custom_only = FALSE
-
-	is_genetrait = TRUE
-	hidden = FALSE
-
-	disability=CENSORED
-	activation_message="You feel less rude..."
-	primitive_expression_messages=list("BEEPS!")
 
 /datum/trait/negative/disability_damagedspine
 	name = "Lumbar Impairment"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_genes.dm
@@ -162,8 +162,8 @@
 	cost = -4
 	custom_only = FALSE
 
-	is_genetrait = FALSE	//VOREStation Note: Disabled on VS
-	hidden = TRUE			//VOREStation Note: Disabled on VS
+	is_genetrait = FALSE	//VOREStation Note: TRAITGENETICS - Disabled on VS
+	hidden = TRUE			//VOREStation Note: TRAITGENETICS - Disabled on VS
 
 	disability=DETERIORATE
 	activation_message="You feel sore..."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
@@ -4,7 +4,7 @@
 /datum/trait/neutral/disability_censored
 	name = "Censored"
 	desc = "You are unable to speak profanity. To an excessive degree..."
-	cost = 0 //Originally was -1
+	cost = 0 // TRAITGENETICS - Originally was -1
 	custom_only = FALSE
 
 	is_genetrait = TRUE
@@ -17,7 +17,7 @@
 /datum/trait/neutral/disability_nervousness
 	name = "Nervousness"
 	desc = "You are generally nervous natured, often stuttering words."
-	cost = 0 //Originally was -1
+	cost = 0 // TRAITGENETICS - Originally was -1
 	custom_only = FALSE
 
 	is_genetrait = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
@@ -1,0 +1,28 @@
+//VOREStation Note: Originally, these were in negative_genes.dm
+//However, given their more RP centric nature, they have been moved to neutral_traits.
+//If desire is wanted to move them back to negative traits, change the 'neutral' to 'negative'
+/datum/trait/neutral/disability_censored
+	name = "Censored"
+	desc = "You are unable to speak profanity. To an excessive degree..."
+	cost = 0 //Originally was -1
+	custom_only = FALSE
+
+	is_genetrait = TRUE
+	hidden = FALSE
+
+	disability=CENSORED
+	activation_message="You feel less rude..."
+	primitive_expression_messages=list("BEEPS!")
+
+/datum/trait/neutral/disability_nervousness
+	name = "Nervousness"
+	desc = "You are generally nervous natured, often stuttering words."
+	cost = 0 //Originally was -1
+	custom_only = FALSE
+
+	is_genetrait = TRUE
+	hidden = FALSE
+
+	disability=NERVOUS
+	activation_message="You feel nervous."
+	primitive_expression_messages=list("nervously chitters.")

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_genes.dm
@@ -1,4 +1,4 @@
-//VOREStation Note: Originally, these were in negative_genes.dm
+//VOREStation Note: TRAITGENETICS - Originally, these were in negative_genes.dm
 //However, given their more RP centric nature, they have been moved to neutral_traits.
 //If desire is wanted to move them back to negative traits, change the 'neutral' to 'negative'
 /datum/trait/neutral/disability_censored

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_genes.dm
@@ -106,7 +106,7 @@
 	cost = 5
 	custom_only = FALSE
 
-	is_genetrait = FALSE //VOREStation Note: Disabled on VS
+	is_genetrait = FALSE //VOREStation Note: TRAITGENETICS - Disabled on VS
 	activity_bounds = DNA_HARDER_BOUNDS
 	hidden = TRUE // Cannot start with superpowers
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_genes.dm
@@ -106,7 +106,7 @@
 	cost = 5
 	custom_only = FALSE
 
-	is_genetrait = TRUE
+	is_genetrait = FALSE //VOREStation Note: Disabled on VS
 	activity_bounds = DNA_HARDER_BOUNDS
 	hidden = TRUE // Cannot start with superpowers
 

--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -213,9 +213,8 @@
 
 /obj/item/organ/internal/brain/cephalon/Initialize(mapload)
 	. = ..()
-	spawn(30 SECONDS)	// FBP Dionaea need some way to be disassembled through surgery, if absolutely necessary.
-		if(!owner.isSynthetic())
-			vital = FALSE
+	if(!owner.isSynthetic())
+		vital = FALSE
 
 /obj/item/organ/internal/brain/cephalon/robotize()
 	return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3188,6 +3188,7 @@
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\negative.dm"
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\negative_genes.dm"
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\neutral.dm"
+#include "code\modules\mob\living\carbon\human\species\station\traits_vr\neutral_genes.dm"
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\positive.dm"
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\positive_genes.dm"
 #include "code\modules\mob\living\carbon\human\species\station\traits_vr\trait.dm"


### PR DESCRIPTION
## About The Pull Request
Staff discussion was had about the various traits and adjustments were made to them.
> [!NOTE]
> For downstreams that want to re-enable or adjust any of the changes made below:
> Search for ' TRAITGENETICS -' and it'll show all the changes that were made. From there, you can simply swap FALSE -> TRUE or TRUE -> FALSE / Remove the comment indicators to re-enable them.

- Disables tourettes
- Disables Rotting Genetics
- Disables xray
- Swaps Anxiety Disorder name to Nervousness
- Censored moved to Neutral (RP trait)
- Nervousness moved to Neutral (RP trait)
## Changelog
:cl: Vorestation Staff Consensus (VORESTATION ONLY)
del: Tourettes disabled
del: Rotting Genetics Disabled
del: Xray disabled
spellcheck: Anxiety Disorder name changed to Nervousness
balance: Censored move to Neutral (RP trait)
balance: Nervousness moved to Neutral (RP Trait)
fix: FBP dionas will no longer explode
/:cl:
