### PR TITLE
Xenoarch adjustments yet again

### DIFF
--- a/code/modules/xenoarcheaology/effects/temperature.dm
+++ b/code/modules/xenoarcheaology/effects/temperature.dm
@@ -1,11 +1,11 @@
 /// Verified to work with the Artifact Harvester
-//inverse of /datum/artifact_effect/heat, the two effects split up for neatness' sake
 #define COLD 1
 #define HOT 2
 /datum/artifact_effect/temperature
 	name = "Atmospheric Temperature Change"
 	var/target_temp
 	var/temp_change = COLD
+	can_start_activated = FALSE
 
 	effect_color = "#b3f6ff"
 

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -343,7 +343,7 @@
 			possible_laser_paths += /obj/item/projectile/ion
 			possible_laser_paths += subtypesof(/obj/item/projectile/energy/floramut)
 			// THE BLACKLIST
-			possible_laser_paths -= list(/obj/item/projectile/beam/pulse, /obj/item/projectile/beam/pulse/heavy)
+			// possible_laser_paths -= list(/obj/item/projectile/beam/pulse, /obj/item/projectile/beam/pulse/heavy, /obj/item/projectile/beam/final_option) //These are very very rare...Disabling the blacklist for now because the chance of finding them is so low that it feels like a nice treat when you DO find them. If it ends up being problemmatic, just reenable this line.
 			var/new_laser = pick(possible_laser_paths)
 			new_gun.projectile_type = new_laser
 			new_item = new_gun


### PR DESCRIPTION

## About The Pull Request
Makes temp artifacts no longer randomly spawn active (prevent hellfire situations)
Disables the xenoarch laser blacklist for now...It's so rare that it doesn't feel like it's a massive problem. If it does prove to be an issue, reenable the line.
## Changelog
:cl: Diana
qol: Temperature artifacts can no longer randomly spawn active.
balance: Laser gun artifacts can spawn with pulse beams if you are lucky.
/:cl:
