### PR TITLE
Airlock Controller Spawn Removal

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -73,6 +73,9 @@
 			close()
 			addtimer(CALLBACK(src, PROC_REF(check_completion), TRUE, 0.2 SECONDS), anim_length_before_density + anim_length_before_finalize)
 
+		if("update")
+			check_completion(delayed_status = TRUE)
+
 /obj/machinery/door/airlock/proc/do_secure_open()
 	PRIVATE_PROC(TRUE)
 	SHOULD_NOT_OVERRIDE(TRUE)
@@ -98,6 +101,9 @@
 
 		if("secure_close")
 			return (locked && density)
+
+		if("update")
+			return TRUE // We just want the send_status() call from check_completion()
 
 	return 1	//Unknown command. Just assume it's completed.
 

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -57,9 +57,8 @@
 		tag_shuttle_mech_sensor = controller.tag_shuttle_mech_sensor? controller.tag_shuttle_mech_sensor : "[id_tag]_shuttle_mech"
 		memory["secure"] = controller.tag_secure
 
-		spawn(10)
-			signalDoor(tag_exterior_door, "update")		//signals connected doors to update their status
-			signalDoor(tag_interior_door, "update")
+		signalDoor(tag_exterior_door, "update")		//signals connected doors to update their status
+		signalDoor(tag_interior_door, "update")
 
 /datum/embedded_program/airlock/receive_signal(datum/signal/signal, receive_method, receive_param)
 	var/receive_tag = signal.data["tag"]

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -28,8 +28,7 @@
 
 		tag_door = controller.tag_door? controller.tag_door : "[id_tag]_hatch"
 
-		spawn(10)
-			signal_door("update")		//signals connected doors to update their status
+		signal_door("update")		//signals connected doors to update their status
 
 
 /datum/embedded_program/docking/simple/receive_signal(datum/signal/signal, receive_method, receive_param)


### PR DESCRIPTION
## About The Pull Request
The virology access console, and related buttons run an airlock control program that can sometimes fail to properly put doors into a correct state on map init, due to their logic still using spawn(). This PR implements a missing "update" radio command for airlocks that make them report their current status to their airlock controller.

This change only affects the virology access airlock in any meaningful way, as other airlock programs do not care about the initial state of the doors, and will forcibly set themselves to the proper docking or airlock cycle state. Viro access airlocks will instead lockup and become unable to cycle in or out until a borg or AI forces the door to open (thus triggering the same send_status() proc we needed). This fixes that init order dependent lockup.


## Changelog
Removed spawn(10)s from the airlock control program news. The proc signalDoor( X,"update") is now responsible for initial door state being updated. Using the already present "delayed signal" logic used in airlock signal processing. Instead of using a hardcoded 10tick spawn that can be called before the doors get their radio controller, it will now properly await the end of initialization to process the timers it uses. 


:cl:
fix: Virology access buttons no longer depend on init lag to setup their state correctly.
code: Removed spawn() behavior from airlock program. Added airlock update radio command to setup doors on airlock init.
/:cl:
