### PR TITLE
Changes knight armour slowdown

### DIFF
--- a/code/modules/clothing/suits/hooded_vr.dm
+++ b/code/modules/clothing/suits/hooded_vr.dm
@@ -22,6 +22,7 @@
 	hoodtype = /obj/item/clothing/head/hood/galahad
 	armor = list(melee = 80, bullet = 50, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 2
+	slowdown = 0.5
 	actions_types = list(/datum/action/item_action/toggle_knight_headgear)
 
 /obj/item/clothing/suit/storage/hooded/knight/galahad
@@ -42,7 +43,7 @@
 	icon_state = "robin"
 	hoodtype = /obj/item/clothing/head/hood/robin
 	armor = list(melee = 70, bullet = 40, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
-	slowdown = -1
+	slowdown = 0
 	siemens_coefficient = 3
 
 // Costume Knight Gear Here


### PR DESCRIPTION

Changed the knight armours to have a slowdown of 0.5 instead of 0, and the robin version to have a slowdown of 0 rather than -1. On this server these are mostly used just as fluff items for the fantasy areas, and people have been rushing to the robin armour in the fantasy redgate due to its buffs. Rather than removing the armour from the map, making it not a straight up movement buff and letting people still find it is better, as it's not used elsewhere.

## Changelog
:cl:
balance: Changed the knight armours to have a slowdown of 0.5 instead of 0, and the robin version to have a slowdown of 0 rather than -1.
/:cl:
