### PR TITLE
Fixes migration issue

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -90,7 +90,7 @@ var/list/gear_datums = list()
 		if(pref.client)
 			if(G.ckeywhitelist && !(pref.client_ckey in G.ckeywhitelist))
 				continue
-			if(G.character_name && !(pref.client.prefs.real_name in G.character_name))
+			if(G.character_name && pref.client.prefs && !(pref.client.prefs.real_name in G.character_name))
 				continue
 		. += gear_name
 
@@ -171,7 +171,7 @@ var/list/gear_datums = list()
 		if(preference_mob && preference_mob.client)
 			if(G.ckeywhitelist && !(preference_mob.ckey in G.ckeywhitelist))
 				continue
-			if(G.character_name && !(preference_mob.client.prefs.real_name in G.character_name))
+			if(G.character_name && preference_mob.client.prefs && !(preference_mob.client.prefs.real_name in G.character_name))
 				continue
 		var/ticked = (G.display_name in pref.gear)
 		. += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='byond://?src=\ref[src];toggle_gear=[html_encode(G.display_name)]'>[G.display_name]</a></td>"


### PR DESCRIPTION

## About The Pull Request
Fixes #17625

Makes it so migrations no longer result in loadout loss if someone has a whitelisted item.
## Changelog
:cl:
fix: Loadout items no longer disappear during migrations
/:cl:
