### PR TITLE
Fixed sizechange nifsoft wear and cost

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -122,8 +122,8 @@
 	name = "Mass Alteration"
 	desc = "A system that allows one to change their size, through drastic mass rearrangement. Causes significant wear when installed."
 	list_pos = NIF_SIZECHANGE
-	cost = 375
-	wear = 6
+	cost = 300
+	wear = 1
 
 /datum/nifsoft/sizechange/activate()
 	if((. = ..()))


### PR DESCRIPTION

## About The Pull Request

With modern design philosophies and ease of access to resizing, this is just a nice ribbon for another way to access it for people who like it. And it should be less taxing for them to enjoy. All it does is make the Mass Alteration nifsoft no longer very hungry on condition usage, in line with our peers. And lowers the cost slightly because, well. 300 is a nicer number and again, it's very easy to access ways to resize nowadays.

## Changelog
:cl:
balance: Adjusted cost and wear of Mass Alteration
/:cl: 
