### PR TITLE
Add an Access Denied message when RIG is locked

### DIFF
--- a/tgui/packages/tgui/interfaces/RIGSuit/index.tsx
+++ b/tgui/packages/tgui/interfaces/RIGSuit/index.tsx
@@ -1,6 +1,7 @@
 import { useBackend, useSharedState } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
-import { Box } from 'tgui-core/components';
+import { Box, Stack } from 'tgui-core/components';
+import { UI_INTERACTIVE } from 'tgui-core/constants';
 
 import { RIGSuitHardware } from './RIGSuitHardware';
 import { RIGSuitLoader } from './RIGSuitLoader';
@@ -9,9 +10,23 @@ import { RIGSuitStatus } from './RIGSuitStatus';
 import type { Data } from './types';
 
 export const RIGSuit = (props) => {
-  const { data } = useBackend<Data>();
+  const { config, data } = useBackend<Data>();
 
   const { interfacelock, malf, aicontrol, ai } = data;
+
+  if (config.status < UI_INTERACTIVE) {
+    return (
+      <Window width={300} height={300}>
+        <Window.Content backgroundColor="black">
+          <Stack align="center" justify="center" fill>
+            <Stack.Item fontSize={2} color="bad">
+              --RIG Access Denied--
+            </Stack.Item>
+          </Stack>
+        </Window.Content>
+      </Window>
+    );
+  }
 
   const [showLoading, setShowLoading] = useSharedState('rigsuit-loading', true);
 


### PR DESCRIPTION

## About The Pull Request

RIGs would get stuck in the loading animation if they were locked, because setSharedState only works for UI_INTERACTIVE users. Now, they show an error screen.

Note: consequence of this change means that you can't watch what's happening to the UI as a UI_UPDATE viewer, but I don't think it's actually possible to reach this state.

![https://i.tigercat2000.net/2025/04/kyBbPQbkkG.png](https://i.tigercat2000.net/2025/04/kyBbPQbkkG.png)
## Changelog
:cl:
fix: RIGs no longer get stuck loading
/:cl:
