### PR TITLE
Reference Tracking

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -180,7 +180,7 @@
 	to_world_log("## UNIT_TEST: [text]")
 
 #ifdef REFERENCE_TRACKING_LOG
-#define log_reftracker(msg) log_world("## REF SEARCH [msg]")
+#define log_reftracker(msg) WRITE_LOG(GLOB.diary, "## REF SEARCH [msg]")
 #else
 #define log_reftracker(msg)
 #endif

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -12,7 +12,6 @@
 //#define to_chat to_chat_filename=__FILE__;to_chat_line=__LINE__;to_chat_src=src;__to_chat
 //#define to_chat __to_chat
 #define to_world(message) to_chat(world, message)
-#define to_world_log(message) world.log << message
 #define to_world_log(message) log_misc(message)
 // TODO - Baystation has this log to crazy places. For now lets just world.log, but maybe look into it later.
 #define log_world(message) to_world_log(message)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -13,6 +13,7 @@
 //#define to_chat __to_chat
 #define to_world(message) to_chat(world, message)
 #define to_world_log(message) world.log << message
+#define to_world_log(message) log_misc(message)
 // TODO - Baystation has this log to crazy places. For now lets just world.log, but maybe look into it later.
 #define log_world(message) to_world_log(message)
 #define to_file(file_entry, source_var) file_entry << source_var

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -12,7 +12,7 @@
 //#define to_chat to_chat_filename=__FILE__;to_chat_line=__LINE__;to_chat_src=src;__to_chat
 //#define to_chat __to_chat
 #define to_world(message) to_chat(world, message)
-#define to_world_log(message) log_misc(message)
+#define to_world_log(message) world.log << message
 // TODO - Baystation has this log to crazy places. For now lets just world.log, but maybe look into it later.
 #define log_world(message) to_world_log(message)
 #define to_file(file_entry, source_var) file_entry << source_var

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -468,7 +468,7 @@
 #include "code\datums\organs.dm"
 #include "code\datums\position_point_vector.dm"
 #include "code\datums\progressbar.dm"
-#include "code\datums\reference_tracking.dm"
+#include "code\datums\reference_tracking_new.dm"
 #include "code\datums\riding.dm"
 #include "code\datums\signals.dm"
 #include "code\datums\soul_link.dm"


### PR DESCRIPTION
## About The Pull Request
Changes log_reftracker to actually write to the .log

Unticks the old reference_tracking and ticks the new reference_tracking_new in the .dme

These don't have any actual changes in game unless you go to _compile_options.dm. Define REFERENCE_TRACKING AND GC_FAILURE_HARD_LOOKUP which causes MASSIVE lag when it's doing ref lookups.
## Changelog
:cl: Diana
server: Ref Track now goes => .log. Proper ref tracking dm ticked in the .dme
/:cl:
