### PR TITLE
makes contamination off by default

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -140,7 +140,7 @@
 	var/tmp/digested_prey_count = 0				// Amount of prey that have been digested
 
 	var/item_digest_mode = IM_DIGEST_FOOD	// Current item-related mode from item_digest_modes
-	var/contaminates = TRUE					// Whether the belly will contaminate stuff
+	var/contaminates = FALSE					// Whether the belly will contaminate stuff
 	var/contamination_flavor = "Generic"	// Determines descriptions of contaminated items
 	var/contamination_color = "green"		// Color of contamination overlay
 


### PR DESCRIPTION

## About The Pull Request

This was changed back in #https://github.com/VOREStation/VOREStation/commit/fa7d2340e8e7c165dcb55f41590dc9b36a171fb4 but was accidentally reverted recently. Change was made back then due to it being a common player complaint iirc. Stuff like making a quick arms belly and accidentally contaminating everything. No idea if this is gonna change existing bellies but honestly I'd rather just fix mine manually than risk overwriting someone's intentional usage of the mechanic.

Note to downstreams: you can ignore this one as it is Vorestation specific. Or don't, I'm a bird, not a cop.
## Changelog
:cl:
config: contaminates set to FALSE to prevent new bellies from having contamination. Shouldn't affect existing bellies.
/:cl:
