### PR TITLE
Update mob_vr.dm nutrition_messages

### DIFF
--- a/code/modules/vore/eating/mob_vr.dm
+++ b/code/modules/vore/eating/mob_vr.dm
@@ -30,17 +30,18 @@
 	var/allow_mimicry = TRUE 	// Allows mimicking their character
 	var/allow_mind_transfer = FALSE			//Allows ones mind to be taken over or swapped
 	var/nutrition_message_visible = TRUE
-	var/list/nutrition_messages = list(
-							"They are starving! You can hear their stomach snarling from across the room!",
-							"They are extremely hungry. A deep growl occasionally rumbles from their empty stomach.",
+	var/list/nutrition_messages = list( // Someday I would like for it to be possible to name the character or refer to specific pronouns... but that is out of scope for me. -Ace
+							"You can hear their empty stomach snarling from across the room. They must be starving!",
+							"You notice a faint growling occasionally rumble from their hungry gut.",
 							"",
-							"They have a stuffed belly, bloated fat and round from eating too much.",
-							"They have a rotund, thick gut. It bulges from their body obscenely, close to sagging under its own weight.",
-							"They are sporting a large, round, sagging stomach. It contains at least their body weight worth of glorping slush.",
-							"They are engorged with a huge stomach that sags and wobbles as they move. They must have consumed at least twice their body weight. It looks incredibly soft.",
-							"Their stomach is firmly packed with digesting slop. They must have eaten at least a few times worth their body weight! It looks hard for them to stand, and their gut jiggles when they move.",
-							"They are so absolutely stuffed that you aren't sure how it's possible for them to move. They can't seem to swell any bigger. The surface of their belly looks sorely strained!",
-							"They are utterly filled to the point where it's hard to even imagine them moving, much less comprehend it when they do. Their gut is swollen to monumental sizes and amount of food they consumed must be insane.")
+							"They seem quite content, if perhaps a little stuffed. Their stomach gurgles with a little more food than is necessary at the moment.",
+							"They look very satisfied, subconsciously licking their lips as their digestive system churns along an excessively rich meal.",
+							"Their face is pleasantly flushed, breathing a bit more heavily than usual as their belly works some mighty feast into soupy nutrients. There's enough sloshing around in there to leave them feeling bloated for hours.",
+							"Their face looks a little woozy while their breathing is somewhat panting. If you listen closely, you can hear a series of lurid wet blorps as their body works down what would have been enough calories to feed a small party.",
+							"Their expression looks dazed and maybe a little uncomfortable while their breathing consists of deep, long, queasy-sounding gasps. If you pay attention, you can make out the constant gushing from their insides as digestion struggles to cope with a whole buffet worth of mush.",
+							"Their expression looks downright hedonistic while their breathing is slow and lethargic. You can plainly hear a series of thick, lurid glorps as their gut strains to process nearly its limit worth of densely packed chyme.",
+							"Their drooling expression looks pale and clammy, their breathing is weak and heaving, and you vividly overhear the emulsion of calorie-dense foodstuff working slowly through their guts with awful, bubbling GROANS... Maybe they don't consciously realize it, but they are definitely at their limit. Eating more won't make a difference at this point; their body couldn't soak up any more nutrients even if they want it to."
+							)
 	var/weight_message_visible = TRUE
 	var/list/weight_messages = list(
 							"They are terribly lithe and frail!",


### PR DESCRIPTION
## About The Pull Request

This is something I have wanted to do for _years._

Ever since Aronai and Leshana added the persistent weight gain mechanic, these ancient pre-Polaris and pre-Baystation descriptions have been made hugely obsolete. They also massively pre-date the addition of actual visible bellies.

As a consequences, for the last 6 years, these descriptions have felt horribly out of place.

This is an attempt to rewrite them not to describe how big a person's belly is, but instead to only describe just how stuffed and glorpy that tummy is, big or small. The goal is to create something that serves as a good baseline for the average character. I tried to keep it vague enough to work with most typical digestive organs a player might have in their body. I can't account for edge cases like slime people or whatever, but this isn't _for_ them. They can write their own or blank it out. I can't cover every scenario, but I can cover most of them better than the old text.

My goal was to write lines on a scale of 1 to 10 between "absolutely starving" and "**_so fucking engorged with calories that your body literally can't take any more and you're just wasting food at this point because your body can't even absorb all of it_**."

For reference, you have to be at nearly a whopping 6,000 nutrition to hit that last level. This is usually only accomplished by digesting multiple players in a shift.


I strongly suggest you come back and re-adjust these descriptions based on actual player behavior and play testing against normal food intake for reference. This is supposed to serve as a new baseline. It's already better than the old one, but I somewhat struggled making it vague but appropriate.

Anyone who uses the old texts on their character should be unchanged.

## Changelog
:cl: Ace
qol: New default nutrition examine texts.
/:cl:
