### PR TITLE
Makes FBP not go blind from welders

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -10,7 +10,10 @@
 /obj/item/organ/internal/eyes/robotize()
 	..()
 	name = "optical sensor"
+	innate_flash_protection = FLASH_PROTECTION_MAJOR
 	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
+	organ_verbs = list(/obj/item/organ/internal/eyes/proc/change_eye_color)
+	handle_organ_mod_special()
 
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
See title.
Also makes it so the eye color verb is actually attached to the eyes.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: FBPs will no longer go blind when a welder is used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
