### PR TITLE
Flying/hover/floating doesn't get blood on your shoes.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -84,6 +84,8 @@ var/global/list/image/splatter_cache=list()
 		return
 	if(!istype(perp))
 		return
+	if(perp.flying || perp.hovering || perp.is_floating) //if the perp isn't on the ground, they shouldn't be affected by the stuff on the floor.
+		return
 	if(amount < 1)
 		return
 


### PR DESCRIPTION

## About The Pull Request

Changed blood splatters and subtypes such as oil to no longer interact with someone flying, hovering or floating over them.

## Changelog
:cl:
qol: Changed blood splatters and subtypes such as oil to no longer interact with someone flying, hovering or floating over them.
/:cl:
