### PR TITLE
Multiple bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -361,6 +361,14 @@
 	var/lleill_energy = 200
 	var/lleill_energy_max = 200
 
+	var/bite_mod = 1 //NYI - Used Downstream
+	var/grab_resist_divisor_victims = 1 //NYI - Used Downstream
+	var/grab_resist_divisor_self = 1 //NYI - Used Downstream
+	var/grab_power_victims = 0 //NYI - Used Downstream
+	var/grab_power_self = 0 //NYI - Used Downstream
+	var/waking_speed = 1 //NYI - Used Downstream
+	var/lightweight_light = 0 //NYI - Used Downstream
+
 /datum/species/proc/update_attack_types()
 	unarmed_attacks = list()
 	for(var/u_type in unarmed_types)
@@ -576,8 +584,10 @@
 /datum/species/proc/handle_death(var/mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
 	return
 
-// Only used for alien plasma weeds atm, but could be used for Dionaea later.
-/datum/species/proc/handle_environment_special(var/mob/living/carbon/human/H)
+// Used for traits and species that have special environmental effects.
+/datum/species/handle_environment_special(var/mob/living/carbon/human/H)
+	for(var/datum/trait/env_trait in env_traits)
+		env_trait.handle_environment_special(H)
 	return
 
 // Used to update alien icons for aliens.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -585,7 +585,7 @@
 	return
 
 // Used for traits and species that have special environmental effects.
-/datum/species/handle_environment_special(var/mob/living/carbon/human/H)
+/datum/species/proc/handle_environment_special(var/mob/living/carbon/human/H)
 	for(var/datum/trait/env_trait in env_traits)
 		env_trait.handle_environment_special(H)
 	return

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -30,7 +30,7 @@
 
 
 	spawn_flags = SPECIES_CAN_JOIN
-	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
+	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 	has_organ = list(
 		O_HEART =		/obj/item/organ/internal/heart,

--- a/code/modules/xenoarcheaology/effects/electric_field.dm
+++ b/code/modules/xenoarcheaology/effects/electric_field.dm
@@ -39,10 +39,14 @@
 			var/mob/living/carbon/human/H = L
 			var/obj/item/organ/external/affected = H.get_organ(check_zone(BP_TORSO))
 			H.electrocute_act(rand(25, 40), holder, H.get_siemens_coefficient_organ(affected), affected)
-			lightning_strike(H.loc, TRUE)
+			var/turf/T = get_turf(H)
+			if(istype(T))
+				lightning_strike(T, TRUE)
 		else
 			L.electrocute_act(rand(25, 40), holder, 0.75, BP_TORSO)
-			lightning_strike(L.loc, TRUE)
+			var/turf/T = get_turf(L)
+			if(istype(T))
+				lightning_strike(T, TRUE)
 
 /datum/artifact_effect/electric_field/DoEffectAura()
 	var/atom/holder = get_master_holder()

--- a/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
+++ b/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
@@ -75,7 +75,9 @@
 		if(last_touched.loc)
 			conjure_animation(last_touched.loc)
 	visible_message(span_cult("\The [src] screeches as it's destroyed"))
-	lightning_strike(last_touched.loc, TRUE)
+	var/turf/T = get_turf(last_touched)
+	if(istype(T))
+		lightning_strike(T, TRUE)
 	playsound(src, 'sound/goonstation/spooky/creepyshriek.ogg', 100, 1, 75) //It plays VERY far.
 	last_touched = null //Get rid of the reference to our owner.
 	..()

--- a/code/modules/xenobio/items/extracts_vr.dm
+++ b/code/modules/xenobio/items/extracts_vr.dm
@@ -458,7 +458,9 @@
 	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 75, 1)
 	spawn(5 SECONDS)
 		if(holder && holder.my_atom)
-			lightning_strike(get_turf(holder.my_atom))
+			var/turf/T = get_turf(holder.my_atom)
+			if(istype(T))
+				lightning_strike(T)
 	..()
 
 


### PR DESCRIPTION
## About The Pull Request

Fixes traits that use environmental special to work properly.
Adds some vars that will eventually be implemented wholly so downstream file can be removed.

For downstream:
File to remove:
modular_chomp/code/modules/mob/living/carbon/human/species/species.dm

Fixes lightning strikes to not try to hit nullspace
Fixes it so humans don't lose their skin color
## Changelog
:cl: Diana
fix: Environmental traits now work properly
fix: Lightning strikes will no longer strike people in nullspace
fix: Humans now have their proper skin color selection back
/:cl:
