### PR TITLE
Allow engineers and chief engineers (not atmos techs) to see wire desc

### DIFF
--- a/code/__defines/traits.dm
+++ b/code/__defines/traits.dm
@@ -7,6 +7,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_BLIND 			"blind"
 */
 #define TRAIT_MUTE				"mute"
+#define TRAIT_CAN_SEE_WIRES		"wire_seerr"
 /*
 #define TRAIT_EMOTEMUTE			"emotemute"
 #define TRAIT_DEAF				"deaf"

--- a/code/__defines/traits/sources.dm
+++ b/code/__defines/traits/sources.dm
@@ -5,5 +5,3 @@
 // #define ROUNDSTART_TRAIT "roundstart"
 /// This trait comes from when a mob is currently typing.
 #define CURRENTLY_TYPING_TRAIT "currently_typing"
-
-#define JOB_TRAIT "job"

--- a/code/__defines/traits/sources.dm
+++ b/code/__defines/traits/sources.dm
@@ -5,3 +5,5 @@
 // #define ROUNDSTART_TRAIT "roundstart"
 /// This trait comes from when a mob is currently typing.
 #define CURRENTLY_TYPING_TRAIT "currently_typing"
+
+#define JOB_TRAIT "job"

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -227,6 +227,10 @@
 	var/obj/item/I = user.get_active_hand()
 	if(istype(I, /obj/item/multitool/alien))
 		return TRUE
+	if(HAS_TRAIT(user, TRAIT_CAN_SEE_WIRES))
+		return TRUE
+	if(user.mind && HAS_TRAIT(user.mind, TRAIT_CAN_SEE_WIRES))
+		return TRUE
 	return FALSE
 
 /**

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -21,6 +21,8 @@
 	var/list/colors
 	/// An associative list of signalers attached to the wires. The wire color is the key, and the signaler object reference is the value.
 	var/list/assemblies
+	/// Admin var to disable seeing wire descriptions
+	var/force_hide_wires = FALSE
 
 /datum/wires/New(atom/_holder)
 	..()
@@ -224,6 +226,8 @@
 	// TODO: Reimplement this if we ever get Advanced Admin Interaction.
 	// if(user.can_admin_interact())
 		// return TRUE
+	if(force_hide_wires)
+		return FALSE
 	var/obj/item/I = user.get_active_hand()
 	if(istype(I, /obj/item/multitool/alien))
 		return TRUE

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -46,6 +46,12 @@
 /datum/job/chief_engineer/get_request_reasons()
 	return list("Engine setup", "Construction project", "Repairs necessary", "Training crew", "Assembling expedition team")
 
+/datum/job/chief_engineer/equip(mob/living/carbon/human/H, alt_title)
+	. = ..()
+	ADD_TRAIT(H, TRAIT_CAN_SEE_WIRES, JOB_TRAIT)
+	if(H.mind)
+		ADD_TRAIT(H.mind, TRAIT_CAN_SEE_WIRES, JOB_TRAIT)
+
 /datum/alt_title/head_engineer
 	title = JOB_ALT_HEAD_ENGINEER
 
@@ -85,6 +91,12 @@
 
 /datum/job/engineer/get_request_reasons()
 	return list("Engine setup", "Construction project", "Repairs necessary", "Assembling expedition team")
+
+/datum/job/engineer/equip(mob/living/carbon/human/H, alt_title)
+	. = ..()
+	ADD_TRAIT(H, TRAIT_CAN_SEE_WIRES, JOB_TRAIT)
+	if(H.mind)
+		ADD_TRAIT(H.mind, TRAIT_CAN_SEE_WIRES, JOB_TRAIT)
 
 // Engineer Alt Titles
 /datum/alt_title/maint_tech


### PR DESCRIPTION
## About The Pull Request

Gives the alien multitool ability to see wires to CE and regular engineers intrinsically.

![https://i.tigercat2000.net/2025/04/io8OMI7Siw.png](https://i.tigercat2000.net/2025/04/io8OMI7Siw.png)

## Changelog
:cl:
add : Chief Engineer and regular Engineers (not atmos techs) can now see a description of what each wire in a wire UI does.
/:cl:
