### PR TITLE
Makes teshari radsuits give tesh normal slowdown

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -109,6 +109,7 @@
 	icon_override = 'icons/inventory/suit/mob_teshari.dmi'
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)
+	slowdown = 0.5
 
 /obj/item/clothing/head/radiation/teshari
 	name = "Small radiation hood"


### PR DESCRIPTION

## About The Pull Request
Instead of doubled.
Tesh naturally have doubled slowdown, so this makes the small rad suit have a reason to exist.
## Changelog
:cl:
qol: Teshari no longer have double slowdown from radsuits
/:cl:
