### PR TITLE
Fix a bunch of oversights in the kitchen sink PRs

### DIFF
--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -28,6 +28,12 @@
 			to_chat(user,span_danger("The target's mind is too complex to be affected!"))
 			return
 
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.resleeve_lock && user.ckey != H.resleeve_lock)
+				to_chat(src, span_danger("[H] cannot be impersonated!"))
+				return
+
 		if(M.stat == DEAD) //Are they dead?
 			to_chat(user,span_warning("A warning pops up on the device, informing you that [M] is dead, and, as such, the mind transfer can not be done."))
 			return

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -634,7 +634,7 @@
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 
 	flags = NO_DNA | NO_SLEEVE | IS_PLANT | NO_PAIN | NO_SLIP | NO_MINOR_CUT | NO_DEFIB
-	spawn_flags = SPECIES_CAN_JOIN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 
 	blood_color = "#004400"
 	flesh_color = "#907E4A"

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -26,8 +26,6 @@
 
 	if(get_restraining_bolt())	// Borgs with Restraining Bolts move slower.
 		. += 1
-	if(nutrition > 1000)
-		. += nutrition / 2000
 
 	. += CONFIG_GET(number/robot_delay)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -77,6 +77,7 @@
 	lastarea = get_area(src)
 	set_focus(src) // VOREStation Add - Key Handling
 	hook_vr("mob_new",list(src)) //VOREStation Code
+	update_transform() // Some mobs may start bigger or smaller than normal.
 	. = ..()
 	//return QDEL_HINT_HARDDEL_NOW Just keep track of mob references. They delete SO much faster now.
 

--- a/code/modules/resleeving/infocore_records.dm
+++ b/code/modules/resleeving/infocore_records.dm
@@ -123,13 +123,11 @@
 	//Person OOCly doesn't want people impersonating them
 	locked = ckeylock
 
-	//Prevent people from printing restricted and whitelisted species
 	var/datum/species/S = GLOB.all_species["[M.dna.species]"]
 	if(S)
-		toocomplex = (S.spawn_flags & SPECIES_IS_WHITELISTED) || (S.spawn_flags & SPECIES_IS_RESTRICTED)
 		// Force ckey locking if species is whitelisted
-		//if((S.spawn_flags & SPECIES_IS_WHITELISTED) || (S.spawn_flags & SPECIES_IS_RESTRICTED))
-			//locked = TRUE
+		if((S.spawn_flags & SPECIES_IS_WHITELISTED) || (S.spawn_flags & SPECIES_IS_RESTRICTED))
+			locked = TRUE
 
 	//General stuff about them
 	synthetic = M.isSynthetic()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/misc.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/misc.tsx
@@ -96,3 +96,17 @@ export const obfuscate_job: FeatureToggle = {
   description: 'Hide your job from other players in the lobby',
   component: CheckboxInput,
 };
+
+export const EMOTE_VARY: FeatureToggle = {
+  name: 'Vary Emote Pitch',
+  category: 'SOUNDS',
+  description: 'Varies the pitch of your emotes randomly.',
+  component: CheckboxInput,
+};
+
+export const AUTOTRANSCORE: FeatureToggle = {
+  name: 'Automatically Notify Transcore on Death',
+  category: 'GAMEPLAY',
+  description: 'Do you want medbay to know you died automatically?',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request
Fixes:
- Diona not being whitelisted
- Body snatcher not respecting resleeve lock
- Borgs being slowed by >1000 nutrition
- Mobs not updating their transform to match their size
- Resleeving not allowed to print whitelisted species
- Game preferences missing tgui options

Noteworth did-not-fix, even though these weren't documented in those PRs
- Death screams no longer occur in bellies
- Pain noises do not work in bellies
- You can now dominate people with an aggressive grab

## Changelog
:cl:
fix: Diona not being whitelisted
fix: Body snatcher not respecting resleeve lock
fix: Borgs being slowed by >1000 nutrition
fix: Mobs not updating their transform to match their size
fix: Resleeving not allowed to print whitelisted species
fix: Game preferences missing tgui options
/:cl:
