### PR TITLE
Ported Autohisses and Autohiss Unit Test

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1524,6 +1524,7 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
 		/datum/trait/neutral/autohiss_vassilian/xenochimera)
@@ -1544,6 +1545,7 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
 		/datum/trait/neutral/autohiss_vassilian/xenochimera)
@@ -1571,6 +1573,7 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_vassilian/xenochimera)

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1675,5 +1675,4 @@
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera,
-		/datum/trait/neutral/autohiss_yingish/xenochimera)
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -71,6 +71,7 @@
 	excludes = list(
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
@@ -89,6 +90,7 @@
 	excludes = list(
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
@@ -114,6 +116,7 @@
 	excludes = list(
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_vassilian,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
@@ -1522,7 +1525,8 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
-		/datum/trait/neutral/autohiss_zaddat/xenochimera)
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 
 /datum/trait/neutral/autohiss_tajaran/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1541,7 +1545,8 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
-		/datum/trait/neutral/autohiss_zaddat/xenochimera)
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 
 /datum/trait/neutral/autohiss_zaddat/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1567,7 +1572,8 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
-		/datum/trait/neutral/autohiss_tajaran/xenochimera)
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 
 /datum/trait/neutral/autohiss_vassilian/xenochimera
 	sort = TRAIT_SORT_SPECIES

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -68,7 +68,13 @@
 			"x" = list("ks", "kss", "ksss")
 		),
 	autohiss_exempt = list(LANGUAGE_UNATHI))
-	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_zaddat)
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 	custom_only = FALSE
 
 /datum/trait/neutral/autohiss_tajaran
@@ -80,7 +86,13 @@
 			"r" = list("rr", "rrr", "rrrr")
 		),
 	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI,LANGUAGE_ALAI))
-	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_zaddat)
+	excludes = list(
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 	custom_only = FALSE
 
 /datum/trait/neutral/autohiss_zaddat
@@ -99,8 +111,38 @@
 			"v" = list("vv", "vvv")
 		),
 	autohiss_exempt = list(LANGUAGE_ZADDAT,LANGUAGE_VESPINAE))
-	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 	custom_only = FALSE
+
+/datum/trait/neutral/autohiss_vassilian
+	name = "Autohiss (Vassilian)"
+	desc = "You buzz your S's, F's, Th's, and R's."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+		"s" = list("sz", "z", "zz"),
+		"f" = list("zk")
+		),
+	autohiss_extra_map = list(
+		"th" = list("zk", "szk"),
+		"r" = list("rk")
+	),
+	autohiss_exempt = list(LANGUAGE_VESPINAE))
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera)
 
 /datum/trait/neutral/bloodsucker
 	name = "Bloodsucker, Obligate"
@@ -1475,7 +1517,12 @@
 			"x" = list("ks", "kss", "ksss")
 		),
 	autohiss_exempt = list("Sinta'unathi"))
-	excludes = list(/datum/trait/neutral/autohiss_tajaran)
+	excludes = list(
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera)
 
 /datum/trait/neutral/autohiss_tajaran/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1489,4 +1536,61 @@
 			"r" = list("rr", "rrr", "rrrr")
 		),
 	autohiss_exempt = list("Siik"))
-	excludes = list(/datum/trait/neutral/autohiss_unathi)
+	excludes = list(
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera)
+
+/datum/trait/neutral/autohiss_zaddat/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Autohiss (Zaddat)"
+	desc = "You buzz your S's and F's."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+			"f" = list("v","vh"),
+			"ph" = list("v", "vh")
+		),
+	autohiss_extra_map = list(
+			"s" = list("z", "zz", "zzz"),
+			"ce" = list("z", "zz"),
+			"ci" = list("z", "zz"),
+			"v" = list("vv", "vvv")
+		),
+	autohiss_exempt = list(LANGUAGE_ZADDAT,LANGUAGE_VESPINAE))
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera)
+
+/datum/trait/neutral/autohiss_vassilian/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Autohiss (Vassilian)"
+	desc = "You buzz your S's, F's, Th's, and R's."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+		"s" = list("sz", "z", "zz"),
+		"f" = list("zk")
+		),
+	autohiss_extra_map = list(
+		"th" = list("zk", "szk"),
+		"r" = list("rk")
+	),
+	autohiss_exempt = list(LANGUAGE_VESPINAE))
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera)

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -55,11 +55,11 @@
 	activation_message="Your body feels chilly."
 	primitive_expression_messages=list("shivers.")
 
-
 /datum/trait/neutral/autohiss_unathi
 	name = "Autohiss (Unathi)"
 	desc = "You roll your S's and x's"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list(
 	autohiss_basic_map = list(
 			"s" = list("ss", "sss", "ssss")
@@ -72,16 +72,18 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
-	custom_only = FALSE
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_tajaran
 	name = "Autohiss (Tajaran)"
 	desc = "You roll your R's."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list(
 	autohiss_basic_map = list(
 			"r" = list("rr", "rrr", "rrrr")
@@ -91,16 +93,18 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
-	custom_only = FALSE
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_zaddat
 	name = "Autohiss (Zaddat)"
 	desc = "You buzz your S's and F's."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list(
 	autohiss_basic_map = list(
 			"f" = list("v","vh"),
@@ -117,11 +121,12 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
-	custom_only = FALSE
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_vassilian
 	name = "Autohiss (Vassilian)"
@@ -142,10 +147,40 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
+
+/datum/trait/neutral/autohiss_yingish
+	name = "Autohiss (Yingish)"
+	desc = "You pronounce th's with a lisp, a bit like zhis!"
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+			"thi" = list("z"),
+			"shi" = list("z"),
+			"tha" = list("z"),
+			"tho" = list("z")
+		),
+	autohiss_extra_map = list(
+			"the" = list("z"),
+			"so" = list("z")
+		),
+	autohiss_exempt = list())
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/bloodsucker
 	name = "Bloodsucker, Obligate"
@@ -1525,9 +1560,11 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_tajaran/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1546,9 +1583,11 @@
 		/datum/trait/neutral/autohiss_tajaran,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_zaddat/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_zaddat/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1574,9 +1613,11 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
-		/datum/trait/neutral/autohiss_vassilian/xenochimera)
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
 
 /datum/trait/neutral/autohiss_vassilian/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -1600,6 +1641,39 @@
 		/datum/trait/neutral/autohiss_unathi,
 		/datum/trait/neutral/autohiss_zaddat,
 		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
 		/datum/trait/neutral/autohiss_unathi/xenochimera,
 		/datum/trait/neutral/autohiss_tajaran/xenochimera,
-		/datum/trait/neutral/autohiss_zaddat/xenochimera)
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)
+
+/datum/trait/neutral/autohiss_yingish/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Autohiss (Yingish)"
+	desc = "You pronounce th's with a lisp, a bit like zhis!"
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+			"thi" = list("z"),
+			"shi" = list("z"),
+			"tha" = list("z"),
+			"tho" = list("z")
+		),
+	autohiss_extra_map = list(
+			"the" = list("z"),
+			"so" = list("z")
+		),
+	autohiss_exempt = list())
+	excludes = list(
+		/datum/trait/neutral/autohiss_tajaran,
+		/datum/trait/neutral/autohiss_unathi,
+		/datum/trait/neutral/autohiss_zaddat,
+		/datum/trait/neutral/autohiss_vassilian,
+		/datum/trait/neutral/autohiss_yingish,
+		/datum/trait/neutral/autohiss_unathi/xenochimera,
+		/datum/trait/neutral/autohiss_tajaran/xenochimera,
+		/datum/trait/neutral/autohiss_zaddat/xenochimera,
+		/datum/trait/neutral/autohiss_vassilian/xenochimera,
+		/datum/trait/neutral/autohiss_yingish/xenochimera)

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -5,10 +5,12 @@
 	var/failed = FALSE
 
 	var/list/hiss_list = list()
-	for(var/datum/trait/T in subtypesof(/datum/trait))
-		if(!islist(T.var_changes["autohiss_basic_map"]))
+	for(var/traitpath in subtypesof(/datum/trait))
+		var/datum/trait/T = GLOB.all_traits[traitpath]
+		// Check if it has a hiss
+		var/list/hiss_list = T.var_changes["autohiss_basic_map"]
+		if(!hiss_list || !hiss_list.len)
 			continue
-		// Has a hiss!
 		hiss_list += T
 
 	for(var/datum/trait/T in hiss_list)

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -23,8 +23,8 @@
 			failed = TRUE
 			continue
 
-		var/list/exempt_list = hiss_list.Copy() - T.type // MUST exclude all others except itself
-		for(var/EX in exempt_list)
+		var/list/exempt_list = hiss_list.Copy() - T // MUST exclude all others except itself
+		for(var/datum/trait/EX in exempt_list)
 			if(!(EX.type in T.excludes))
 				log_unit_test("[T.type]: Trait - Autohiss missing exclusion for [EX].")
 				failed = TRUE

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -18,9 +18,14 @@
 			log_unit_test("[T.type]: Trait - Autohiss excludes itself.")
 			failed = TRUE
 
-		var/list/exempt_list = hiss_list.Copy() - list(T.type) // MUST exclude all others except itself
+		if(!T.excludes)
+			log_unit_test("[T.type]: Trait - Autohiss missing exclusion list.")
+			failed = TRUE
+			continue
+
+		var/list/exempt_list = hiss_list.Copy() - T.type // MUST exclude all others except itself
 		for(var/EX in exempt_list)
-			if(!(EX in T.excludes))
+			if(!(EX.type in T.excludes))
 				log_unit_test("[T.type]: Trait - Autohiss missing exclusion for [EX].")
 				failed = TRUE
 

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -6,7 +6,7 @@
 
 	var/list/hiss_list = list()
 	for(var/datum/trait/T in subtypesof(/datum/trait))
-		if(!islist(!T.var_changes[autohiss_basic_map]))
+		if(!islist(T.var_changes["autohiss_basic_map"]))
 			continue
 		// Has a hiss!
 		hiss_list += T

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -7,7 +7,8 @@
 	var/list/hiss_list = list()
 	for(var/traitpath in GLOB.all_traits)
 		var/datum/trait/T = GLOB.all_traits[traitpath]
-		if(!islist(T.var_changes["autohiss_basic_map"]))
+		var/list/L = T.var_changes["autohiss_basic_map"]
+		if(!L || !islist(L))
 			continue
 		hiss_list += T
 

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -7,8 +7,9 @@
 	var/list/hiss_list = list()
 	for(var/traitpath in GLOB.all_traits)
 		var/datum/trait/T = GLOB.all_traits[traitpath]
-		var/list/L = T.var_changes["autohiss_basic_map"]
-		if(!L || !islist(L))
+		if(!T.var_changes)
+			continue
+		if(!islist(T.var_changes["autohiss_basic_map"]))
 			continue
 		hiss_list += T
 

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -5,9 +5,8 @@
 	var/failed = FALSE
 
 	var/list/hiss_list = list()
-	for(var/traitpath in subtypesof(/datum/trait))
+	for(var/traitpath in GLOB.all_traits)
 		var/datum/trait/T = GLOB.all_traits[traitpath]
-		// Check if it has a hiss
 		if(!islist(T.var_changes["autohiss_basic_map"]))
 			continue
 		hiss_list += T

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -25,5 +25,5 @@
 	if(failed)
 		fail("One or more autohiss traits allow another autohiss to be chosen with it.")
 	else
-		pass("Autohiss traits are exclusive.")
+		pass("All [hiss_list.len] autohiss traits are properly exclusive.")
 	return failed

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -6,7 +6,7 @@
 
 	var/list/hiss_list = list()
 	for(var/datum/trait/T in subtypesof(/datum/trait))
-		if(!islist(!T.var_changes["autohiss_basic_map"]))
+		if(!islist(!T.var_changes[autohiss_basic_map]))
 			continue
 		// Has a hiss!
 		hiss_list += T

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -8,8 +8,7 @@
 	for(var/traitpath in subtypesof(/datum/trait))
 		var/datum/trait/T = GLOB.all_traits[traitpath]
 		// Check if it has a hiss
-		var/list/hiss_list = T.var_changes["autohiss_basic_map"]
-		if(!hiss_list || !hiss_list.len)
+		if(!islist(T.var_changes["autohiss_basic_map"]))
 			continue
 		hiss_list += T
 

--- a/code/unit_tests/authohiss_tests.dm
+++ b/code/unit_tests/authohiss_tests.dm
@@ -1,0 +1,29 @@
+/datum/unit_test/autohiss_shall_be_exclusive
+	name = "TRAITS: Autohiss traits shall be exclusive"
+
+/datum/unit_test/autohiss_shall_be_exclusive/start_test()
+	var/failed = FALSE
+
+	var/list/hiss_list = list()
+	for(var/datum/trait/T in subtypesof(/datum/trait))
+		if(!islist(!T.var_changes["autohiss_basic_map"]))
+			continue
+		// Has a hiss!
+		hiss_list += T
+
+	for(var/datum/trait/T in hiss_list)
+		if(T.type in T.excludes)
+			log_unit_test("[T.type]: Trait - Autohiss excludes itself.")
+			failed = TRUE
+
+		var/list/exempt_list = hiss_list.Copy() - list(T.type) // MUST exclude all others except itself
+		for(var/EX in exempt_list)
+			if(!(EX in T.excludes))
+				log_unit_test("[T.type]: Trait - Autohiss missing exclusion for [EX].")
+				failed = TRUE
+
+	if(failed)
+		fail("One or more autohiss traits allow another autohiss to be chosen with it.")
+	else
+		pass("Autohiss traits are exclusive.")
+	return failed

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4479,6 +4479,7 @@
 #include "code\modules\xenobio\machinery\processor.dm"
 #include "code\modules\xgm\xgm_gas_data.dm"
 #include "code\modules\xgm\xgm_gas_mixture.dm"
+#include "code\unit_tests\authohiss_tests.dm"
 #include "code\unit_tests\clothing_tests.dm"
 #include "code\unit_tests\cosmetic_tests.dm"
 #include "code\unit_tests\decl_tests.dm"


### PR DESCRIPTION
## About The Pull Request
Autohiss traits are exclusive, and only function with a single autohiss per character. This unit test ensures only one autohiss can be applied to a character at a time by forcing complete trait exclusivity lists for each autohiss.

Also adds a mistakenly removed vassilian, and ports outpost 21's yingish autohiss upstream.

## Changelog

Unit test for autohiss exclusivity, ports and adds missing autohisses

:cl:
add: vassilian autohiss
add: yingish autohiss
code: autohiss unit testing
/:cl: