### PR TITLE
adds a trait that lets you chase people down the halls at 2am 

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -115,6 +115,14 @@
 			. *= 0.5
 		. -= chem_effects[CE_SPEEDBOOST]	// give 'em a buff on top.
 
+	if(ishuman(src)) //r u human
+		var/mob/living/carbon/human/H = src //wowie you are, take this badge
+		if(species.unusual_running == 1) // do you have the trait
+			var/obj/item/I = H.get_active_hand() // checking their hand
+			var/obj/item/OH = H.get_inactive_hand() // and their other hand
+			if(!istype(I,/obj/item) && !istype(OH,/obj/item)) //better not have any items on you mfer
+				. += -0.5 // ok vibe check passed, take this small movement buff and leave
+
 	. = max(HUMAN_LOWEST_SLOWDOWN, . + CONFIG_GET(number/human_delay))	// Minimum return should be the same as force_max_speed
 	. += ..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -121,7 +121,7 @@
 			var/obj/item/I = H.get_active_hand() // checking their hand
 			var/obj/item/OH = H.get_inactive_hand() // and their other hand
 			if(!istype(I,/obj/item) && !istype(OH,/obj/item)) //better not have any items on you mfer
-				. += -0.5 // ok vibe check passed, take this small movement buff and leave
+				. -= 0.5 // ok vibe check passed, take this small movement buff and leave
 
 	. = max(HUMAN_LOWEST_SLOWDOWN, . + CONFIG_GET(number/human_delay))	// Minimum return should be the same as force_max_speed
 	. += ..()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -209,6 +209,7 @@
 	var/spawn_flags = 0										// Flags that specify who can spawn as this species
 
 	var/slowdown = 0										// Passive movement speed malus (or boost, if negative)
+	var/unusual_running = 0									// Trait var to change movement speed in human_movement.dm when nothing in hands
 	var/obj/effect/decal/cleanable/blood/tracks/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // What marks are left when walking
 	var/list/skin_overlays = list()
 	var/has_floating_eyes = 0								// Whether the eyes can be shown above other icons

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -15,6 +15,17 @@
 
 	activation_message="Your leg muscles pulsate."
 	primitive_expression_messages=list("dances around.")
+	excludes = list(/datum/trait/positive/unusual_running) // you best not be naruto running in this house
+
+/datum/trait/positive/unusual_running
+	name = "Unusual Gait"
+	desc = "Your method of running is unorthodox, you move faster when not holding things in your hands."
+	cost = 2
+	var_changes = list("unusual_running" = 1)
+
+	custom_only = FALSE //I think this is probably fine since it's half RP trait and half mechanical trait. also you can't have speed and use your hands so this is kinda niche outside of travel time reduction.
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_TESHARI, SPECIES_TAJARAN, SPECIES_DIONA, SPECIES_UNATHI, SPECIES_VASILISSAN, SPECIES_XENOCHIMERA) //i assume if a dev made your base slowdown different then you shouldn't have this.
+	excludes = list(/datum/trait/positive/speed_fast) // olympic sprinters don't naruto run
 
 /datum/trait/positive/hardy
 	name = "Hardy"


### PR DESCRIPTION
## About The Pull Request

**Unusual Gait** is a trait that modifies your movement delay by -0.5 (aka: one whole haste or taj base speed) so long as your hands are empty. Other slowdowns still apply so heavy items and armor will cut your speed but not deactivate the trait. Currently, it is not locked to custom species only because of two thinkies:
- I bothered to check who gets their slowdown changed at the species level. And if you do? no trait for you
- Movement as a balance concern is most key when it comes to combat/damage because of kiting strategies. However, it is pretty damn hard to fight with only your unarmed attacks and thus the majority of the mechanical advantage around this trait is removed simply by revoking hand privileges (then you spent 2 points for nothing). Theoretically you can get around this by using a hardsuit integrated weapon but those kinda suck if imma be honest. 

So it's an RP trait, that does mechanics. The initial vision was to allow people who play species that might have a faster "natural gait" that doesn't work well with holding things (ie, running on all fours) to get a lil speed boost when they aren't holding stuff. But if you want to roleplay this as your character naruto running around then by all means, go wild lol.

Also it's mutually exclusive with haste. I felt that was kind of an obvious thing to do, but it's worth mentioning.

https://github.com/user-attachments/assets/25c28188-27d4-4c4c-b7e6-6613434d0232

## Changelog
:cl:
add: Unusual gait positive trait for 2 points. This trait makes you move faster when your hands are empty.
/:cl:
