### PR TITLE
pai zmovement for climbing ladders, space and scaffolding

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -103,6 +103,10 @@
 /mob/observer/dead/Initialize(mapload, aghost = FALSE)
 
 	appearance = loc
+	invisibility = initial(invisibility)
+	layer = initial(layer)
+	plane = initial(plane)
+	alpha = initial(alpha)
 	admin_ghosted = aghost
 
 	see_in_dark = world.view //I mean. I don't even know if byond has occlusion culling... but...

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -287,6 +287,12 @@
 /mob/living/silicon/pai/UnarmedAttack(atom/A, proximity_flag)
 	. = ..()
 
+	if(istype(A,/obj/structure/ladder))
+		// Zmovement already allows these to be used with the verbs anyway
+		var/obj/structure/ladder/L = A
+		L.attack_hand(src)
+		return
+
 	if(!ismob(A) || A == src)
 		return
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -255,6 +255,16 @@
 		if(T.density)
 			return TRUE
 
+/mob/living/silicon/pai/can_ztravel()
+	if(incapacitated())
+		return FALSE
+
+	if(Process_Spacemove())
+		return TRUE
+
+	if(!restrained())
+		return TRUE
+
 // TODO - Leshana Experimental
 
 //Execution by grand piano!


### PR DESCRIPTION
## About The Pull Request
While PAIs are intended to be restricted in almost every form of interaction. Climbing is something even mice can do, and being trapped in a room where you know you can climb out of it due to a lattice overhead doesn't make much sense. You also could not drop down through lattices... which also doesn't make much sense.

## Changelog
PAI may now climb ladders, climb lattices, drop down through lattices, and move up and down in zero gravity environments.

:cl:
qol: PAI may now climb up and down ladders, lattices, and move freely up and down in zeroG
/:cl: