### PR TITLE
Emote voice and sound toggle [DRAFT]

### DIFF
--- a/code/modules/emotes/custom_emote.dm
+++ b/code/modules/emotes/custom_emote.dm
@@ -79,7 +79,13 @@
 	if(!T) return
 
 	if(client)
-		playsound(T, pick(GLOB.emote_sound), 75, TRUE, falloff = 1 , is_global = TRUE, frequency = voice_freq, ignore_walls = TRUE, preference = /datum/preference/toggle/emote_sounds)
+		switch(use_emote_pref_old_sonds)
+			if(OLD_VERSION)
+				playsound(T, pick(GLOB.emote_sound), 75, TRUE, falloff = 1 , is_global = TRUE, frequency = 0, ignore_walls = TRUE, preference = /datum/preference/toggle/emote_sounds)
+			if(USE_VOICETONE)
+				playsound(T, pick(GLOB.emote_sound), 75, TRUE, falloff = 1 , is_global = TRUE, frequency = voice_freq, ignore_walls = TRUE, preference = /datum/preference/toggle/emote_sounds)
+			if(USE_VOICETONE_AND_SPEECH)
+				playsound(T, pick(voice_sounds_list), 75, TRUE, falloff = 1 , is_global = TRUE, frequency = voice_freq, ignore_walls = TRUE, preference = /datum/preference/toggle/emote_sounds)
 
 	var/list/in_range = get_mobs_and_objs_in_view_fast(T,range,2,remote_ghosts = client ? TRUE : FALSE)
 	var/list/m_viewers = in_range["mobs"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Toggle that allows for toggling your emote sounds to be able to choose between:
1. Having 0 frequency (sound is unaffected and comes out normal)
2. Having set frequency (sound if affected by your set frequency)
And:
1. Use GLOB.emote_sound
2. Or use voice_sounds_list
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: You can now toggle if you wish for your voice frequency to make your emotes sound lower/higher pitched
add: You can now toggle if you wish for your emotes to use the base 'emote sound' list or use your selected voice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
