### PR TITLE
Default Save Organs/Markings to No

### DIFF
--- a/code/__defines/persistence.dm
+++ b/code/__defines/persistence.dm
@@ -4,4 +4,4 @@
 #define PERSIST_MARKINGS	0x08	// Persist markings
 #define PERSIST_SIZE		0x10	// Persist size
 #define PERSIST_COUNT		5		// Number of valid bits in this bitflag.  Keep this updated!
-#define PERSIST_DEFAULT		PERSIST_SPAWN|PERSIST_ORGANS|PERSIST_MARKINGS|PERSIST_SIZE // Default setting for new folks
+#define PERSIST_DEFAULT		PERSIST_SPAWN|PERSIST_SIZE // Default setting for new folks


### PR DESCRIPTION

## About The Pull Request

Changed the default setting for Save Organs and Save Markings to No in character setup, which seem to cause more problems for people than people who use them intentionally. This won't change any existing character's settings.

For clarity for those unsure, these are the settings that decide that when you leave the round, whether changes to your organs or markings persist into future rounds. This is can be cool from a story perspective, but on a server like this the majority of people tend to want more control over their own characters and having settings change like this unexpectedly (sometimes due to bugs) is a pain.

## Changelog
:cl:
qol: Changed the default setting for Save Organs and Save Markings to No in character setup
/:cl:
