### PR TITLE
moving eye layer behind vorebellies

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1002,6 +1002,12 @@
 
 	if(stat == CONSCIOUS)
 		update_fullness()
+		if(sprite_datum.has_eye_sprites)
+			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.
+				var/eyes_overlay = sprite_datum.get_eyes_overlay(src)
+				if(eyes_overlay)
+					add_overlay(eyes_overlay)
+
 		for(var/belly_class in vore_fullness_ex)
 			reset_belly_lights(belly_class)
 			var/vs_fullness = vore_fullness_ex[belly_class]
@@ -1039,11 +1045,7 @@
 
 		if(resting && sprite_datum.has_rest_sprites)
 			icon_state = sprite_datum.get_rest_sprite(src)
-		if(sprite_datum.has_eye_sprites)
-			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.
-				var/eyes_overlay = sprite_datum.get_eyes_overlay(src)
-				if(eyes_overlay)
-					add_overlay(eyes_overlay)
+		//moved eyes from here
 
 		if(lights_on && sprite_datum.has_eye_light_sprites)
 			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1045,7 +1045,6 @@
 
 		if(resting && sprite_datum.has_rest_sprites)
 			icon_state = sprite_datum.get_rest_sprite(src)
-		//moved eyes from here
 
 		if(lights_on && sprite_datum.has_eye_light_sprites)
 			if(!shell || deployed) // Shell borgs that are not deployed will have no eyes.


### PR DESCRIPTION
## About The Pull Request
![Screenshot 2025-04-09 160418](https://github.com/user-attachments/assets/ec25a77a-a504-46f2-8ba4-1a9e07796851)
![Screenshot 2025-04-09 161506](https://github.com/user-attachments/assets/15eca126-a22d-43c0-ba3c-29724ae34d4b)
before and after pics.


Moving the eyelayer in code to load behind vorebellies so big bellies cover eye lights. (these show the shell is online but bad in this case)
:cl:
change: moves eye layer under bellies for borgs
/:cl:
