### PR TITLE
Nuclear Warfare [WIP]

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -23,6 +23,13 @@
 	var/del_on_map_removal = TRUE
 
 /**
+ * Ending cinematic for when the game is ending (or is doing a 'normally round ending' cinematic)
+ * We have a list of watchers so we can remove ourself from them after we're done!
+ */
+/obj/screen/game_end
+	var/mob/living/watchers = list()
+
+/**
  * A screen object, which acts as a container for turfs and other things
  * you want to show on the map, which you usually attach to "vis_contents".
  */

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -310,7 +310,8 @@ var/global/datum/controller/subsystem/ticker/ticker
 	cinematic.mouse_opacity = 0
 	cinematic.screen_loc = "1,0"
 
-	var/obj/structure/bed/temp_buckle = new(src)
+	var/obj/structure/bed/chair/temp_buckle = new(src)
+	temp_buckle.dir = 2 //face South.
 	LAZYINITLIST(temp_buckle.buckled_mobs)
 	//Incredibly hackish. It creates a bed within the gameticker (lol) to stop mobs running around
 	if(station_missed) //0 = Station was directly hit. 1 = Bomb was on borders of the map (glancing blow) 2 = Bomb missed station entirely.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -30,6 +30,7 @@ var/global/list/additional_antag_types = list()
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
 
 	var/station_was_nuked = 0                // See nuclearbomb.dm and malfunction.dm.
+	var/nuke_off_station = FALSE			 //Used for tracking if the syndies actually haul the nuke to the station
 	var/explosion_in_progress = 0            // Sit back and relax
 	var/waittime_l = 600                     // Lower bound on time before intercept arrives (in tenths of seconds)
 	var/waittime_h = 1800                    // Upper bound on time before intercept arrives (in tenths of seconds)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -30,8 +30,9 @@ var/global/list/additional_antag_types = list()
 	var/require_all_templates = 0            // Will only start if all templates are checked and can spawn.
 
 	var/station_was_nuked = 0                // See nuclearbomb.dm and malfunction.dm.
-	var/nuke_off_station = FALSE			 //Used for tracking if the syndies actually haul the nuke to the station
+	var/nuke_off_station = FALSE			 // Used for tracking if the syndies actually haul the nuke to the station
 	var/explosion_in_progress = 0            // Sit back and relax
+	var/syndies_didnt_escape = 0			 // Used for tracking if the syndies got the shuttle off of the z-level
 	var/waittime_l = 600                     // Lower bound on time before intercept arrives (in tenths of seconds)
 	var/waittime_h = 1800                    // Upper bound on time before intercept arrives (in tenths of seconds)
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -16,7 +16,6 @@ var/list/nuke_disks = list()
 	required_players_secret = 12
 	required_enemies = 3
 	end_on_antag_death = 0
-	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 	antag_tags = list(MODE_MERCENARY)
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -16,7 +16,6 @@ var/list/nuke_disks = list()
 	required_players_secret = 12
 	required_enemies = 3
 	end_on_antag_death = 0
-	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 	antag_tags = list(MODE_MERCENARY)
 
 //delete all nuke disks not on a station zlevel

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -391,7 +391,7 @@ var/bomb_set
 			if(syndie_location)
 				ticker.mode:syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
 			ticker.mode:nuke_off_station = off_station
-		ticker.station_explosion_cinematic(off_station,null)
+		ticker.station_explosion_cinematic(off_station,null, src)
 		if(ticker.mode)
 			ticker.mode.explosion_in_progress = 0
 			switch(off_station)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -361,8 +361,6 @@ var/bomb_set
 /obj/machinery/nuclearbomb/ex_act(severity)
 	return
 
-
-#define NUKERANGE 80
 /obj/machinery/nuclearbomb/proc/explode()
 	if(safety)
 		timing = 0
@@ -372,7 +370,7 @@ var/bomb_set
 	safety = 1
 	if(!lighthack)
 		icon_state = "nuclearbomb3"
-	playsound(src,'sound/machines/Alarm.ogg',100,0,5)
+	playsound(src,'sound/machines/Alarm.ogg',100,0,5, is_global = 2, pressure_affected = FALSE) //EVERYONE gets to hear it.
 	if(ticker && ticker.mode)
 		ticker.mode.explosion_in_progress = 1
 	sleep(100)
@@ -380,7 +378,7 @@ var/bomb_set
 	var/off_station = STATION_DIRECT_HIT
 	var/turf/bomb_location = get_turf(src)
 	if(bomb_location && (bomb_location.z in using_map.station_levels))
-		if((bomb_location.x < (128-NUKERANGE)) || (bomb_location.x > (128+NUKERANGE)) || (bomb_location.y < (128-NUKERANGE)) || (bomb_location.y > (128+NUKERANGE)))
+		if((bomb_location.x < 10) || (bomb_location.x > world.maxx-10) || (bomb_location.y < 10) || (bomb_location.y > (world.maxy - 10))) //Putting it on the outskirts of the map.
 			off_station = STATION_GLANCING_BLOW
 	else
 		off_station = STATION_COMPLETELY_MISSED
@@ -389,8 +387,8 @@ var/bomb_set
 		if(ticker.mode && ticker.mode.name == "Mercenary")
 			var/obj/machinery/computer/shuttle_control/multi/syndicate/syndie_location = locate(/obj/machinery/computer/shuttle_control/multi/syndicate)
 			if(syndie_location)
-				ticker.mode:syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
-			ticker.mode:nuke_off_station = off_station
+				ticker.mode.syndies_didnt_escape = (syndie_location.z > 1 ? 0 : 1)	//muskets will make me change this, but it will do for now
+			ticker.mode.nuke_off_station = off_station
 		ticker.station_explosion_cinematic(off_station,null, src)
 		if(ticker.mode)
 			ticker.mode.explosion_in_progress = 0
@@ -419,8 +417,6 @@ var/bomb_set
 				return
 	bomb_set = 0 //Bomb has gone kaboom, let's reset it! If there's another nuke ongoing, it'll set bomb_set to 1 in it's processing tick.
 	return
-
-#undef NUKERANGE
 
 /obj/item/disk/nuclear/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes it so the cinematic unbuckles you after it ends. Makes it so the round doesn't immediately end after the nuclear bomb goes off if it's off station. Makes it so nuclear blast has different text for each explosion type that occurs (Direct hit /  Glancing blow / Missed Entirely)

Makes it so the nuclear blast (if blown off off station) kills everything on that Z level instead just shrugging.

Clears up some of the bugs in the nuclear bomb code (The nuclear alarm is a GLOBAL sound now instead of coming from the nuclear bomb itself)

Makes sound code actually respect global sounds.

Just updating some old code that will probably NEVER see the light of day (I can't recall the last time we actually used a nuke) but this updates the code to be more modernized and not full of bugs.

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
add: You can now nuke singular Z levels
fix: The round will continue after the nuclear bomb goes off if the station was not involved in the nuclear bomb explosion
fix: Things on the Z level that a bomb goes off on will actually die
fix: You will no longer accidentally stop viewing the nuclear bomb cinematic when it explodes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
