### PR TITLE
hides item tf spawn from spawnpoint options

### DIFF
--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -120,9 +120,9 @@ GLOBAL_LIST_EMPTY(latejoin_tram)
 	display_name = "Vorespawn - Pred"
 	msg = "has arrived on the station"
 
-/datum/spawnpoint/vore/itemtf
+/*/datum/spawnpoint/vore/itemtf
 	display_name = "Item TF spawn"
-	msg = "has arrived on the station"
+	msg = "has arrived on the station"*/
 
 /datum/spawnpoint/vore/New()
 	..()


### PR DESCRIPTION

## About The Pull Request

Hides the item tf spawn option, as this is currently not functional. This just comments out the spawn point, so it can be easily reenabled in the future if we decide to use it.

## Changelog
:cl:
fix: Hides the item tf spawn option, as this is currently not functional. 
/:cl:
