### PR TITLE
Couple of virology fixes + additions

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -162,6 +162,12 @@ GLOBAL_LIST_INIT(advance_cures, list(
 			AssignName()
 		GLOB.archive_diseases[GetDiseaseID()] = src // So we don't infinite loop
 		GLOB.archive_diseases[GetDiseaseID()] = new /datum/disease/advance(0, src, 1)
+	else
+		var/datum/disease/advance/A = GLOB.archive_diseases[GetDiseaseID()]
+		var/actual_name = A.name
+		if(actual_name != "Unknown")
+			name = actual_name
+
 
 /datum/disease/advance/proc/GenerateProperties()
 	resistance = 0
@@ -286,8 +292,11 @@ GLOBAL_LIST_INIT(advance_cures, list(
 
 // Name the disease.
 /datum/disease/advance/proc/AssignName(new_name = "Unknown")
-	name = new_name
-	return
+	Refresh()
+	var/datum/disease/advance/A = GLOB.archive_diseases[GetDiseaseID()]
+	A.name = new_name
+	for(var/datum/disease/advance/AD in GLOB.active_diseases)
+		AD.Refresh()
 
 // Return a unique ID of the disease.
 /datum/disease/advance/GetDiseaseID()

--- a/code/game/machinery/pandemic.dm
+++ b/code/game/machinery/pandemic.dm
@@ -80,6 +80,8 @@
 			if(!A)
 				atom_say("Unable to find requested strain.")
 				return FALSE
+			print_form(A, ui.user)
+			return TRUE
 		else
 			return FALSE
 

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -139,6 +139,24 @@
 /obj/effect/decal/cleanable/vomit/old/Crossed(mob/living/carbon/human/perp)
 	return // Don't spread our viruses
 
+/obj/effect/decal/cleanable/blood/old
+	dryname = "nasty dried blood"
+	drydesc = "Why hasn't anyone cleaned this up yet?"
+
+/obj/effect/decal/cleanable/blood/old/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
+	basecolor = get_random_colour(rand(0, 1))
+	update_icon()
+	if(length(diseases))
+		viruses += diseases
+	if(prob(75))
+		var/datum/disease/advance/new_disease = new /datum/disease/advance/random(rand(2, 4), rand(7, 9), 4)
+		src.viruses += new_disease
+	dry()
+
+/obj/effect/decal/cleanable/blood/old/Crossed(mob/living/carbon/human/perp)
+	return
+
 /obj/effect/decal/cleanable/tomato_smudge
 	name = "tomato smudge"
 	desc = "It's red."

--- a/code/game/objects/items/devices/extrapolator.dm
+++ b/code/game/objects/items/devices/extrapolator.dm
@@ -194,12 +194,11 @@
 	if(!target_disease)
 		return
 	using = TRUE
-	// I'll see about this...
-	// var/choice = tgui_alert(user, "What would you like to isolate?", "Isolate", list("Symptom", "Disease"))
-	// if(choice == "Symptom")
-	//. = isolate_symptom(user, target, target_disease)
-	// else
-	. = isolate_disease(user, target, target_disease)
+	var/choice = tgui_alert(user, "What would you like to isolate?", "Isolate", list("Symptom", "Disease"))
+	if(choice == "Symptom")
+		. = isolate_symptom(user, target, target_disease)
+	else
+		. = isolate_disease(user, target, target_disease)
 	using = FALSE
 
 /obj/item/extrapolator/proc/isolate_symptom(mob/living/user, atom/target, datum/disease/advance/target_disease)


### PR DESCRIPTION

## About The Pull Request

Fixed the pandemic not allowing to rename or print diseases, extrapolator upgrades and old blood

## Changelog
:cl:
add: Added old blood
qol: Extrapolator can isolate symptoms now
fix: Fixed Pandemic not saving the name of named diseases
fix: Fixed Pandemic not printing the "virus release" notice
/:cl:
