### PR TITLE
protean bugfix

### DIFF
--- a/code/__defines/rust_g.dm
+++ b/code/__defines/rust_g.dm
@@ -200,7 +200,7 @@
 /// All icons have the same y coordinate, and their x coordinate is equal to `icon_width * position`.
 ///
 /// hash_icons is a boolean (0 or 1), and determines if the generator will spend time creating hashes for the output field dmi_hashes.
-/// These hashes can be heplful for 'smart' caching (see rustg_iconforge_cache_valid), but require extra computation.
+/// These hashes can be helpful for 'smart' caching (see rustg_iconforge_cache_valid), but require extra computation.
 ///
 /// Spritesheet will contain all sprites listed within "sprites".
 /// "sprites" format:

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -172,7 +172,7 @@
 	return S.get_icobase(H, get_deform)
 
 /datum/species/protean/get_valid_shapeshifter_forms(var/mob/living/carbon/human/H)
-	var/static/list/protean_shapeshifting_forms = GLOB.playable_species.Copy() - SPECIES_PROMETHEAN
+	var/list/protean_shapeshifting_forms = GLOB.playable_species.Copy() - SPECIES_PROMETHEAN //Removing the 'static' here fixes it returning an empty list. I do not know WHY that is the case, but it is for some reason. This needs to be investigated further, but this fixes the issue at the moment.
 	return protean_shapeshifting_forms
 
 /datum/species/protean/get_tail(var/mob/living/carbon/human/H)


### PR DESCRIPTION

## About The Pull Request
Makes proteans able to select their iconbase properly

There is something horribly, horribly wrong with the code here... Removing the /static/ fixed the issue, but...The static list shouldn't be returning empty.

Checked on 1651 and 1659 and it's broken on both, so this doesn't LOOK LIKE a byond issue? And if it is, it more than likely happened during the 515->516 swap.
## Changelog
:cl:
fix: Proteans can select icon base again
/:cl:
