### PR TITLE
Makes bodyscanners show missing internal organs

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -184,6 +184,14 @@
 		update_icon() //VOREStation Edit - Health display for consoles with light and such.
 		var/mob/living/carbon/human/H = occupant
 		occupantData["name"] = H.name
+		occupantData["species"] = H.species.name
+		if(H.custom_species)
+			if( H.species.name == SPECIES_CUSTOM )
+				// Fully custom species
+				occupantData["species"] = "[H.custom_species]"
+			else
+				// Using another species as base, doctors should know this to avoid some meds
+				occupantData["species"] = "[H.custom_species] \[Similar biology to [H.species.name]\]"
 		occupantData["stat"] = H.stat
 		occupantData["health"] = H.health
 		occupantData["maxHealth"] = H.getMaxHealth()
@@ -304,7 +312,7 @@
 		occupantData["extOrgan"] = extOrganData
 
 		var/intOrganData[0]
-		for(var/organ_tag in H.species.has_organ) //Check to see if we are missing any vital organs
+		for(var/organ_tag in H.species.has_organ) //Check to see if we are missing any organs
 			var/organData[0]
 			var/obj/item/organ/O = H.species.has_organ[organ_tag]
 			var/name = initial(O.name)
@@ -383,6 +391,17 @@
 
 	dat = span_blue(span_bold("Occupant Statistics:")) + "<br>" //Blah obvious
 	if(istype(occupant)) //is there REALLY someone in there?
+		if(ishuman(occupant))
+			var/mob/living/carbon/human/H = occupant
+			var/speciestext = H.species.name
+			if(H.custom_species)
+				if(H.species.name == SPECIES_CUSTOM )
+					// Fully custom species
+					speciestext = "[H.custom_species]"
+					dat += span_blue("Sapient Species: [speciestext]") + "<BR>"
+				else
+					speciestext = "[H.custom_species] \[Similar biology to [H.species.name]\]"
+					dat += span_blue("Sapient Species: [speciestext]") + "<BR>"
 		var/t1
 		switch(occupant.stat) // obvious, see what their status is
 			if(0)
@@ -554,6 +573,16 @@
 			dat += "<tr>"
 			dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech][i_dead]</td><td></td>"
 			dat += "</tr>"
+		for(var/organ_tag in occupant.species.has_organ) //Check to see if we are missing any organs
+			var/organData[0]
+			var/obj/item/organ/O = occupant.species.has_organ[organ_tag]
+			var/name = initial(O.name)
+			organData["name"] = name
+			O = occupant.internal_organs_by_name[organ_tag]
+			if(!O) // Missing organ
+				dat += "<tr>"
+				dat += "<td>[name]</td><td>N/A</td><td>NA</td><td>MISSING</td><td></td>"
+				dat += "</tr>"
 		dat += "</table>"
 		if(occupant.sdisabilities & BLIND)
 			dat += span_red("Cataracts detected.") + "<BR>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -56,7 +56,7 @@
 			return
 		M.forceMove(src)
 		occupant = M
-		update_icon() //icon_state = "body_scanner_1" //VOREStation Edit - Health display for consoles with light and such.
+		update_icon()
 		playsound(src, 'sound/machines/medbayscanner1.ogg', 50) // Beepboop you're being scanned. <3
 		add_fingerprint(user)
 		qdel(G)
@@ -101,7 +101,7 @@
 
 	O.forceMove(src)
 	occupant = O
-	update_icon() //icon_state = "body_scanner_1" //VOREStation Edit - Health display for consoles with light and such.
+	update_icon()
 	playsound(src, 'sound/machines/medbayscanner1.ogg', 50) // Beepboop you're being scanned. <3
 	add_fingerprint(user)
 	SStgui.update_uis(src)
@@ -262,7 +262,6 @@
 			for(var/obj/thing in E.implants)
 				var/implantSubData[0]
 				var/obj/item/implant/I = thing
-			//VOREStation Block Edit Start
 				var/obj/item/nif/N = thing
 				if(istype(I))
 					implantSubData["name"] =  I.name
@@ -272,7 +271,6 @@
 					implantSubData["name"] =  N.name
 					implantSubData["known"] = istype(N) && N.known_implant
 					implantData.Add(list(implantSubData))
-			//VOREStation Block Edit End
 
 			organData["implants"] = implantData
 			organData["implants_len"] = implantData.len
@@ -306,6 +304,24 @@
 		occupantData["extOrgan"] = extOrganData
 
 		var/intOrganData[0]
+		for(var/organ_tag in H.species.has_organ) //Check to see if we are missing any vital organs
+			var/organData[0]
+			var/obj/item/organ/O = H.species.has_organ[organ_tag]
+			var/name = initial(O.name)
+			organData["name"] = name
+			O = H.internal_organs_by_name[organ_tag]
+			if(!O)
+				organData["desc"] = ""
+				organData["germ_level"] = 0
+				organData["damage"] = 0
+				organData["maxHealth"] = 0
+				organData["bruised"] = 0
+				organData["broken"] = 0
+				organData["robotic"] = 0
+				organData["dead"] = 0
+				organData["missing"] = TRUE
+				intOrganData.Add(list(organData))
+
 		for(var/obj/item/organ/I in H.internal_organs)
 			var/organData[0]
 			organData["name"] = I.name

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -319,14 +319,6 @@
 			organData["name"] = name
 			O = H.internal_organs_by_name[organ_tag]
 			if(!O)
-				organData["desc"] = ""
-				organData["germ_level"] = 0
-				organData["damage"] = 0
-				organData["maxHealth"] = 0
-				organData["bruised"] = 0
-				organData["broken"] = 0
-				organData["robotic"] = 0
-				organData["dead"] = 0
 				organData["missing"] = TRUE
 				intOrganData.Add(list(organData))
 

--- a/code/game/objects/items/weapons/storage/belt_vr.dm
+++ b/code/game/objects/items/weapons/storage/belt_vr.dm
@@ -118,7 +118,8 @@
 		/obj/item/storage/bag/sheetsnatcher,
 		/obj/item/melee,
 		/obj/item/kinetic_crusher,
-		/obj/item/mining_scanner
+		/obj/item/mining_scanner,
+		/obj/item/storage/bag/ore
 		)
 		//Pretty much, if it's in the mining vendor, they should be able to put it on the belt.
 

--- a/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOccupant.tsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOccupant.tsx
@@ -30,6 +30,7 @@ export const BodyScannerMainOccupant = (props: { occupant: occupant }) => {
     >
       <LabeledList>
         <LabeledList.Item label="Name">{occupant.name}</LabeledList.Item>
+        <LabeledList.Item label="Species">{occupant.species}</LabeledList.Item>
         <LabeledList.Item label="Health">
           <ProgressBar
             minValue={0}

--- a/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOrgansInternal.tsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOrgansInternal.tsx
@@ -33,19 +33,19 @@ export const BodyScannerMainOrgansInternal = (props: {
               {!o.missing && (
                 <ProgressBar
                   minValue={0}
-                  maxValue={o.maxHealth / 100}
-                  value={o.damage / 100}
+                  maxValue={o.maxHealth ? o.maxHealth / 100 : 0}
+                  value={o.damage ? o.damage / 100 : 0}
                   mt={i > 0 && '0.5rem'}
                   ranges={damageRange}
                 >
-                  {toFixed(o.damage)}
+                  {!!o.damage && toFixed(o.damage)}
                 </ProgressBar>
               )}
             </Table.Cell>
             <Table.Cell textAlign="right" width="33%">
               <Box color="average" inline>
                 {reduceOrganStatus([
-                  germStatus(o.germ_level),
+                  !!o.germ_level && germStatus(o.germ_level),
                   !!o.inflamed && 'Appendicitis detected.',
                 ])}
               </Box>

--- a/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOrgansInternal.tsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainOrgansInternal.tsx
@@ -30,15 +30,17 @@ export const BodyScannerMainOrgansInternal = (props: {
           <Table.Row key={i} style={{ textTransform: 'capitalize' }}>
             <Table.Cell width="33%">{o.name}</Table.Cell>
             <Table.Cell textAlign="center">
-              <ProgressBar
-                minValue={0}
-                maxValue={o.maxHealth / 100}
-                value={o.damage / 100}
-                mt={i > 0 && '0.5rem'}
-                ranges={damageRange}
-              >
-                {toFixed(o.damage)}
-              </ProgressBar>
+              {!o.missing && (
+                <ProgressBar
+                  minValue={0}
+                  maxValue={o.maxHealth / 100}
+                  value={o.damage / 100}
+                  mt={i > 0 && '0.5rem'}
+                  ranges={damageRange}
+                >
+                  {toFixed(o.damage)}
+                </ProgressBar>
+              )}
             </Table.Cell>
             <Table.Cell textAlign="right" width="33%">
               <Box color="average" inline>
@@ -52,6 +54,7 @@ export const BodyScannerMainOrgansInternal = (props: {
                   o.robotic === 1 && 'Robotic',
                   o.robotic === 2 && 'Assisted',
                   !!o.dead && <Box color="bad">DEAD</Box>,
+                  !!o.missing && <Box color="bad">MISSING</Box>,
                 ])}
               </Box>
             </Table.Cell>

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -52,6 +52,7 @@ export type internalOrgan = {
   robotic: BooleanLike;
   dead: BooleanLike;
   inflamed: BooleanLike;
+  missing: BooleanLike;
 };
 
 export type externalOrgan = {

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -45,11 +45,11 @@ type reagent = { name: string; amount: number; overdose: BooleanLike };
 export type internalOrgan = {
   name: string;
   desc: string | null;
-  germ_level: number;
-  damage: number;
-  maxHealth: number;
-  bruised: number;
-  broken: number;
+  germ_level?: number;
+  damage?: number;
+  maxHealth?: number;
+  bruised?: number;
+  broken?: number;
   robotic: BooleanLike;
   dead: BooleanLike;
   inflamed: BooleanLike;

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -7,6 +7,7 @@ export type Data = {
 
 export type occupant = {
   name: string;
+  species: string;
   stat: number;
   health: number;
   maxHealth: number;

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -44,7 +44,7 @@ type reagent = { name: string; amount: number; overdose: BooleanLike };
 
 export type internalOrgan = {
   name: string;
-  desc: string | null;
+  desc?: string | null;
   germ_level?: number;
   damage?: number;
   maxHealth?: number;


### PR DESCRIPTION

## About The Pull Request
Bodyscanners now will tell you if an organ is missing instead of requiring you to innately know that X species lacks X organ while Y species has Y organ
## Changelog
:cl: Diana
qol: Bodyscanner now tells you when someone is missing an organ instead of omitting it entirely
/:cl:
