### PR TITLE
DNA Clone Fix

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -12,6 +12,7 @@
 #define NO_INFECT		0x400	// Don't allow infections in limbs or organs, similar to IS_PLANT, without other strings.
 #define NO_DEFIB		0x800	// Don't allow them to be defibbed
 #define NO_DNA          0x1000	// Cannot have mutations or have their dna changed by genetics/radiation/genome-stolen.
+#define THICK_SKIN		0x2000	// Needles have a chain to fail when attempted to be used on them.
 // unused: 0x8000 - higher than this will overflow
 
 // Species EMP vuln for carbons

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -301,12 +301,10 @@
 	else
 		return 0
 
-//VOREStation Add
 /mob/living/carbon/human/proc/force_update_organs()
 	for(var/obj/item/organ/O as anything in organs + internal_organs)
-		O.species = species
+		O.data.setup_from_species(species)
 	species.post_spawn_special(src)
-//VOREStation Add End
 
 // Used below, simple injection modifier.
 /proc/probinj(var/pr, var/inj)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -248,8 +248,7 @@
 
 	if(O.data)
 		// This is a very hacky way of doing of what organ/New() does if it has an owner
-		var/datum/species/SP = O.data.get_species_datum()
-		O.w_class = max(O.w_class + mob_size_difference(SP, MOB_MEDIUM), 1)
+		O.w_class = max(O.w_class + mob_size_difference(O.data.get_species_mob_size(), MOB_MEDIUM), 1)
 
 	return O
 // END GENERIC PRINTER

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -227,7 +227,7 @@
 	O.status |= ORGAN_CUT_AWAY
 	var/mob/living/carbon/human/C = loaded_dna["donor"]
 	O.set_dna(C.dna)
-	O.species = C.species
+	O.data.setup_from_species(C.species)
 
 	var/malfunctioned = FALSE
 
@@ -237,7 +237,7 @@
 		var/new_species = pick(possible_species)
 		if(!GLOB.all_species[new_species])
 			new_species = SPECIES_HUMAN
-		O.species = GLOB.all_species[new_species]
+		O.data.setup_from_species(GLOB.all_species[new_species])
 
 	if(istype(O, /obj/item/organ/external) && !malfunctioned)
 		var/obj/item/organ/external/E = O
@@ -246,9 +246,9 @@
 	O.pixel_x = rand(-6.0, 6)
 	O.pixel_y = rand(-6.0, 6)
 
-	if(O.species)
+	if(O.data)
 		// This is a very hacky way of doing of what organ/New() does if it has an owner
-		O.w_class = max(O.w_class + mob_size_difference(O.species.mob_size, MOB_MEDIUM), 1)
+		O.w_class = max(O.w_class + mob_size_difference(O.data.species.mob_size, MOB_MEDIUM), 1)
 
 	return O
 // END GENERIC PRINTER

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -248,7 +248,8 @@
 
 	if(O.data)
 		// This is a very hacky way of doing of what organ/New() does if it has an owner
-		O.w_class = max(O.w_class + mob_size_difference(O.data.species.mob_size, MOB_MEDIUM), 1)
+		var/datum/species/SP = O.data.get_species_datum()
+		O.w_class = max(O.w_class + mob_size_difference(SP, MOB_MEDIUM), 1)
 
 	return O
 // END GENERIC PRINTER

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -209,7 +209,7 @@
 	if(ishuman(victim) && user.zone_sel.selecting != BP_GROIN && user.zone_sel.selecting != BP_TORSO)
 		var/mob/living/carbon/human/H = victim
 		E = H.get_organ(user.zone_sel.selecting)
-		if(!E || E.species.flags & NO_PAIN)
+		if(!E || E.data.species.flags & NO_PAIN)
 			nopain = 2
 		else if(E.robotic >= ORGAN_ROBOT)
 			nopain = 1

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -209,8 +209,7 @@
 	if(ishuman(victim) && user.zone_sel.selecting != BP_GROIN && user.zone_sel.selecting != BP_TORSO)
 		var/mob/living/carbon/human/H = victim
 		E = H.get_organ(user.zone_sel.selecting)
-		var/datum/species/SP = E.data.get_species_datum()
-		if(!E || SP.flags & NO_PAIN)
+		if(!E || E.data.get_species_appearance_flags() & NO_PAIN)
 			nopain = 2
 		else if(E.robotic >= ORGAN_ROBOT)
 			nopain = 1

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -209,7 +209,8 @@
 	if(ishuman(victim) && user.zone_sel.selecting != BP_GROIN && user.zone_sel.selecting != BP_TORSO)
 		var/mob/living/carbon/human/H = victim
 		E = H.get_organ(user.zone_sel.selecting)
-		if(!E || E.data.species.flags & NO_PAIN)
+		var/datum/species/SP = E.data.get_species_datum()
+		if(!E || SP.flags & NO_PAIN)
 			nopain = 2
 		else if(E.robotic >= ORGAN_ROBOT)
 			nopain = 1

--- a/code/modules/mob/living/butchering.dm
+++ b/code/modules/mob/living/butchering.dm
@@ -62,8 +62,6 @@
 						var/mob/living/simple_mob/SM = src
 						if(SM.limb_icon)
 							neworg.force_icon = SM.limb_icon
-							neworg.force_icon_key = SM.limb_icon_key
-
 					organs |= neworg
 					organs -= path
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -197,7 +197,7 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	if(H) use_species = H.species.get_bodytype(src)
+	if(H) use_species = H.data.species.get_bodytype(src)
 
 	var/list/valid_hairstyles = new()
 	for(var/hairstyle in hair_styles_list)
@@ -223,7 +223,7 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	if(H) use_species = H.species.get_bodytype(src)
+	if(H) use_species = H.data.species.get_bodytype(src)
 
 	var/list/valid_facial_hairstyles = new()
 	for(var/facialhairstyle in facial_hair_styles_list)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -197,7 +197,8 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	if(H) use_species = H.data.species.get_bodytype(src)
+	var/datum/species/SP = H.data.get_species_datum()
+	if(H) use_species = SP.get_bodytype(src)
 
 	var/list/valid_hairstyles = new()
 	for(var/hairstyle in hair_styles_list)
@@ -223,7 +224,8 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	if(H) use_species = H.data.species.get_bodytype(src)
+	var/datum/species/SP = H.data.get_species_datum()
+	if(H) use_species = SP.get_bodytype(src)
 
 	var/list/valid_facial_hairstyles = new()
 	for(var/facialhairstyle in facial_hair_styles_list)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -172,8 +172,7 @@
 /mob/living/carbon/human/proc/update_dna()
 	check_dna()
 	dna.ready_dna(src)
-	for(var/obj/item/organ/O in organs)
-		qdel_swap(O.dna, dna.Clone()) // Update all of those because apparently they're separate, and icons won't update properly
+	sync_organ_dna(dna)
 
 /mob/living/carbon/human/proc/generate_valid_species(var/check_whitelist = 1, var/list/whitelist = list(), var/list/blacklist = list())
 	var/list/valid_species = new()

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -197,8 +197,7 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	var/datum/species/SP = H.data.get_species_datum()
-	if(H) use_species = SP.get_bodytype(src)
+	if(H) use_species = H.data.get_species_bodytype(src)
 
 	var/list/valid_hairstyles = new()
 	for(var/hairstyle in hair_styles_list)
@@ -224,8 +223,7 @@
 
 	var/use_species = species.get_bodytype(src)
 	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	var/datum/species/SP = H.data.get_species_datum()
-	if(H) use_species = SP.get_bodytype(src)
+	if(H) use_species = H.data.get_species_bodytype(src)
 
 	var/list/valid_facial_hairstyles = new()
 	for(var/facialhairstyle in facial_hair_styles_list)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1431,7 +1431,7 @@
 	else if (affecting.robotic >= ORGAN_LIFELIKE)
 		. = 0
 		fail_msg = "Your needle refuses to penetrate more than a short distance..."
-	else if (affecting.thick_skin && prob(70 - round(affecting.brute_dam + affecting.burn_dam / 2)))	// Allows transplanted limbs with thick skin to maintain their resistance.
+	else if ((species.flags & THICK_SKIN) && prob(70 - round(affecting.brute_dam + affecting.burn_dam / 2)))	// Allows transplanted limbs with thick skin to maintain their resistance.
 		. = 0
 		fail_msg = "Your needle fails to penetrate \the [affecting]'s thick hide..."
 	else

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -276,7 +276,7 @@ var/list/wrapped_species_by_ref = list()
 	for(var/limb in organs_by_name)
 		var/obj/item/organ/external/O = organs_by_name[limb]
 		if(limb_exists[O.organ_tag])
-			O.species = GLOB.all_species[new_species]
+			O.data.setup_from_species(GLOB.all_species[new_species])
 			O.wounds = wounds_by_limb[O.organ_tag]
 			// sync the organ's damage with its wounds
 			O.update_damages()

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -24,7 +24,7 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	flags =  NO_DNA | NO_SLEEVE | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_INFECT | NO_DEFIB
+	flags =  NO_DNA | NO_SLEEVE | NO_PAIN | NO_SLIP | NO_POISON | NO_MINOR_CUT | NO_INFECT | NO_DEFIB | THICK_SKIN
 	spawn_flags = SPECIES_IS_RESTRICTED
 
 	reagent_tag = IS_XENOS

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -226,7 +226,8 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			continue
 		if(part)
 			wholeicontransparent &&= part.transparent //VORESTATION EDIT: transparent instead of nonsolid
-			icon_key += "[part.data.species.get_race_key(part.owner)]"
+			var/datum/species/SP = part.data.get_species_datum()
+			icon_key += "[SP.get_race_key(part.owner)]"
 			icon_key += "[part.data.body_gender]"
 			icon_key += "[part.s_tone]"
 			if(part.s_col && part.s_col.len >= 3)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -226,7 +226,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			continue
 		if(part)
 			wholeicontransparent &&= part.transparent //VORESTATION EDIT: transparent instead of nonsolid
-			icon_key += "[part.species.get_race_key(part.owner)]"
+			icon_key += "[part.data.species.get_race_key(part.owner)]"
 			icon_key += "[part.data.body_gender]"
 			icon_key += "[part.s_tone]"
 			if(part.s_col && part.s_col.len >= 3)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -227,7 +227,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		if(part)
 			wholeicontransparent &&= part.transparent //VORESTATION EDIT: transparent instead of nonsolid
 			icon_key += "[part.species.get_race_key(part.owner)]"
-			icon_key += "[part.dna.GetUIState(DNA_UI_GENDER)]"
+			icon_key += "[part.data.body_gender]"
 			icon_key += "[part.s_tone]"
 			if(part.s_col && part.s_col.len >= 3)
 				icon_key += "[rgb(part.s_col[1],part.s_col[2],part.s_col[3])]"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -226,8 +226,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			continue
 		if(part)
 			wholeicontransparent &&= part.transparent //VORESTATION EDIT: transparent instead of nonsolid
-			var/datum/species/SP = part.data.get_species_datum()
-			icon_key += "[SP.get_race_key(part.owner)]"
+			icon_key += "[part.data.get_species_race_key(part.owner)]"
 			icon_key += "[part.data.body_gender]"
 			icon_key += "[part.s_tone]"
 			if(part.s_col && part.s_col.len >= 3)

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -52,79 +52,55 @@
 
 // All accessed vars need to be cached during read.
 // Get data from species, if this fails use cached data
+#define SETUP_SPECIES_CHECK(p,x)\
+var/datum/species/SP = get_species_datum();\
+if(SP)\
+	cached_species_vars[p] = x;\
+return cached_species_vars[p];
+
+
 /datum/organ_data/proc/get_species_name()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["name"] = SP.name
-	return cached_species_vars["name"]
+	SETUP_SPECIES_CHECK("name",SP.name)
 
 /datum/organ_data/proc/get_species_race_key(var/owner)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["race_key"] = SP.get_race_key(owner)
-	return cached_species_vars["race_key"]
+	SETUP_SPECIES_CHECK("race_key",SP.get_race_key(owner))
 
 /datum/organ_data/proc/get_species_bodytype(var/mob/living/carbon/human/H)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["bodytype"] = SP.get_bodytype(H)
-	return cached_species_vars["bodytype"]
+	SETUP_SPECIES_CHECK("bodytype",SP.get_bodytype(H))
 
 /datum/organ_data/proc/get_species_icobase(var/mob/living/carbon/human/H, var/get_deform)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["icobase"] = SP.get_icobase(H,get_deform)
-	return cached_species_vars["icobase"]
+	SETUP_SPECIES_CHECK("icobase",SP.get_icobase(H,get_deform))
 
 /datum/organ_data/proc/get_species_appearance_flags()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["appearance_flags"] = SP.appearance_flags
-	return cached_species_vars["appearance_flags"]
+	SETUP_SPECIES_CHECK("appearance_flags",SP.appearance_flags)
 
 /datum/organ_data/proc/get_species_health_hud_intensity()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["health_hud_intensity"] = SP.health_hud_intensity
-	return cached_species_vars["health_hud_intensity"]
+	SETUP_SPECIES_CHECK("health_hud_intensity",SP.health_hud_intensity)
 
 /datum/organ_data/proc/get_species_color_mult()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["color_mult"] = SP.color_mult
-	return cached_species_vars["color_mult"]
+	SETUP_SPECIES_CHECK("color_mult",SP.color_mult)
 
 /datum/organ_data/proc/get_species_mob_size()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["mob_size"] = SP.mob_size
-	return cached_species_vars["mob_size"]
+	SETUP_SPECIES_CHECK("mob_size",SP.mob_size)
 
 /datum/organ_data/proc/get_species_flesh_colour(var/owner)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["flesh_colour"] = SP.get_flesh_colour(owner) || "#C80000"
-	return cached_species_vars["flesh_colour"]
+	SETUP_SPECIES_CHECK("flesh_colour",SP.get_flesh_colour(owner) || "#C80000")
 
 /datum/organ_data/proc/get_species_blood_colour(var/owner)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["blood_colour"] = SP.get_blood_colour(owner) || "#C80000"
-	return cached_species_vars["blood_colour"]
+	SETUP_SPECIES_CHECK("blood_colour",SP.get_blood_colour(owner) || "#C80000")
 
 /datum/organ_data/proc/get_species_icodigi()
 	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/SP = get_species_datum()
-	if(SP)
-		cached_species_vars["icodigi"] = SP.icodigi
-	return cached_species_vars["icodigi"]
+	SETUP_SPECIES_CHECK("icodigi",SP.icodigi)
+
+#undef SETUP_SPECIES_CHECK

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -1,8 +1,8 @@
 // Data written to each organ on creation for appearance and blood, this WAS originally done by sending the full dna datum.
 // However sending the whole dna datum through Clone() is extremely expensive, and a memory leak if its a hardref instead.
 /datum/organ_data
-	// Species
-	var/datum/species/species
+	VAR_PRIVATE/datum/weakref/species
+	VAR_PRIVATE/species_name // Fallback
 	// Dna
 	var/unique_enzymes
 	var/b_type
@@ -14,13 +14,22 @@
 	var/list/hair_color
 
 /datum/organ_data/proc/setup_from_species(var/datum/species/S) // This needs a full rework, but can't be done unless all of transformating species code is refactored
-	species = S
+	SHOULD_NOT_OVERRIDE(TRUE)
+	species = WEAKREF(S)
+	species_name = S.name
 
-/datum/organ_data/Destroy(force)
-	species = null
-	. = ..()
+/datum/organ_data/proc/get_species_datum()
+	RETURN_TYPE(/datum/species)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/S = species?.resolve()
+	if(!S)
+		S = GLOB.all_species[species_name]
+	if(!S)
+		S = GLOB.all_species[SPECIES_HUMAN]
+	return S
 
 /datum/organ_data/proc/setup_from_dna(var/datum/dna/dna)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	// Prosfab uses default dna to get vars, lets respect that still
 	var/self_clear = FALSE
 	if(!dna)

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -1,6 +1,9 @@
 // Data written to each organ on creation for appearance and blood, this WAS originally done by sending the full dna datum.
 // However sending the whole dna datum through Clone() is extremely expensive, and a memory leak if its a hardref instead.
 /datum/organ_data
+	// Species
+	var/datum/species/species
+	// Dna
 	var/unique_enzymes
 	var/b_type
 	var/body_gender
@@ -10,7 +13,14 @@
 	var/list/skin_color
 	var/list/hair_color
 
-/datum/organ_data/setup_from_dna(var/datum/dna/dna)
+/datum/organ_data/proc/setup_from_species(var/datum/species/S) // This needs a full rework, but can't be done unless all of transformating species code is refactored
+	species = S
+
+/datum/organ_data/Destroy(force)
+	species = null
+	. = ..()
+
+/datum/organ_data/proc/setup_from_dna(var/datum/dna/dna)
 	// Prosfab uses default dna to get vars, lets respect that still
 	var/self_clear = FALSE
 	if(!dna)

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -2,16 +2,17 @@
 // However sending the whole dna datum through Clone() is extremely expensive, and a memory leak if its a hardref instead.
 /datum/organ_data
 	VAR_PRIVATE/datum/weakref/species
-	VAR_PRIVATE/species_name // Fallback
 	// Species currently uses a cache system, if the species datum deletes, these are used as fallbacks for the last obtained state from the species datum
 	// In the future, transforming species need to be refactored to not need this, as it's the only thing holding it back from proper isolation.
+
+	// Species
 	VAR_PRIVATE/cached_species_vars = list()
+
 	// Dna
 	var/unique_enzymes
 	var/b_type
 	var/body_gender
 	var/digitigrade
-	// Colorsets
 	var/skin_tone
 	var/list/skin_color
 	var/list/hair_color
@@ -41,19 +42,11 @@
 /datum/organ_data/proc/setup_from_species(var/datum/species/S) // This needs a full rework, but can't be done unless all of transformating species code is refactored
 	SHOULD_NOT_OVERRIDE(TRUE)
 	species = WEAKREF(S)
-	species_name = S.name
-
-/datum/organ_data/proc/get_species_datum()
-	RETURN_TYPE(/datum/species)
-	PRIVATE_PROC(TRUE)
-	SHOULD_NOT_OVERRIDE(TRUE)
-	return species?.resolve()
-
 
 // All accessed vars need to be cached during read.
 // Get data from species, if this fails use cached data
 #define SETUP_SPECIES_CHECK(p,x)\
-var/datum/species/SP = get_species_datum();\
+var/datum/species/SP = species?.resolve();\
 if(SP)\
 	cached_species_vars[p] = x;\
 return cached_species_vars[p];

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -1,0 +1,31 @@
+// Data written to each organ on creation for appearance and blood, this WAS originally done by sending the full dna datum.
+// However sending the whole dna datum through Clone() is extremely expensive, and a memory leak if its a hardref instead.
+/datum/organ_data
+	var/unique_enzymes
+	var/b_type
+	var/body_gender
+	var/digitigrade
+	// Colorsets
+	var/skin_tone
+	var/list/skin_color
+	var/list/hair_color
+
+/datum/organ_data/setup_from_dna(var/datum/dna/dna)
+	// Prosfab uses default dna to get vars, lets respect that still
+	var/self_clear = FALSE
+	if(!dna)
+		dna = new()
+		dna.ResetUI()
+		self_clear = TRUE
+
+	unique_enzymes = dna.unique_enzymes
+	body_gender = dna.GetUIState(DNA_UI_GENDER)
+	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)))
+		skin_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
+	skin_color = list(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
+	hair_color = list(dna.GetUIValue(DNA_UI_HAIR_R),dna.GetUIValue(DNA_UI_HAIR_G),dna.GetUIValue(DNA_UI_HAIR_B))
+	digitigrade = dna.digitigrade
+
+	// Cleanup for synthfab default dna
+	if(self_clear)
+		qdel(dna)

--- a/code/modules/organs/data.dm
+++ b/code/modules/organs/data.dm
@@ -3,6 +3,9 @@
 /datum/organ_data
 	VAR_PRIVATE/datum/weakref/species
 	VAR_PRIVATE/species_name // Fallback
+	// Species currently uses a cache system, if the species datum deletes, these are used as fallbacks for the last obtained state from the species datum
+	// In the future, transforming species need to be refactored to not need this, as it's the only thing holding it back from proper isolation.
+	VAR_PRIVATE/cached_species_vars = list()
 	// Dna
 	var/unique_enzymes
 	var/b_type
@@ -13,21 +16,6 @@
 	var/list/skin_color
 	var/list/hair_color
 
-/datum/organ_data/proc/setup_from_species(var/datum/species/S) // This needs a full rework, but can't be done unless all of transformating species code is refactored
-	SHOULD_NOT_OVERRIDE(TRUE)
-	species = WEAKREF(S)
-	species_name = S.name
-
-/datum/organ_data/proc/get_species_datum()
-	RETURN_TYPE(/datum/species)
-	SHOULD_NOT_OVERRIDE(TRUE)
-	var/datum/species/S = species?.resolve()
-	if(!S)
-		S = GLOB.all_species[species_name]
-	if(!S)
-		S = GLOB.all_species[SPECIES_HUMAN]
-	return S
-
 /datum/organ_data/proc/setup_from_dna(var/datum/dna/dna)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	// Prosfab uses default dna to get vars, lets respect that still
@@ -37,14 +25,106 @@
 		dna.ResetUI()
 		self_clear = TRUE
 
+	// Setup cached dna data, as storing the entire DNA cloned is horrifically laggy
 	unique_enzymes = dna.unique_enzymes
 	body_gender = dna.GetUIState(DNA_UI_GENDER)
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)))
 		skin_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
 	skin_color = list(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
-	hair_color = list(dna.GetUIValue(DNA_UI_HAIR_R),dna.GetUIValue(DNA_UI_HAIR_G),dna.GetUIValue(DNA_UI_HAIR_B))
+	hair_color = list(dna.GetUIValue(DNA_UI_HAIR_R), dna.GetUIValue(DNA_UI_HAIR_G), dna.GetUIValue(DNA_UI_HAIR_B))
 	digitigrade = dna.digitigrade
 
 	// Cleanup for synthfab default dna
 	if(self_clear)
 		qdel(dna)
+
+/datum/organ_data/proc/setup_from_species(var/datum/species/S) // This needs a full rework, but can't be done unless all of transformating species code is refactored
+	SHOULD_NOT_OVERRIDE(TRUE)
+	species = WEAKREF(S)
+	species_name = S.name
+
+/datum/organ_data/proc/get_species_datum()
+	RETURN_TYPE(/datum/species)
+	PRIVATE_PROC(TRUE)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return species?.resolve()
+
+
+// All accessed vars need to be cached during read.
+// Get data from species, if this fails use cached data
+/datum/organ_data/proc/get_species_name()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["name"] = SP.name
+	return cached_species_vars["name"]
+
+/datum/organ_data/proc/get_species_race_key(var/owner)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["race_key"] = SP.get_race_key(owner)
+	return cached_species_vars["race_key"]
+
+/datum/organ_data/proc/get_species_bodytype(var/mob/living/carbon/human/H)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["bodytype"] = SP.get_bodytype(H)
+	return cached_species_vars["bodytype"]
+
+/datum/organ_data/proc/get_species_icobase(var/mob/living/carbon/human/H, var/get_deform)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["icobase"] = SP.get_icobase(H,get_deform)
+	return cached_species_vars["icobase"]
+
+/datum/organ_data/proc/get_species_appearance_flags()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["appearance_flags"] = SP.appearance_flags
+	return cached_species_vars["appearance_flags"]
+
+/datum/organ_data/proc/get_species_health_hud_intensity()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["health_hud_intensity"] = SP.health_hud_intensity
+	return cached_species_vars["health_hud_intensity"]
+
+/datum/organ_data/proc/get_species_color_mult()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["color_mult"] = SP.color_mult
+	return cached_species_vars["color_mult"]
+
+/datum/organ_data/proc/get_species_mob_size()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["mob_size"] = SP.mob_size
+	return cached_species_vars["mob_size"]
+
+/datum/organ_data/proc/get_species_flesh_colour(var/owner)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["flesh_colour"] = SP.get_flesh_colour(owner) || "#C80000"
+	return cached_species_vars["flesh_colour"]
+
+/datum/organ_data/proc/get_species_blood_colour(var/owner)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["blood_colour"] = SP.get_blood_colour(owner) || "#C80000"
+	return cached_species_vars["blood_colour"]
+
+/datum/organ_data/proc/get_species_icodigi()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/datum/species/SP = get_species_datum()
+	if(SP)
+		cached_species_vars["icodigi"] = SP.icodigi
+	return cached_species_vars["icodigi"]

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -23,8 +23,7 @@ var/list/organ_cache = list()
 	var/list/transplant_data			// Transplant match data.
 	var/list/autopsy_data = list()		// Trauma data for forensics.
 	var/list/trace_chemicals = list()	// Traces of chemicals in the organ.
-	var/datum/organ_data/data = new()		// Stores data for appearance and investigation
-	var/datum/species/species			// Original species.
+	var/datum/organ_data/data = new()	// Stores data for appearance and investigation
 
 	// Damage vars.
 	var/min_bruised_damage = 10			// Damage before considered bruised
@@ -55,7 +54,6 @@ var/list/organ_cache = list()
 	if(autopsy_data)    autopsy_data.Cut()
 	if(trace_chemicals) trace_chemicals.Cut()
 	QDEL_NULL(data)
-	species = null
 
 	return ..()
 
@@ -91,10 +89,11 @@ var/list/organ_cache = list()
 		max_damage = min_broken_damage * 2
 	if(iscarbon(owner))
 		var/mob/living/carbon/C = owner
-		species = GLOB.all_species[SPECIES_HUMAN]
+		if(!C.species)
+			data.setup_from_species(GLOB.all_species[SPECIES_HUMAN])
 		if(owner.dna)
 			data.setup_from_dna(C.dna)
-			species = C.species
+			data.setup_from_species(C.species)
 		else
 			log_debug("[src] at [loc] spawned without a proper DNA.")
 		var/mob/living/carbon/human/H = C
@@ -110,7 +109,7 @@ var/list/organ_cache = list()
 					blood_DNA = list()
 				blood_DNA[data.unique_enzymes] = data.b_type
 	else
-		species = GLOB.all_species["Human"]
+		data.setup_from_species(GLOB.all_species["Human"])
 
 	handle_organ_mod_special()
 
@@ -261,7 +260,7 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(data && can_reject)
 		if(!rejecting)
-			if(blood_incompatible(data.b_type, owner.dna.b_type, species.name, owner.species.name)) //VOREStation Edit - Process species by name.
+			if(blood_incompatible(data.b_type, owner.dna.b_type, data.species.name, owner.species.name)) //VOREStation Edit - Process species by name.
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.
@@ -519,7 +518,7 @@ var/list/organ_cache = list()
 	qdel(src)
 
 /obj/item/organ/proc/organ_can_feel_pain()
-	if(species.flags & NO_PAIN)
+	if(data.species.flags & NO_PAIN)
 		return 0
 	if(status & ORGAN_DESTROYED)
 		return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -23,7 +23,7 @@ var/list/organ_cache = list()
 	var/list/transplant_data			// Transplant match data.
 	var/list/autopsy_data = list()		// Trauma data for forensics.
 	var/list/trace_chemicals = list()	// Traces of chemicals in the organ.
-	var/datum/dna/dna					// Original DNA.
+	var/datum/organ_data/data = new()		// Stores data for appearance and investigation
 	var/datum/species/species			// Original species.
 
 	// Damage vars.
@@ -54,7 +54,7 @@ var/list/organ_cache = list()
 	if(transplant_data) transplant_data.Cut()
 	if(autopsy_data)    autopsy_data.Cut()
 	if(trace_chemicals) trace_chemicals.Cut()
-	QDEL_NULL(dna)
+	QDEL_NULL(data)
 	species = null
 
 	return ..()
@@ -93,7 +93,7 @@ var/list/organ_cache = list()
 		var/mob/living/carbon/C = owner
 		species = GLOB.all_species[SPECIES_HUMAN]
 		if(owner.dna)
-			qdel_swap(dna, C.dna.Clone())
+			data.setup_from_dna(C.dna)
 			species = C.species
 		else
 			log_debug("[src] at [loc] spawned without a proper DNA.")
@@ -105,10 +105,10 @@ var/list/organ_cache = list()
 					if(E.internal_organs == null)
 						E.internal_organs = list()
 					E.internal_organs |= src
-			if(dna)
+			if(data)
 				if(!blood_DNA)
 					blood_DNA = list()
-				blood_DNA[dna.unique_enzymes] = dna.b_type
+				blood_DNA[data.unique_enzymes] = data.b_type
 	else
 		species = GLOB.all_species["Human"]
 
@@ -131,10 +131,10 @@ var/list/organ_cache = list()
 
 /obj/item/organ/proc/set_dna(var/datum/dna/new_dna)
 	if(new_dna)
-		qdel_swap(dna, new_dna.Clone())
+		data.setup_from_dna(new_dna)
 		if(blood_DNA)
 			blood_DNA.Cut()
-			blood_DNA[dna.unique_enzymes] = dna.b_type
+			blood_DNA[data.unique_enzymes] = data.b_type
 
 /obj/item/organ/proc/die()
 	if(robotic < ORGAN_ROBOT)
@@ -259,9 +259,9 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/handle_rejection()
 	// Process unsuitable transplants. TODO: consider some kind of
 	// immunosuppressant that changes transplant data to make it match.
-	if(dna && can_reject)
+	if(data && can_reject)
 		if(!rejecting)
-			if(blood_incompatible(dna.b_type, owner.dna.b_type, species.name, owner.species.name)) //VOREStation Edit - Process species by name.
+			if(blood_incompatible(data.b_type, owner.dna.b_type, species.name, owner.species.name)) //VOREStation Edit - Process species by name.
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -260,8 +260,7 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(data && can_reject)
 		if(!rejecting)
-			var/datum/species/SP = data.get_species_datum()
-			if(blood_incompatible(data.b_type, owner.dna.b_type, SP.name, owner.species.name)) //VOREStation Edit - Process species by name.
+			if(blood_incompatible(data.b_type, owner.dna.b_type, data.get_species_name(), owner.species.name)) //VOREStation Edit - Process species by name.
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.
@@ -519,8 +518,7 @@ var/list/organ_cache = list()
 	qdel(src)
 
 /obj/item/organ/proc/organ_can_feel_pain()
-	var/datum/species/SP = data.get_species_datum()
-	if(SP.flags & NO_PAIN)
+	if(data.get_species_appearance_flags() & NO_PAIN)
 		return 0
 	if(status & ORGAN_DESTROYED)
 		return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -260,7 +260,8 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(data && can_reject)
 		if(!rejecting)
-			if(blood_incompatible(data.b_type, owner.dna.b_type, data.species.name, owner.species.name)) //VOREStation Edit - Process species by name.
+			var/datum/species/SP = data.get_species_datum()
+			if(blood_incompatible(data.b_type, owner.dna.b_type, SP.name, owner.species.name)) //VOREStation Edit - Process species by name.
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.
@@ -518,7 +519,8 @@ var/list/organ_cache = list()
 	qdel(src)
 
 /obj/item/organ/proc/organ_can_feel_pain()
-	if(data.species.flags & NO_PAIN)
+	var/datum/species/SP = data.get_species_datum()
+	if(SP.flags & NO_PAIN)
 		return 0
 	if(status & ORGAN_DESTROYED)
 		return 0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -594,9 +594,8 @@ This function completely restores a damaged organ to perfect condition.
 
 	//moved this before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Possibly trigger an internal wound, too.
-	var/datum/species/SP = data.get_species_datum()
 	var/local_damage = brute_dam + burn_dam + damage
-	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(SP.flags & NO_BLOOD))
+	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(data.get_species_appearance_flags() & NO_BLOOD))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
 		owner.custom_pain("Something ruptures inside of your [name]. You get the feeling you'll need more than just a bandage to fix it.", 15, TRUE)
@@ -604,7 +603,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Burn damage can cause fluid loss due to blistering and cook-off
 
-	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(SP.flags & NO_BLOOD))
+	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(data.get_species_appearance_flags() & NO_BLOOD))
 		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
@@ -793,8 +792,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()
-	var/datum/species/SP = data.get_species_datum()
-	if((robotic >= ORGAN_ROBOT) || (SP.flags & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
+	if((robotic >= ORGAN_ROBOT) || (data.get_species_appearance_flags() & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
 				wounds -= W    //TODO: robot wounds for robot limbs
@@ -965,9 +963,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	var/obj/item/organ/external/parent_organ = parent
 
-	var/datum/species/SP = data.get_species_datum()
-	var/use_flesh_colour = SP.get_flesh_colour(owner) ? SP.get_flesh_colour(owner) : "#C80000"
-	var/use_blood_colour = SP.get_blood_colour(owner) ? SP.get_blood_colour(owner) : "#C80000"
+	var/use_flesh_colour = data.get_species_flesh_colour(owner)
+	var/use_blood_colour = data.get_species_blood_colour(owner)
 
 	removed(null, ignore_children)
 	victim?.traumatic_shock += 60
@@ -1020,9 +1017,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(droploc)
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(droploc)
-				var/datum/species/SP = data.get_species_datum()
-				gore.fleshcolor = use_flesh_colour
-				gore.basecolor =  use_blood_colour
+				gore.fleshcolor = data.get_species_flesh_colour(owner)
+				gore.basecolor =  data.get_species_blood_colour(owner)
 				gore.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
@@ -1207,8 +1203,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(company)
 		model = company
 		var/datum/robolimb/R = all_robolimbs[company]
-		var/datum/species/SP = data.get_species_datum()
-		if(!R || (SP.name in R.species_cannot_use))
+		if(!R || (data.get_species_name() in R.species_cannot_use))
 			R = basic_robolimb
 		if(R)
 			force_icon = R.icon

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -594,8 +594,9 @@ This function completely restores a damaged organ to perfect condition.
 
 	//moved this before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Possibly trigger an internal wound, too.
+	var/datum/species/SP = data.get_species_datum()
 	var/local_damage = brute_dam + burn_dam + damage
-	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(data.species.flags & NO_BLOOD))
+	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(SP.flags & NO_BLOOD))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
 		owner.custom_pain("Something ruptures inside of your [name]. You get the feeling you'll need more than just a bandage to fix it.", 15, TRUE)
@@ -603,7 +604,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Burn damage can cause fluid loss due to blistering and cook-off
 
-	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(data.species.flags & NO_BLOOD))
+	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(SP.flags & NO_BLOOD))
 		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
@@ -792,8 +793,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()
-
-	if((robotic >= ORGAN_ROBOT) || (data.species.flags & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
+	var/datum/species/SP = data.get_species_datum()
+	if((robotic >= ORGAN_ROBOT) || (SP.flags & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
 				wounds -= W    //TODO: robot wounds for robot limbs
@@ -964,8 +965,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	var/obj/item/organ/external/parent_organ = parent
 
-	var/use_flesh_colour = data.species?.get_flesh_colour(owner) ? data.species.get_flesh_colour(owner) : "#C80000"
-	var/use_blood_colour = data.species?.get_blood_colour(owner) ? data.species.get_blood_colour(owner) : "#C80000"
+	var/datum/species/SP = data.get_species_datum()
+	var/use_flesh_colour = SP.get_flesh_colour(owner) ? SP.get_flesh_colour(owner) : "#C80000"
+	var/use_blood_colour = SP.get_blood_colour(owner) ? SP.get_blood_colour(owner) : "#C80000"
 
 	removed(null, ignore_children)
 	victim?.traumatic_shock += 60
@@ -1018,10 +1020,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(droploc)
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(droploc)
-				if(data.species)
-					gore.fleshcolor = use_flesh_colour
-					gore.basecolor =  use_blood_colour
-					gore.update_icon()
+				var/datum/species/SP = data.get_species_datum()
+				gore.fleshcolor = use_flesh_colour
+				gore.basecolor =  use_blood_colour
+				gore.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
 
@@ -1205,7 +1207,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(company)
 		model = company
 		var/datum/robolimb/R = all_robolimbs[company]
-		if(!R || (data.species && (data.species.name in R.species_cannot_use)))
+		var/datum/species/SP = data.get_species_datum()
+		if(!R || (SP.name in R.species_cannot_use))
 			R = basic_robolimb
 		if(R)
 			force_icon = R.icon

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -257,7 +257,8 @@
 
 /obj/item/organ/external/LateInitialize()
 	. = ..()
-	get_icon()
+	if(!QDELETED(src))
+		get_icon()
 
 /obj/item/organ/external/replaced(var/mob/living/carbon/human/target)
 	owner = target
@@ -1017,8 +1018,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(droploc)
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(droploc)
-				gore.fleshcolor = data.get_species_flesh_colour(owner)
-				gore.basecolor =  data.get_species_blood_colour(owner)
+				gore.fleshcolor = use_flesh_colour
+				gore.basecolor = use_blood_colour
 				gore.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -595,7 +595,7 @@ This function completely restores a damaged organ to perfect condition.
 	//moved this before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Possibly trigger an internal wound, too.
 	var/local_damage = brute_dam + burn_dam + damage
-	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(species.flags & NO_BLOOD))
+	if((damage > 15) && (type != BURN) && (local_damage > 30) && prob(damage) && (robotic < ORGAN_ROBOT) && !(data.species.flags & NO_BLOOD))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
 		owner.custom_pain("Something ruptures inside of your [name]. You get the feeling you'll need more than just a bandage to fix it.", 15, TRUE)
@@ -603,7 +603,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Burn damage can cause fluid loss due to blistering and cook-off
 
-	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(species.flags & NO_BLOOD))
+	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(data.species.flags & NO_BLOOD))
 		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
@@ -793,7 +793,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()
 
-	if((robotic >= ORGAN_ROBOT) || (species.flags & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
+	if((robotic >= ORGAN_ROBOT) || (data.species.flags & UNDEAD)) //Robotic and dead limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
 				wounds -= W    //TODO: robot wounds for robot limbs
@@ -964,8 +964,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	var/obj/item/organ/external/parent_organ = parent
 
-	var/use_flesh_colour = species?.get_flesh_colour(owner) ? species.get_flesh_colour(owner) : "#C80000"
-	var/use_blood_colour = species?.get_blood_colour(owner) ? species.get_blood_colour(owner) : "#C80000"
+	var/use_flesh_colour = data.species?.get_flesh_colour(owner) ? data.species.get_flesh_colour(owner) : "#C80000"
+	var/use_blood_colour = data.species?.get_blood_colour(owner) ? data.species.get_blood_colour(owner) : "#C80000"
 
 	removed(null, ignore_children)
 	victim?.traumatic_shock += 60
@@ -1018,7 +1018,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(droploc)
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(droploc)
-				if(species)
+				if(data.species)
 					gore.fleshcolor = use_flesh_colour
 					gore.basecolor =  use_blood_colour
 					gore.update_icon()
@@ -1205,7 +1205,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(company)
 		model = company
 		var/datum/robolimb/R = all_robolimbs[company]
-		if(!R || (species && (species.name in R.species_cannot_use)))
+		if(!R || (data.species && (data.species.name in R.species_cannot_use)))
 			R = basic_robolimb
 		if(R)
 			force_icon = R.icon

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -30,8 +30,6 @@
 	var/burn_dam = 0                   // Actual current burn damage.
 	var/last_dam = -1                  // used in healing/processing calculations.
 	var/spread_dam = 0
-	var/thick_skin = 0                 // If a needle has a chance to fail to penetrate.
-
 	// Appearance vars.
 	var/nonsolid                       // Snowflake warning, reee. Used for slime limbs.
 	var/transparent                    // As above, so below. Used for transparent limbs.
@@ -40,7 +38,6 @@
 	var/icon_position = 0              // Used in mob overlay layering calculations.
 	var/model                          // Used when caching robolimb icons.
 	var/force_icon                     // Used to force override of species-specific limb icons (for prosthetics). Also used for any limbs chopped from a simple mob, and then attached to humans.
-	var/force_icon_key                 // Used to force the override of the icon-key generated using the species. Must be used in tandem with the above.
 	var/icon/mob_icon                  // Cached icon for use in mob overlays.
 	var/gendered_icon = 0              // Whether or not the icon state appends a gender.
 	var/s_tone                         // Skin tone.

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -22,8 +22,7 @@ var/global/list/limb_icon_cache = list()
 			if(human.synth_color)
 				s_col = list(human.r_synth, human.g_synth, human.b_synth)
 			return
-	var/datum/species/SP = data.get_species_datum()
-	if(human.species && SP.name != human.species.name)
+	if(human.species && data.get_species_name() != human.species.name)
 		return
 	if(!isnull(human.s_tone) && (human.species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = human.s_tone
@@ -39,10 +38,9 @@ var/global/list/limb_icon_cache = list()
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skin_tone) && !(franchise && franchise.skin_color))
 			return
-	var/datum/species/SP = data.get_species_datum()
-	if(!isnull(data.skin_tone) && (SP.appearance_flags & HAS_SKIN_TONE))
+	if(!isnull(data.skin_tone) && (data.get_species_appearance_flags() & HAS_SKIN_TONE))
 		s_tone = data.skin_tone
-	if(SP.appearance_flags & HAS_SKIN_COLOR)
+	if(data.get_species_appearance_flags() & HAS_SKIN_COLOR)
 		s_col = data.skin_color.Copy()
 	h_col = data.hair_color.Copy()
 
@@ -57,9 +55,8 @@ var/global/list/limb_icon_cache = list()
 	var/image/res = image('icons/mob/human_face.dmi',"bald_s")
 	//Facial hair
 	if(owner.f_style)
-		var/datum/species/SP = data.get_species_datum()
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (SP.get_bodytype(owner) in facial_hair_style.species_allowed))
+		if(facial_hair_style && facial_hair_style.species_allowed && (data.get_species_bodytype(owner) in facial_hair_style.species_allowed))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			if(facial_hair_style.do_colouration)
 				facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), facial_hair_style.color_blend_mode)
@@ -72,8 +69,7 @@ var/global/list/limb_icon_cache = list()
 		if(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR))
 			if(!(hair_style.flags & HAIR_VERY_SHORT))
 				hair_style = hair_styles_list["Short Hair"]
-		var/datum/species/SP = data.get_species_datum()
-		if(hair_style && (SP.get_bodytype(owner) in hair_style.species_allowed))
+		if(hair_style && (data.get_species_bodytype(owner) in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			var/icon/hair_s_add = new/icon("icon" = hair_style.icon_add, "icon_state" = "[hair_style.icon_state]_s")
 			if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
@@ -129,8 +125,7 @@ var/global/list/limb_icon_cache = list()
 	var/should_apply_transparency = FALSE
 
 	if(!force_icon_key)
-		var/datum/species/SP = data.get_species_datum()
-		icon_cache_key = "[icon_name]_[SP.get_bodytype()]" //VOREStation Edit
+		icon_cache_key = "[icon_name]_[data.get_species_bodytype(owner)]"
 	else
 		icon_cache_key = "[icon_name]_[force_icon_key]"
 
@@ -160,8 +155,7 @@ var/global/list/limb_icon_cache = list()
 				should_apply_transparency = TRUE
 			else
 				//Use digi icon if digitigrade, otherwise use regular icon. Ternary operator is based.
-				var/datum/species/SP = data.get_species_datum()
-				mob_icon = new /icon(digitigrade ? SP.icodigi : SP.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
+				mob_icon = new /icon(digitigrade ? data.get_species_icodigi() : data.get_species_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 
@@ -180,8 +174,7 @@ var/global/list/limb_icon_cache = list()
 			if(body_hair && islist(h_col) && h_col.len >= 3)
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 				if(!limb_icon_cache[cache_key])
-					var/datum/species/SP = data.get_species_datum()
-					var/icon/I = icon(SP.get_icobase(owner), "[icon_name]_[body_hair]")
+					var/icon/I = icon(data.get_species_icobase(owner), "[icon_name]_[body_hair]")
 					I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 					limb_icon_cache[cache_key] = I
 				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -213,8 +206,7 @@ var/global/list/limb_icon_cache = list()
 		if(body_hair && islist(h_col) && h_col.len >= 3)
 			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 			if(!limb_icon_cache[cache_key])
-				var/datum/species/SP = data.get_species_datum()
-				var/icon/I = icon(SP.get_icobase(owner), "[icon_name]_[body_hair]")
+				var/icon/I = icon(data.get_species_icobase(owner), "[icon_name]_[body_hair]")
 				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -231,8 +223,7 @@ var/global/list/limb_icon_cache = list()
 
 	if(transparent) //VOREStation edit
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
-		var/datum/species/SP = data.get_species_datum()
-		if(SP.get_bodytype(owner) != SPECIES_HUMAN)
+		if(data.get_species_bodytype(owner) != SPECIES_HUMAN)
 			applying.SetIntensity(1) // Unathi, Taj and Skrell have -very- dark base icons. VOREStation edit fixes this and brings the number back to 1
 		else
 			applying.SetIntensity(1) //VOREStation edit to make Prometheans not look like shit with mob coloring.
@@ -249,15 +240,12 @@ var/global/list/limb_icon_cache = list()
 			applying.Blend(rgb(-s_tone,  -s_tone,  -s_tone), ICON_SUBTRACT)
 		icon_cache_key += "_tone_[s_tone]"
 	else if(s_col && s_col.len >= 3)
-		//VOREStation Edit - Support for species.color_mult
-		var/datum/species/SP = data.get_species_datum()
-		if(SP.color_mult)
+		if(data.get_species_color_mult())
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_MULTIPLY)
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_MULTIPLY]"
 		else
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_ADD)
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_ADD]"
-		//VOREStation Edit End
 
 	return applying
 
@@ -291,12 +279,12 @@ var/list/robot_hud_colours = list("#CFCFCF","#AFAFAF","#8F8F8F","#6F6F6F","#4F4F
 		if(!icon_cache_key || !limb_icon_cache[cache_key])
 			limb_icon_cache[cache_key] = icon(get_icon(), null, SOUTH)
 		var/image/temp = image(limb_icon_cache[cache_key])
-		var/datum/species/SP = data.get_species_datum()
 		if((robotic < ORGAN_ROBOT))
 			// Calculate the required colour matrix.
-			var/r = 0.30 * SP.health_hud_intensity
-			var/g = 0.59 * SP.health_hud_intensity
-			var/b = 0.11 * SP.health_hud_intensity
+			var/int = data.get_species_health_hud_intensity()
+			var/r = 0.30 * int
+			var/g = 0.59 * int
+			var/b = 0.11 * int
 			temp.color = list(r, r, r, g, g, g, b, b, b)
 		else if(model)
 			var/datum/robolimb/R = all_robolimbs[model]

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -218,12 +218,9 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/proc/apply_colouration(var/icon/applying)
 
-	if(transparent) //VOREStation edit
+	if(transparent)
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
-		if(data.get_species_bodytype(owner) != SPECIES_HUMAN)
-			applying.SetIntensity(1) // Unathi, Taj and Skrell have -very- dark base icons. VOREStation edit fixes this and brings the number back to 1
-		else
-			applying.SetIntensity(1) //VOREStation edit to make Prometheans not look like shit with mob coloring.
+		applying.SetIntensity(1)
 
 	else if(status & ORGAN_DEAD)
 		icon_cache_key += "_dead"

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -38,11 +38,11 @@ var/global/list/limb_icon_cache = list()
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skin_tone) && !(franchise && franchise.skin_color))
 			return
-	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.appearance_flags & HAS_SKIN_TONE))
-		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
+	if(!isnull(data.skin_tone) && (species.appearance_flags & HAS_SKIN_TONE))
+		s_tone = data.skin_tone
 	if(species.appearance_flags & HAS_SKIN_COLOR)
-		s_col = list(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
-	h_col = list(dna.GetUIValue(DNA_UI_HAIR_R),dna.GetUIValue(DNA_UI_HAIR_G),dna.GetUIValue(DNA_UI_HAIR_B))
+		s_col = data.skin_color.Copy()
+	h_col = data.hair_color.Copy()
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/human)
 	..()
@@ -89,8 +89,8 @@ var/global/list/limb_icon_cache = list()
 	var/check_digi = istype(src,/obj/item/organ/external/leg) || istype(src,/obj/item/organ/external/foot)
 	if(owner)
 		digitigrade = check_digi && owner.digitigrade
-	else if(dna)
-		digitigrade = check_digi && dna.digitigrade
+	else if(data)
+		digitigrade = check_digi && data.digitigrade
 
 	for(var/M in markings)
 		if (!markings[M]["on"])
@@ -132,14 +132,14 @@ var/global/list/limb_icon_cache = list()
 	if(force_icon)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")
 	else
-		if(!dna)
+		if(!data)
 			mob_icon = new /icon('icons/mob/human_races/r_human.dmi', "[icon_name][gendered_icon ? "_[gender]" : ""]")
 		else
 
 			if(!gendered_icon)
 				gender = null
 			else
-				if(dna.GetUIState(DNA_UI_GENDER))
+				if(data.body_gender)
 					gender = "f"
 				else
 					gender = "m"

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -124,10 +124,7 @@ var/global/list/limb_icon_cache = list()
 
 	var/should_apply_transparency = FALSE
 
-	if(!force_icon_key)
 		icon_cache_key = "[icon_name]_[data.get_species_bodytype(owner)]"
-	else
-		icon_cache_key = "[icon_name]_[force_icon_key]"
 
 	if(force_icon)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -22,7 +22,7 @@ var/global/list/limb_icon_cache = list()
 			if(human.synth_color)
 				s_col = list(human.r_synth, human.g_synth, human.b_synth)
 			return
-	if(species && human.species && species.name != human.species.name)
+	if(data.species && human.species && data.species.name != human.species.name)
 		return
 	if(!isnull(human.s_tone) && (human.species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = human.s_tone
@@ -38,9 +38,9 @@ var/global/list/limb_icon_cache = list()
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skin_tone) && !(franchise && franchise.skin_color))
 			return
-	if(!isnull(data.skin_tone) && (species.appearance_flags & HAS_SKIN_TONE))
+	if(!isnull(data.skin_tone) && (data.species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = data.skin_tone
-	if(species.appearance_flags & HAS_SKIN_COLOR)
+	if(data.species.appearance_flags & HAS_SKIN_COLOR)
 		s_col = data.skin_color.Copy()
 	h_col = data.hair_color.Copy()
 
@@ -56,7 +56,7 @@ var/global/list/limb_icon_cache = list()
 	//Facial hair
 	if(owner.f_style)
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype(owner) in facial_hair_style.species_allowed))
+		if(facial_hair_style && facial_hair_style.species_allowed && (data.species.get_bodytype(owner) in facial_hair_style.species_allowed))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			if(facial_hair_style.do_colouration)
 				facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), facial_hair_style.color_blend_mode)
@@ -69,7 +69,7 @@ var/global/list/limb_icon_cache = list()
 		if(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR))
 			if(!(hair_style.flags & HAIR_VERY_SHORT))
 				hair_style = hair_styles_list["Short Hair"]
-		if(hair_style && (species.get_bodytype(owner) in hair_style.species_allowed))
+		if(hair_style && (data.species.get_bodytype(owner) in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			var/icon/hair_s_add = new/icon("icon" = hair_style.icon_add, "icon_state" = "[hair_style.icon_state]_s")
 			if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
@@ -125,7 +125,7 @@ var/global/list/limb_icon_cache = list()
 	var/should_apply_transparency = FALSE
 
 	if(!force_icon_key)
-		icon_cache_key = "[icon_name]_[species ? species.get_bodytype() : SPECIES_HUMAN]" //VOREStation Edit
+		icon_cache_key = "[icon_name]_[data.species ? data.species.get_bodytype() : SPECIES_HUMAN]" //VOREStation Edit
 	else
 		icon_cache_key = "[icon_name]_[force_icon_key]"
 
@@ -155,7 +155,7 @@ var/global/list/limb_icon_cache = list()
 				should_apply_transparency = TRUE
 			else
 				//Use digi icon if digitigrade, otherwise use regular icon. Ternary operator is based.
-				mob_icon = new /icon(digitigrade ? species.icodigi : species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
+				mob_icon = new /icon(digitigrade ? data.species.icodigi : data.species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 
@@ -174,7 +174,7 @@ var/global/list/limb_icon_cache = list()
 			if(body_hair && islist(h_col) && h_col.len >= 3)
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 				if(!limb_icon_cache[cache_key])
-					var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
+					var/icon/I = icon(data.species.get_icobase(owner), "[icon_name]_[body_hair]")
 					I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 					limb_icon_cache[cache_key] = I
 				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -206,7 +206,7 @@ var/global/list/limb_icon_cache = list()
 		if(body_hair && islist(h_col) && h_col.len >= 3)
 			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 			if(!limb_icon_cache[cache_key])
-				var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
+				var/icon/I = icon(data.species.get_icobase(owner), "[icon_name]_[body_hair]")
 				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -223,7 +223,7 @@ var/global/list/limb_icon_cache = list()
 
 	if(transparent) //VOREStation edit
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
-		if(species && species.get_bodytype(owner) != SPECIES_HUMAN)
+		if(data.species && data.species.get_bodytype(owner) != SPECIES_HUMAN)
 			applying.SetIntensity(1) // Unathi, Taj and Skrell have -very- dark base icons. VOREStation edit fixes this and brings the number back to 1
 		else
 			applying.SetIntensity(1) //VOREStation edit to make Prometheans not look like shit with mob coloring.
@@ -241,7 +241,7 @@ var/global/list/limb_icon_cache = list()
 		icon_cache_key += "_tone_[s_tone]"
 	else if(s_col && s_col.len >= 3)
 		//VOREStation Edit - Support for species.color_mult
-		if(species && species.color_mult)
+		if(data.species && data.species.color_mult)
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_MULTIPLY)
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_MULTIPLY]"
 		else
@@ -281,11 +281,11 @@ var/list/robot_hud_colours = list("#CFCFCF","#AFAFAF","#8F8F8F","#6F6F6F","#4F4F
 		if(!icon_cache_key || !limb_icon_cache[cache_key])
 			limb_icon_cache[cache_key] = icon(get_icon(), null, SOUTH)
 		var/image/temp = image(limb_icon_cache[cache_key])
-		if((robotic < ORGAN_ROBOT) && species)
+		if((robotic < ORGAN_ROBOT) && data.species)
 			// Calculate the required colour matrix.
-			var/r = 0.30 * species.health_hud_intensity
-			var/g = 0.59 * species.health_hud_intensity
-			var/b = 0.11 * species.health_hud_intensity
+			var/r = 0.30 * data.species.health_hud_intensity
+			var/g = 0.59 * data.species.health_hud_intensity
+			var/b = 0.11 * data.species.health_hud_intensity
 			temp.color = list(r, r, r, g, g, g, b, b, b)
 		else if(model)
 			var/datum/robolimb/R = all_robolimbs[model]

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -124,7 +124,7 @@ var/global/list/limb_icon_cache = list()
 
 	var/should_apply_transparency = FALSE
 
-		icon_cache_key = "[icon_name]_[data.get_species_bodytype(owner)]"
+	icon_cache_key = "[icon_name]_[data.get_species_bodytype(owner)]"
 
 	if(force_icon)
 		mob_icon = new /icon(force_icon, "[icon_name][gendered_icon ? "_[gender]" : ""]")

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -22,7 +22,8 @@ var/global/list/limb_icon_cache = list()
 			if(human.synth_color)
 				s_col = list(human.r_synth, human.g_synth, human.b_synth)
 			return
-	if(data.species && human.species && data.species.name != human.species.name)
+	var/datum/species/SP = data.get_species_datum()
+	if(human.species && SP.name != human.species.name)
 		return
 	if(!isnull(human.s_tone) && (human.species.appearance_flags & HAS_SKIN_TONE))
 		s_tone = human.s_tone
@@ -38,9 +39,10 @@ var/global/list/limb_icon_cache = list()
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skin_tone) && !(franchise && franchise.skin_color))
 			return
-	if(!isnull(data.skin_tone) && (data.species.appearance_flags & HAS_SKIN_TONE))
+	var/datum/species/SP = data.get_species_datum()
+	if(!isnull(data.skin_tone) && (SP.appearance_flags & HAS_SKIN_TONE))
 		s_tone = data.skin_tone
-	if(data.species.appearance_flags & HAS_SKIN_COLOR)
+	if(SP.appearance_flags & HAS_SKIN_COLOR)
 		s_col = data.skin_color.Copy()
 	h_col = data.hair_color.Copy()
 
@@ -55,8 +57,9 @@ var/global/list/limb_icon_cache = list()
 	var/image/res = image('icons/mob/human_face.dmi',"bald_s")
 	//Facial hair
 	if(owner.f_style)
+		var/datum/species/SP = data.get_species_datum()
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
-		if(facial_hair_style && facial_hair_style.species_allowed && (data.species.get_bodytype(owner) in facial_hair_style.species_allowed))
+		if(facial_hair_style && facial_hair_style.species_allowed && (SP.get_bodytype(owner) in facial_hair_style.species_allowed))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			if(facial_hair_style.do_colouration)
 				facial_s.Blend(rgb(owner.r_facial, owner.g_facial, owner.b_facial), facial_hair_style.color_blend_mode)
@@ -69,7 +72,8 @@ var/global/list/limb_icon_cache = list()
 		if(owner.head && (owner.head.flags_inv & BLOCKHEADHAIR))
 			if(!(hair_style.flags & HAIR_VERY_SHORT))
 				hair_style = hair_styles_list["Short Hair"]
-		if(hair_style && (data.species.get_bodytype(owner) in hair_style.species_allowed))
+		var/datum/species/SP = data.get_species_datum()
+		if(hair_style && (SP.get_bodytype(owner) in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			var/icon/hair_s_add = new/icon("icon" = hair_style.icon_add, "icon_state" = "[hair_style.icon_state]_s")
 			if(hair_style.do_colouration && islist(h_col) && h_col.len >= 3)
@@ -125,7 +129,8 @@ var/global/list/limb_icon_cache = list()
 	var/should_apply_transparency = FALSE
 
 	if(!force_icon_key)
-		icon_cache_key = "[icon_name]_[data.species ? data.species.get_bodytype() : SPECIES_HUMAN]" //VOREStation Edit
+		var/datum/species/SP = data.get_species_datum()
+		icon_cache_key = "[icon_name]_[SP.get_bodytype()]" //VOREStation Edit
 	else
 		icon_cache_key = "[icon_name]_[force_icon_key]"
 
@@ -155,7 +160,8 @@ var/global/list/limb_icon_cache = list()
 				should_apply_transparency = TRUE
 			else
 				//Use digi icon if digitigrade, otherwise use regular icon. Ternary operator is based.
-				mob_icon = new /icon(digitigrade ? data.species.icodigi : data.species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
+				var/datum/species/SP = data.get_species_datum()
+				mob_icon = new /icon(digitigrade ? SP.icodigi : SP.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
 				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 
@@ -174,7 +180,8 @@ var/global/list/limb_icon_cache = list()
 			if(body_hair && islist(h_col) && h_col.len >= 3)
 				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 				if(!limb_icon_cache[cache_key])
-					var/icon/I = icon(data.species.get_icobase(owner), "[icon_name]_[body_hair]")
+					var/datum/species/SP = data.get_species_datum()
+					var/icon/I = icon(SP.get_icobase(owner), "[icon_name]_[body_hair]")
 					I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 					limb_icon_cache[cache_key] = I
 				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -206,7 +213,8 @@ var/global/list/limb_icon_cache = list()
 		if(body_hair && islist(h_col) && h_col.len >= 3)
 			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 			if(!limb_icon_cache[cache_key])
-				var/icon/I = icon(data.species.get_icobase(owner), "[icon_name]_[body_hair]")
+				var/datum/species/SP = data.get_species_datum()
+				var/icon/I = icon(SP.get_icobase(owner), "[icon_name]_[body_hair]")
 				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
@@ -223,7 +231,8 @@ var/global/list/limb_icon_cache = list()
 
 	if(transparent) //VOREStation edit
 		applying.MapColors("#4D4D4D","#969696","#1C1C1C", "#000000")
-		if(data.species && data.species.get_bodytype(owner) != SPECIES_HUMAN)
+		var/datum/species/SP = data.get_species_datum()
+		if(SP.get_bodytype(owner) != SPECIES_HUMAN)
 			applying.SetIntensity(1) // Unathi, Taj and Skrell have -very- dark base icons. VOREStation edit fixes this and brings the number back to 1
 		else
 			applying.SetIntensity(1) //VOREStation edit to make Prometheans not look like shit with mob coloring.
@@ -241,7 +250,8 @@ var/global/list/limb_icon_cache = list()
 		icon_cache_key += "_tone_[s_tone]"
 	else if(s_col && s_col.len >= 3)
 		//VOREStation Edit - Support for species.color_mult
-		if(data.species && data.species.color_mult)
+		var/datum/species/SP = data.get_species_datum()
+		if(SP.color_mult)
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_MULTIPLY)
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_MULTIPLY]"
 		else
@@ -281,11 +291,12 @@ var/list/robot_hud_colours = list("#CFCFCF","#AFAFAF","#8F8F8F","#6F6F6F","#4F4F
 		if(!icon_cache_key || !limb_icon_cache[cache_key])
 			limb_icon_cache[cache_key] = icon(get_icon(), null, SOUTH)
 		var/image/temp = image(limb_icon_cache[cache_key])
-		if((robotic < ORGAN_ROBOT) && data.species)
+		var/datum/species/SP = data.get_species_datum()
+		if((robotic < ORGAN_ROBOT))
 			// Calculate the required colour matrix.
-			var/r = 0.30 * data.species.health_hud_intensity
-			var/g = 0.59 * data.species.health_hud_intensity
-			var/b = 0.11 * data.species.health_hud_intensity
+			var/r = 0.30 * SP.health_hud_intensity
+			var/g = 0.59 * SP.health_hud_intensity
+			var/b = 0.11 * SP.health_hud_intensity
 			temp.color = list(r, r, r, g, g, g, b, b, b)
 		else if(model)
 			var/datum/robolimb/R = all_robolimbs[model]

--- a/code/modules/organs/subtypes/seromi.dm
+++ b/code/modules/organs/subtypes/seromi.dm
@@ -1,8 +1,0 @@
-/obj/item/organ/external/foot/seromi
-	//body_hair = "feathers" //TESHARI TEMPORARY REMOVAL
-/obj/item/organ/external/foot/right/seromi
-	//body_hair = "feathers" //TESHARI TEMPORARY REMOVAL
-/obj/item/organ/external/hand/seromi
-	//body_hair = "feathers" //TESHARI TEMPORARY REMOVAL
-/obj/item/organ/external/hand/right/seromi
-	//body_hair = "feathers" //TESHARI TEMPORARY REMOVAL

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -389,8 +389,7 @@
 			icon_cache_key += "[eye_icon]"
 
 	//Lip color/icon
-	var/datum/species/SP = data.get_species_datum()
-	if(owner.lip_style && (SP.appearance_flags & HAS_LIPS))
+	if(owner.lip_style && (data.get_species_appearance_flags() & HAS_LIPS))
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		add_overlay(lip_icon)
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -389,7 +389,7 @@
 			icon_cache_key += "[eye_icon]"
 
 	//Lip color/icon
-	if(owner.lip_style && (species && (species.appearance_flags & HAS_LIPS)))
+	if(owner.lip_style && (data.species && (data.species.appearance_flags & HAS_LIPS)))
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		add_overlay(lip_icon)
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -389,7 +389,8 @@
 			icon_cache_key += "[eye_icon]"
 
 	//Lip color/icon
-	if(owner.lip_style && (data.species && (data.species.appearance_flags & HAS_LIPS)))
+	var/datum/species/SP = data.get_species_datum()
+	if(owner.lip_style && (SP.appearance_flags & HAS_LIPS))
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		add_overlay(lip_icon)
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)

--- a/code/modules/organs/subtypes/xenos.dm
+++ b/code/modules/organs/subtypes/xenos.dm
@@ -154,72 +154,61 @@
 /obj/item/organ/external/chest/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
-	thick_skin = TRUE
 
 /obj/item/organ/external/groin/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/arm/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/arm/right/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/leg/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/leg/right/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/foot/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/foot/right/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/hand/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/hand/right/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
 	stapled_nerves = TRUE
 	encased = TRUE
-	thick_skin = TRUE
 
 /obj/item/organ/external/head/unseverable/xeno
 	cannot_gib = 1
 	cannot_amputate = 1
-	thick_skin = TRUE
 	eye_icon = "blank_eyes"

--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -21,11 +21,11 @@
 				manf = manf.species_alternates[prosfab.species]
 
 			if(!prosfab.species || (prosfab.species in manf.species_cannot_use))	// Fabricator ensures the manufacturer can make parts for the species we're set to.
-				O.species = GLOB.all_species["[manf.suggested_species]"]
+				O.data.setup_from_species(GLOB.all_species["[manf.suggested_species]"])
 			else
-				O.species = GLOB.all_species[prosfab.species]
+				O.data.setup_from_species(GLOB.all_species[prosfab.species])
 		else
-			O.species = GLOB.all_species["Human"]
+			O.data.setup_from_species(GLOB.all_species["Human"])
 		O.robotize(prosfab.manufacturer)
 		return O
 	return ..()
@@ -57,7 +57,7 @@
 				EO.remove_rejuv()
 
 		for(var/obj/item/organ/external/O in H.organs)
-			O.species = GLOB.all_species[newspecies]
+			O.data.setup_from_species(GLOB.all_species[newspecies])
 
 			if(!(O.organ_tag in manf.parts))	// Make sure we're using an actually present icon.
 				manf = all_robolimbs["Unbranded"]

--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -27,9 +27,6 @@
 		else
 			O.species = GLOB.all_species["Human"]
 		O.robotize(prosfab.manufacturer)
-		qdel_swap(O.dna, new/datum/dna()) //Uuughhhh... why do I have to do this?
-		O.dna.ResetUI()
-		O.dna.ResetSE()
 		return O
 	return ..()
 
@@ -66,9 +63,7 @@
 				manf = all_robolimbs["Unbranded"]
 
 			O.robotize(manf.company)
-			qdel_swap(O.dna, new/datum/dna())
-			O.dna.ResetUI()
-			O.dna.ResetSE()
+			O.data.setup_from_dna()
 
 			// Skincolor weirdness.
 			O.s_col[1] = 0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3655,6 +3655,7 @@
 #include "code\modules\nifsoft\software\14_commlink.dm"
 #include "code\modules\nifsoft\software\15_misc.dm"
 #include "code\modules\organs\blood.dm"
+#include "code\modules\organs\data.dm"
 #include "code\modules\organs\misc.dm"
 #include "code\modules\organs\organ.dm"
 #include "code\modules\organs\organ_external.dm"


### PR DESCRIPTION
## About The Pull Request
In a prior change dna was cloned per organ to avoid the GC locking up from multiple hardrefs to the same dna datum. However, cloning the full dna datum is very costly, and caused substantial lag on character spawn.

## Changelog
Organs have been altered to use an organ_data datum, with all the dna entries that they actually use, instead of a full dna or species datum copy. While I cannot fully achieve what I wanted to with species, the current code is still functional. I would require a full recode of transforming species to achieve the function I want. 

Organ references to original species have been moved to weakrefs, and cache their data if the species datum is ever deleted. This is to prevent any future work on deleting hanging species datums, though they are currently not deleted at all, and are a memory leak. Deleting them is currently too dangerous due to mixed global and local species datums.

This also makes tracking bugs slightly less confusing, as there is no longer a dna datum in every organ. So finding errors where "they're entire dna was deleted" only to learn it was their hand's dna that was deleted... Should be easier from the outset, as the datums are entirely different.

:cl:
qol: spawning carbon mobs is less laggy
refactor: dna datum cloning per organ removed in favor of a organ_data datum
/:cl:
