### PR TITLE
Various Fixes For Heavy Cables

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -700,7 +700,11 @@ var/list/possible_cable_coil_colours = list(
 	if(!istype(F))
 		return
 
-	var/obj/structure/cable/C = new(F)
+	var/obj/structure/cable/C
+	if(istype(src,/obj/item/stack/cable_coil/heavyduty)) // this is the only cable that does this, not worth an override
+		C = new /obj/structure/cable/heavyduty(F)
+	else
+		C = new /obj/structure/cable(F)
 	C.cableColor(color)
 	C.d1 = d1
 	C.d2 = d2

--- a/code/modules/power/cable_heavyduty.dm
+++ b/code/modules/power/cable_heavyduty.dm
@@ -19,7 +19,7 @@
 		return
 
 	if(W.has_tool_quality(TOOL_WIRECUTTER))
-		to_chat(user, span_blue("These cables are too tough to be cut with those [W.name]."))
+		to_chat(user, span_notice("These cables are too tough to be cut with those [W.name]."))
 		return
 	else if(W.has_tool_quality(TOOL_WELDER))
 		if(!allow_cutting)
@@ -28,7 +28,7 @@
 
 		var/obj/item/weldingtool/WT = W.get_welder()
 		if(!WT.remove_fuel(2, user)) // Takes lots of fuel and time...
-			to_chat(user, infoplain("The welding tool must be on to complete this task."))
+			to_chat(user, span_infoplain("The welding tool must be on to complete this task."))
 			return
 
 		playsound(src, WT.usesound, 50, 1)
@@ -47,14 +47,14 @@
 			qdel(src)
 		return
 	else if(istype(W, /obj/item/stack/cable_coil) && !istype(W, /obj/item/stack/cable_coil/heavyduty))
-		to_chat(user, span_blue("You will need heavier cables to connect to these."))
+		to_chat(user, span_notice("You will need heavier cables to connect to these."))
 		return
 	else
 		..()
 
 /obj/item/stack/cable_coil/heavyduty/turf_place(turf/simulated/F, mob/user)
 	if(istype(F, /turf/simulated/open))
-		to_chat(user, infoplain("\The [src] isn't flexible enough to do this!"))
+		to_chat(user, span_infoplain("\The [src] isn't flexible enough to do this!"))
 		return
 	. = ..()
 

--- a/code/modules/power/cable_heavyduty.dm
+++ b/code/modules/power/cable_heavyduty.dm
@@ -10,6 +10,7 @@
 	plane = PLATING_PLANE
 	layer = PIPES_LAYER - 0.05 //Just below pipes
 	color = null
+	var/static/allow_cutting = TRUE // Allows heavy cables to be cut by welder, up to server preference or admin vv during round. Changing it on one changes them all!
 
 /obj/structure/cable/heavyduty/attackby(obj/item/W, mob/user)
 
@@ -20,11 +21,42 @@
 	if(W.has_tool_quality(TOOL_WIRECUTTER))
 		to_chat(user, span_blue("These cables are too tough to be cut with those [W.name]."))
 		return
-	else if(istype(W, /obj/item/stack/cable_coil))
+	else if(W.has_tool_quality(TOOL_WELDER))
+		if(!allow_cutting)
+			to_chat(user, span_warning("Something in these cables make them too strong to cut!"))
+			return
+
+		var/obj/item/weldingtool/WT = W.get_welder()
+		if(!WT.remove_fuel(2, user)) // Takes lots of fuel and time...
+			to_chat(user, "The welding tool must be on to complete this task.")
+			return
+
+		playsound(src, WT.usesound, 50, 1)
+		if(do_after(user, 250 * WT.toolspeed)) // Meant to be an obnoxiously long time due to these being intended as "mapper placed indestructable cables". However explosions can already break them if they turf change.
+			var/obj/item/stack/cable_coil/heavyduty/CC
+			if(src.d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
+				CC = new/obj/item/stack/cable_coil/heavyduty(T, 2, color)
+			else
+				CC = new/obj/item/stack/cable_coil/heavyduty(T, 1, color)
+
+			src.add_fingerprint(user)
+			src.transfer_fingerprints_to(CC)
+			for(var/mob/O in viewers(src, null))
+				O.show_message(span_warning("[user] cuts the cable."), 1)
+
+			qdel(src)
+		return
+	else if(istype(W, /obj/item/stack/cable_coil) && !istype(W, /obj/item/stack/cable_coil/heavyduty))
 		to_chat(user, span_blue("You will need heavier cables to connect to these."))
 		return
 	else
 		..()
+
+/obj/item/stack/cable_coil/heavyduty/turf_place(turf/simulated/F, mob/user)
+	if(istype(F, /turf/simulated/open))
+		to_chat(user, "\The [src] isn't flexible enough to do this!")
+		return
+	. = ..()
 
 /obj/structure/cable/heavyduty/cableColor(var/colorC)
 	return

--- a/code/modules/power/cable_heavyduty.dm
+++ b/code/modules/power/cable_heavyduty.dm
@@ -28,7 +28,7 @@
 
 		var/obj/item/weldingtool/WT = W.get_welder()
 		if(!WT.remove_fuel(2, user)) // Takes lots of fuel and time...
-			to_chat(user, "The welding tool must be on to complete this task.")
+			to_chat(user, infoplain("The welding tool must be on to complete this task."))
 			return
 
 		playsound(src, WT.usesound, 50, 1)
@@ -54,7 +54,7 @@
 
 /obj/item/stack/cable_coil/heavyduty/turf_place(turf/simulated/F, mob/user)
 	if(istype(F, /turf/simulated/open))
-		to_chat(user, "\The [src] isn't flexible enough to do this!")
+		to_chat(user, infoplain("\The [src] isn't flexible enough to do this!"))
 		return
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Heavy cable bundles have been broken for a while due to being an admin spawn item. They do not place heavy cable, and heavy cables also have no method to be destroyed by tools. However I recently discovered a very easy method to get them without admin spawn, simply destroying their current turf will break and spawn their coils. Because of this I have uported the cable changes I did on outpost, but made them intentionally more annoying to cut. Increasing fuel and time to do so.

![cablecut](https://github.com/user-attachments/assets/df190544-1263-415e-9eba-82ef6aa195e1)


## Changelog
Makes heavy cable rolls actually lay heavy cables
Makes heavy cables cut-able with welder, but takes a long time and a bit of fuel.
Prevents an illegal Zlevel transfer using heavy cables (they have no icons for it)
Added a static var to enable or disable the ability to cut cables with the welder, incase servers want to disable this function, but still want the rest of the fixes.

:cl:
code: fixed various issues related to placing and cutting heavy cables
code: added option in code to allow players to cut heavy cables with a welder
/:cl: