### PR TITLE
Fixes all earrings being grey by default

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_ears.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_ears.dm
@@ -40,4 +40,18 @@
 	earrings["dangle, platinum"] = /obj/item/clothing/ears/earring/dangle/platinum
 	earrings["dangle, diamond"] = /obj/item/clothing/ears/earring/dangle/diamond
 	gear_tweaks += new/datum/gear_tweak/path(earrings)
+
+
+/datum/gear/ears/earringscolour
+	display_name = "earring selection (colourable)"
+	description = "A selection of eye-catching earrings, now colourable!"
+	path = /obj/item/clothing/ears/earring
+
+/datum/gear/ears/earringscolour/New()
+	..()
+	var/earringscolour = list()
+	earringscolour["stud"] = /obj/item/clothing/ears/earring/stud
+	earringscolour["dangle"] = /obj/item/clothing/ears/earring/dangle
+
+	gear_tweaks += new/datum/gear_tweak/path(earringscolour)
 	gear_tweaks += gear_tweak_free_color_choice


### PR DESCRIPTION

## About The Pull Request
So it turns out I may have done a woopsie and all earrings were being set to grey by default. This PR fixes it by moving the colour selector to an entirety new option instead of using the old one.
That way people won't need to fix their loadouts, yaaaaaaaaay.
