### PR TITLE
Painting materials

### DIFF
--- a/code/game/machinery/painter_vr.dm
+++ b/code/game/machinery/painter_vr.dm
@@ -29,7 +29,8 @@
 		/obj/item/clothing,
 		/obj/item/storage/backpack,
 		/obj/item/storage/belt,
-		/obj/item/toy
+		/obj/item/toy,
+		/obj/item/stack/material
 	)
 
 /obj/machinery/gear_painter/Initialize(mapload)
@@ -68,6 +69,8 @@
 		return
 
 	if(is_type_in_list(I, allowed_types) && !inoperable())
+		if(istype(I,/obj/item/stack/material/cyborg)) //Needs an exception for borg materials to avoid glitches.
+			return
 		user.visible_message(span_notice("[user] inserts \the [I] into the Color Mate receptable."))
 		user.drop_from_inventory(I)
 		I.forceMove(src)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added the ability to recolour material stacks (such as plastic). Some items crafted from stacks (such as curtains or beds) inherit the color variable of the stack, now you can actually recolour your stack to take advantage of this!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added the ability to recolour material stacks (such as plastic). Some items crafted from stacks (such as curtains or beds) inherit the color variable of the stack, now you can actually recolour your stack to take advantage of this!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
