### PR TITLE
add Xenoarch access to the SD's EVA shuttle

### DIFF
--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -16384,7 +16384,7 @@
 	dir = 4;
 	door_color = "#525252";
 	name = "EVA Shuttle";
-	req_one_access = list(18,19,43);
+	req_one_access = list(18,19,43,65);
 	stripe_color = "#408f3b"
 	},
 /obj/structure/cable/green{


### PR DESCRIPTION

## About The Pull Request

EVA shuttle used to be explo's (when that was a thing) so they could do stuff on the asteroid without impacting the miners. However it became more broadly just "the shuttle people with EVA or Command access can use" after that removal. With Xenoarch being more of a thing people actually enjoy doing now, giving xenoarch access to the shuttle makes sense. Their lab's still on the aerostat tho so hopefully they keep that in mind.

For anyone curious, only the basic scientist role (and its alt roles) has xenoarch access and no EVA access, and thus is the only role impacted by this change.
## Changelog
:cl:
add: Adds Xenoarch access to the SD's EVA shuttle
/:cl:
