### PR TITLE
Moves the medical kiosk in SD medbay lobby

### DIFF
--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -5726,9 +5726,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/engineering/engine_room)
 "lW" = (
-/obj/machinery/medical_kiosk{
-	pixel_y = 6
-	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/reception)
 "lX" = (
@@ -19285,11 +19283,13 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/stellardelight/deck2/triage)
 "Qq" = (
-/obj/structure/bed/chair,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/medical_kiosk{
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/reception)
 "Qr" = (


### PR DESCRIPTION

## About The Pull Request

Very minor change. Moved the medical kiosk from the west side of the medbay lobby over to the east corner, near chemistry. This positioning of the kiosk created a single turf bottleneck in the lobby, which was regularly traversed, especially in medical emergencies.

## Changelog
:cl:
maptweak: Moved the medical kiosk from the west side of the medbay lobby over to the east corner, near chemistry. 
/:cl:
