### PR TITLE
Fixes a limb augment oversight

### DIFF
--- a/code/modules/organs/internal/augment/armmounted.dm
+++ b/code/modules/organs/internal/augment/armmounted.dm
@@ -108,6 +108,8 @@
 	icon_state = "augment_armframe"
 
 	organ_tag = O_AUG_R_UPPERARM
+	parent_organ = BP_R_ARM
+	target_slot = slot_r_hand
 
 	w_class = ITEMSIZE_HUGE
 
@@ -163,8 +165,6 @@
 	desc = "A large implant that fits into a subject's arm. It deploys an array of tools by some painful means."
 
 	icon_state = "augment_toolkit"
-
-	organ_tag = O_AUG_R_UPPERARM
 
 	w_class = ITEMSIZE_HUGE
 


### PR DESCRIPTION

## About The Pull Request
Fixes an oversight that meant that limbs had to be screwdrivered twice to be attached
## Changelog
:cl: Diana
fix: Shoulder augments can now be installed the first time without having to screwdriver them twice
/:cl:
