### PR TITLE
Adds colour selection to earrings

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -40,3 +40,4 @@
 	earrings["dangle, platinum"] = /obj/item/clothing/ears/earring/dangle/platinum
 	earrings["dangle, diamond"] = /obj/item/clothing/ears/earring/dangle/diamond
 	gear_tweaks += new/datum/gear_tweak/path(earrings)
+	gear_tweaks += gear_tweak_free_color_choice


### PR DESCRIPTION

## About The Pull Request
So originally this PR was going to touch earrings in a more interesting way and fix up the lipstick. Turns out the lipstick is a cursed abomination and I can't care to break people's loadouts for a minor new feature.
So instead, there you go, now you can colour your earrings and use the name and desc editors to have cool earrings. Just. Don't put them in the dye machine.
## Changelog
:cl:Tost
add: Adds colour selection to earrings

/:cl:
