### PR TITLE
Makes IDs trash eater-able

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -244,7 +244,8 @@ var/global/list/edible_trash = list(/obj/item/broken_device,
 				/obj/item/entrepreneur,
 				/obj/item/capture_crystal,
 				/obj/item/roulette_ball,
-				/obj/item/pizzabox
+				/obj/item/pizzabox,
+				/obj/item/card/id
 				)
 
 var/global/list/contamination_flavors = list(

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -57,18 +57,41 @@
 		if(!watching)
 			return FALSE
 		else
-			visible_message(span_warning("[user] is threatening to make [src] disappear!"))
+			user.visible_message(span_warning("[user] is threatening to make [src] disappear!"))
 			if(id)
 				var/confirm = tgui_alert(user, "The PDA you're holding contains a vulnerable ID card. Will you risk it?", "Confirmation", list("Definitely", "Cancel"))
 				if(confirm != "Definitely")
 					return FALSE
 			if(!do_after(user, 100, src))
 				return FALSE
-			visible_message(span_warning("[user] successfully makes [src] disappear!"))
+			user.visible_message(span_warning("[user] successfully makes [src] disappear!"))
 	return TRUE
 
 /obj/item/pda/after_trash_eaten(var/mob/living/user)
 	to_chat(user, span_notice("You can taste the sweet flavor of delicious technology."))
+
+// ID
+
+/obj/item/card/id/on_trash_eaten(var/mob/living/user)
+	if(!..())
+		return FALSE
+	if(registered_name)
+		var/watching = FALSE
+		for(var/mob/living/carbon/human/H in view(user))
+			if(H.real_name == registered_name && H.client)
+				watching = TRUE
+				break
+		if(!watching)
+			return FALSE
+		else
+			user.visible_message(span_warning("[user] is threatening to make [src] disappear!"))
+			if(!do_after(user, 100, src))
+				return FALSE
+			user.visible_message(span_warning("[user] successfully makes [src] disappear!"))
+	return TRUE
+
+/obj/item/card/id/after_trash_eaten(var/mob/living/user)
+	to_chat(user, span_notice("You can taste the delicious flavour of a person's whole identity."))
 
 // Shoes
 /obj/item/clothing/shoes/on_trash_eaten(var/mob/living/user)


### PR DESCRIPTION

## About The Pull Request

Added IDs to the list of edible trash eater items. Just like PDA's they require the owner to be watching when they're eaten. Seeing as they are edible inside of PDAs anyway, should just allow them to be eaten in the same way, because it's hot. 

Fixed PDA eating warning messages not being visible.

## Changelog
:cl:
add: Added IDs to the list of edible trash eater items. Just like PDA's they require the owner to be watching when they're eaten.
fix: Fixed PDA eating warning messages not being visible.
/:cl:
