### PR TITLE
Changes how pronouns are selected on character setup

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -22,6 +22,20 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 
 #define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER,HERM) //VOREStaton Edit
 #define all_genders_text_list list("Male","Female","Plural","Neuter","Herm") //VOREStation Edit
+#define pronoun_set_to_genders list(\
+            "He/Him" = MALE,\
+            "She/Her" = FEMALE,\
+            "It/Its" = NEUTER,\
+            "They/Them" = PLURAL,\
+            "Shi/Hir" = HERM\
+            )
+#define genders_to_pronoun_set list(\
+            MALE = "He/Him",\
+            FEMALE = "She/Her",\
+            NEUTER = "It/Its",\
+            PLURAL = "They/Them",\
+            HERM = "Shi/Hir"\
+        )
 
 var/list/mannequins_
 

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -61,7 +61,7 @@
 	. += "(<a href='byond://?src=\ref[src];reset_nickname=1'>Clear</A>)"
 	. += "<br>"
 	. += span_bold("Biological Sex:") + " <a href='byond://?src=\ref[src];bio_gender=1'><b>[gender2text(pref.biological_gender)]</b></a><br>"
-	. += span_bold("Pronouns:") + " <a href='byond://?src=\ref[src];id_gender=1'><b>[gender2text(pref.identifying_gender)]</b></a><br>"
+	. += span_bold("Pronouns:") + " <a href='byond://?src=\ref[src];id_gender=1'><b>[genders_to_pronoun_set[pref.identifying_gender]]</b></a><br>"
 	. += span_bold("Age:") + " <a href='byond://?src=\ref[src];age=1'>[pref.read_preference(/datum/preference/numeric/human/age)]</a> <b>Birthday:</b> <a href='byond://?src=\ref[src];bday_month=1'>[pref.read_preference(/datum/preference/numeric/human/bday_month)]</a><b>/</b><a href='byond://?src=\ref[src];bday_day=1'>[pref.read_preference(/datum/preference/numeric/human/bday_day)]</a> - <b>Announce?:</b> <a href='byond://?src=\ref[src];bday_announce=1'>[pref.read_preference(/datum/preference/toggle/human/bday_announce) ? "Yes" : "No"]</a><br>"
 	. += span_bold("Spawn Point:") + " <a href='byond://?src=\ref[src];spawnpoint=1'>[pref.read_preference(/datum/preference/choiced/living/spawnpoint)]</a><br>"
 	if(CONFIG_GET(flag/allow_metadata))
@@ -112,9 +112,9 @@
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["id_gender"])
-		var/new_gender = tgui_input_list(user, "Choose your character's pronouns:", "Character Preference", all_genders_define_list, pref.identifying_gender)
+		var/new_gender = tgui_input_list(user, "Choose your character's pronouns:", "Character Preference", pronoun_set_to_genders, genders_to_pronoun_set[pref.identifying_gender])
 		if(new_gender && CanUseTopic(user))
-			pref.identifying_gender = new_gender
+			pref.identifying_gender = pronoun_set_to_genders[new_gender]
 		return TOPIC_REFRESH
 
 	else if(href_list["age"])


### PR DESCRIPTION

## About The Pull Request
Changes the Pronouns selector on the character setup to actual pronouns instead of cryptic names like "Neuter".
Currently only does so on the character setup area, stuff like the shapeshift menu hasn't been changed, may do later.
I want to thank Teletubby2 for doing 90% of the code.
Also if people could offer improvements/test for potential horrible stuff it would be appreciated, we did this at 11PM and neither of us was very fresh.
## Changelog
:cl:Tost
fix: You can now see what pronouns you are choosing for your character on setup.
/:cl:
