### PR TITLE
Makes self surgery not work when var is set to 0

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1124,9 +1124,9 @@ var/global/list/common_tools = list(
 // check if mob is lying down on something we can operate him on.
 // The RNG with table/rollerbeds comes into play in do_surgery() so that fail_step() can be used instead.
 /proc/can_operate(mob/living/carbon/M, mob/living/user)
-	. = M.lying
-
-	if(user && M == user && user.allow_self_surgery && user.a_intent == I_HELP)	// You can, technically, always operate on yourself after standing still. Inadvised, but you can.
+	if(M != user)
+		. = M.lying
+	else if(user && user.allow_self_surgery && user.a_intent == I_HELP)    // You can, technically, always operate on yourself after standing still. Inadvised, but you can.
 		. = TRUE
 	return .
 


### PR DESCRIPTION

## About The Pull Request
Because we can crawl and use items lying down now, the self surgery check never procced cause you were lying down, automatically making it valid. This fixes it
## Changelog
:cl:
fix: You cant self surgery without NT's permission anymore.
/:cl:
