### PR TITLE
fix diona xenoarch organ init

### DIFF
--- a/code/modules/organs/subtypes/diona.dm
+++ b/code/modules/organs/subtypes/diona.dm
@@ -213,7 +213,7 @@
 
 /obj/item/organ/internal/brain/cephalon/Initialize(mapload)
 	. = ..()
-	if(!owner.isSynthetic())
+	if(!owner?.isSynthetic())
 		vital = FALSE
 
 /obj/item/organ/internal/brain/cephalon/robotize()


### PR DESCRIPTION

Those can spawn without an owner, if they were spawned outside of a person... so we need to null check
## About The Pull Request
## Changelog
:cl:
fix: xenoarch organ spawn
/:cl:
