### PR TITLE
Proper MaxHealth checks and Crit Point

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -1,9 +1,6 @@
 /datum/config_entry/number/health_threshold_softcrit
 	default = 0
 
-/datum/config_entry/number/health_threshold_crit
-	default = 0
-
 /datum/config_entry/flag/bones_can_break
 
 /datum/config_entry/flag/limbs_can_break

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -4,9 +4,6 @@
 /datum/config_entry/number/health_threshold_crit
 	default = 0
 
-/datum/config_entry/number/health_threshold_dead
-	default = -100
-
 /datum/config_entry/flag/bones_can_break
 
 /datum/config_entry/flag/limbs_can_break

--- a/code/datums/components/species/xenochimera.dm
+++ b/code/datums/components/species/xenochimera.dm
@@ -607,7 +607,7 @@
 	//Unfreeze some things
 	does_not_breathe = FALSE
 	update_canmove()
-	weakened = 2
+	stunned = 2
 
 	xc.revive_ready = world.time + 10 MINUTES //set the cooldown, Reduced this to 10 minutes, you're playing with fire if you're reviving that often.
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -478,8 +478,8 @@
 		if(!allowed || (NOCLONE in WC.mutations) || !WC.dna)
 			occupantData["isViableSubject"] = 0
 		occupantData["health"] = WC.health
-		occupantData["maxHealth"] = WC.maxHealth
-		occupantData["minHealth"] = CONFIG_GET(number/health_threshold_dead)
+		occupantData["maxHealth"] = WC.getMaxHealth()
+		occupantData["minHealth"] = -(WC.getMaxHealth())
 		occupantData["uniqueEnzymes"] = WC.dna.unique_enzymes
 		occupantData["uniqueIdentity"] = WC.dna.uni_identity
 		occupantData["structuralEnzymes"] = WC.dna.struc_enzymes

--- a/code/game/gamemodes/changeling/powers/fake_death.dm
+++ b/code/game/gamemodes/changeling/powers/fake_death.dm
@@ -37,7 +37,7 @@
 		C.does_not_breathe = 0	//This means they don't autoheal the oxy damage from the next step
 
 	if(C.stat != DEAD)
-		C.adjustOxyLoss(C.maxHealth * 2)
+		C.adjustOxyLoss(C.getMaxHealth() * 2)
 
 	C.forbid_seeing_deadchat = TRUE
 

--- a/code/game/gamemodes/changeling/powers/rapid_regen.dm
+++ b/code/game/gamemodes/changeling/powers/rapid_regen.dm
@@ -23,7 +23,7 @@
 		var/mob/living/carbon/human/C = src
 		var/healing_amount = 40
 		if(src.mind.changeling.recursive_enhancement)
-			healing_amount = C.maxHealth
+			healing_amount = C.getMaxHealth()
 			to_chat(src, span_notice("We completely heal ourselves."))
 		spawn(0)
 			C.adjustBruteLoss(-healing_amount)

--- a/code/game/gamemodes/cult/soulstone.dm
+++ b/code/game/gamemodes/cult/soulstone.dm
@@ -109,7 +109,7 @@
 	if(src.imprinted != "empty")
 		to_chat(U, span_danger("Capture failed!") + ": The soul stone has already been imprinted with [src.imprinted]'s mind!")
 		return
-	if ((T.health + T.halloss) > CONFIG_GET(number/health_threshold_crit) && T.stat != DEAD)
+	if ((T.health + T.halloss) > T.get_crit_point() && T.stat != DEAD)
 		to_chat(U, span_danger("Capture failed!") + ": Kill or maim the victim first!")
 		return
 	if(T.client == null)

--- a/code/game/gamemodes/technomancer/spells/insert/asphyxiation.dm
+++ b/code/game/gamemodes/technomancer/spells/insert/asphyxiation.dm
@@ -50,7 +50,7 @@
 /obj/item/inserted_spell/asphyxiation/on_expire()
 	..()
 
-// if((getOxyLoss() > (species.total_health/2)) || (health <= config.health_threshold_crit))
+// if((getOxyLoss() > (species.total_health/2)) || (health <= get_crit_point())
 
 /obj/item/inserted_spell/asphyxiation/proc/predict_crit(var/pulses_remaining, var/mob/living/carbon/human/victim, var/previous_damage = 0)
 	if(pulses_remaining <= 0) // Infinite loop protection

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -189,8 +189,8 @@
 		occupantData["name"] = occupant.name
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
-		occupantData["maxHealth"] = occupant.maxHealth
-		occupantData["minHealth"] = CONFIG_GET(number/health_threshold_dead)
+		occupantData["maxHealth"] = occupant.getMaxHealth()
+		occupantData["minHealth"] = -(occupant.getMaxHealth())
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()

--- a/code/game/machinery/adv_med_vr.dm
+++ b/code/game/machinery/adv_med_vr.dm
@@ -35,7 +35,7 @@
 	else
 		var/h_ratio
 		if(occupant)
-			h_ratio = occupant.health / occupant.maxHealth
+			h_ratio = occupant.health / occupant.getMaxHealth()
 			switch(h_ratio)
 				if(1.000)
 					icon_state = "scanner_green"

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -67,8 +67,8 @@
 		occupantData["name"] = occupant.name
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
-		occupantData["maxHealth"] = occupant.maxHealth
-		occupantData["minHealth"] = CONFIG_GET(number/health_threshold_dead)
+		occupantData["maxHealth"] = occupant.getMaxHealth()
+		occupantData["minHealth"] = -(occupant.getMaxHealth())
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()
@@ -177,8 +177,8 @@
 					playsound(src.loc, 'sound/machines/defib_success.ogg', 50, 0)
 				if(oxy && victim.getOxyLoss()>oxyAlarm)
 					playsound(src.loc, 'sound/machines/defib_safetyOff.ogg', 50, 0)
-				if(healthAnnounce && ((victim.health / victim.maxHealth) * 100) <= healthAlarm)
-					atom_say("[round(((victim.health / victim.maxHealth) * 100))]% health.")
+				if(healthAnnounce && ((victim.health / victim.getMaxHealth()) * 100) <= healthAlarm)
+					atom_say("[round(((victim.health / victim.getMaxHealth()) * 100))]% health.")
 
 // Surgery Helpers
 /obj/machinery/computer/operating/proc/build_surgery_list(mob/user)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -138,7 +138,7 @@
 			locked_down = R.lockcharge,
 			locstring = "[A.name] ([T.x], [T.y])",
 			status = R.stat,
-			health = round(R.health * 100 / R.maxHealth, 0.1),
+			health = round(R.health * 100 / R.getMaxHealth(), 0.1),
 			charge = R.cell ? round(R.cell.percent()) : null,
 			cell_capacity = R.cell ? R.cell.maxcharge : null,
 			module = R.module ? R.module.name : "No Module Detected",

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -113,7 +113,7 @@
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
 		occupantData["maxHealth"] = occupant.getMaxHealth()
-		occupantData["minHealth"] = CONFIG_GET(number/health_threshold_dead)
+		occupantData["minHealth"] = -(occupant.getMaxHealth())
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -104,7 +104,7 @@
 				holder.icon_state = "hudhealth-100"
 				C.images += holder
 			else
-				holder.icon_state = RoundHealth((patient.health-config.health_threshold_crit)/(patient.getMaxHealth()-config.health_threshold_crit)*100)
+				holder.icon_state = RoundHealth((-patient.getMaxHealth()*0.5))/(patient.getMaxHealth()-(-getMaxHealth()*0.5)*100)
 				C.images += holder
 
 			holder = patient.hud_list[STATUS_HUD]

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -298,10 +298,10 @@
 	H.updatehealth()
 
 	if(H.isSynthetic())
-		if(H.health + H.getOxyLoss() + H.getToxLoss() <= CONFIG_GET(number/health_threshold_dead))
+		if(H.health + H.getOxyLoss() + H.getToxLoss() <= -(H.getMaxHealth()))
 			return "buzzes, \"Resuscitation failed - Severe damage detected. Begin damage restoration before further attempts.\""
 
-	else if(H.health + H.getOxyLoss() <= CONFIG_GET(number/health_threshold_dead)) //They need to be healed first.
+	else if(H.health + H.getOxyLoss() <= -(H.getMaxHealth())) //They need to be healed first.
 		return "buzzes, \"Resuscitation failed - Severe tissue damage detected. Repair of anatomical damage required.\""
 
 	else if(HUSK in H.mutations) //Husked! Need to fix their husk status first.

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -434,7 +434,7 @@
 	H.apply_damage(burn_damage_amt, BURN, BP_TORSO)
 
 	//set oxyloss so that the patient is just barely in crit, if possible
-	var/barely_in_crit = CONFIG_GET(number/health_threshold_crit) - 1
+	var/barely_in_crit = H.get_crit_point() - 1
 	var/adjust_health = barely_in_crit - H.health //need to increase health by this much
 	H.adjustOxyLoss(-adjust_health)
 

--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -44,7 +44,7 @@
 	if(user == owner && bound_mob)
 		. += span_notice("[bound_mob]'s crystal")
 		if(isanimal(bound_mob))
-			. += span_notice("[bound_mob.health / bound_mob.maxHealth * 100]%")
+			. += span_notice("[bound_mob.health / bound_mob.getMaxHealth() * 100]%")
 		if(bound_mob.ooc_notes)
 			. += span_deptradio("OOC Notes:") + " <a href='byond://?src=\ref[bound_mob];ooc_notes=1'>\[View\]</a> - <a href='byond://?src=\ref[src];print_ooc_notes_chat=1'>\[Print\]</a>"
 		. += span_deptradio("<a href='byond://?src=\ref[bound_mob];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>")
@@ -275,10 +275,10 @@
 /obj/item/capture_crystal/proc/capture_chance(mob/living/M, user)
 	if(capture_chance_modifier >= 100)		//Master crystal always work
 		return 100
-	var/capture_chance = ((1 - (M.health / M.maxHealth)) * 100)	//Inverted health percent! 100% = 0%
+	var/capture_chance = ((1 - (M.health / M.getMaxHealth())) * 100)	//Inverted health percent! 100% = 0%
 	//So I don't know how this works but here's a kind of explanation
 	//Basic chance + ((Mob's max health - minimum calculated health) / (Max allowed health - Min allowed health)*(Chance at Max allowed health - Chance at minimum allowed health)
-	capture_chance += 35 + ((M.maxHealth - 5)/ (1000-5)*(-100 - 35))
+	capture_chance += 35 + ((M.getMaxHealth() - 5)/ (1000-5)*(-100 - 35))
 	//Basically! Mobs over 1000 max health will be unable to be caught without using status effects.
 	//Thanks Aronai!
 	var/effect_count = 0	//This will give you a smol chance to capture if you have applied status effects, even if the chance would ordinarily be <0

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -65,7 +65,7 @@
 		if(DPS > 0)
 			to_chat(user, span_notice("At your maximum health ([user.getMaxHealth()]), it would take approximately;"))
 			to_chat(user, span_notice("[(user.getMaxHealth() - CONFIG_GET(number/health_threshold_softcrit)) / DPS] seconds to softcrit you. ([CONFIG_GET(number/health_threshold_softcrit)] health)"))
-			to_chat(user, span_notice("[(user.getMaxHealth() - CONFIG_GET(number/health_threshold_crit)) / DPS] seconds to hardcrit you. ([CONFIG_GET(number/health_threshold_crit)] health)"))
+			to_chat(user, span_notice("[(user.getMaxHealth() - user.get_crit_point()) / DPS] seconds to hardcrit you. ([user.get_crit_point()] health)"))
 			to_chat(user, span_notice("[(user.getMaxHealth() - (-user.getMaxHealth())) / DPS] seconds to kill you. ([(-user.getMaxHealth())] health)"))
 
 	else

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -66,7 +66,7 @@
 			to_chat(user, span_notice("At your maximum health ([user.getMaxHealth()]), it would take approximately;"))
 			to_chat(user, span_notice("[(user.getMaxHealth() - CONFIG_GET(number/health_threshold_softcrit)) / DPS] seconds to softcrit you. ([CONFIG_GET(number/health_threshold_softcrit)] health)"))
 			to_chat(user, span_notice("[(user.getMaxHealth() - CONFIG_GET(number/health_threshold_crit)) / DPS] seconds to hardcrit you. ([CONFIG_GET(number/health_threshold_crit)] health)"))
-			to_chat(user, span_notice("[(user.getMaxHealth() - CONFIG_GET(number/health_threshold_dead)) / DPS] seconds to kill you. ([CONFIG_GET(number/health_threshold_dead)] health)"))
+			to_chat(user, span_notice("[(user.getMaxHealth() - (-user.getMaxHealth())) / DPS] seconds to kill you. ([(-user.getMaxHealth())] health)"))
 
 	else
 		to_chat(user, span_warning("You need to be a living mob, with hands, and for an object to be in your active hand, to use this verb."))

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -158,7 +158,7 @@
 					return FALSE
 		//VOREStation add start
 		else if(forgive_resting && !isbelly(holder.loc))	//Doing it this way so we only think about the other conditions if the var is actually set
-			if((holder.health == holder.maxHealth) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
+			if((holder.health == holder.getMaxHealth()) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
 				var/mob/living/simple_mob/vore/eater = holder
 				if(!eater.will_eat(L))		//We forgive people we can eat by eating them
 					set_stance(STANCE_IDLE)

--- a/code/modules/eventkit/gm_interfaces/mob_spawner.dm
+++ b/code/modules/eventkit/gm_interfaces/mob_spawner.dm
@@ -65,7 +65,7 @@
 					intent  = (L.a_intent ? L.a_intent : I_HELP)
 					new_path = FALSE
 
-					data["max_health"] = L.maxHealth
+					data["max_health"] = L.getMaxHealth()
 					data["health"] = L.health
 					if(isanimal(L))
 						var/mob/living/simple_mob/S = L

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -93,7 +93,7 @@
 		blinded = 1
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
-		if( !container && (health < CONFIG_GET(number/health_threshold_dead) || ((world.time - timeofhostdeath) > CONFIG_GET(number/revival_brain_life))) )
+		if( !container && (health < -getMaxHealth() || ((world.time - timeofhostdeath) > CONFIG_GET(number/revival_brain_life))) )
 			death()
 			blinded = 1
 			silent = 0

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -2,7 +2,7 @@
 
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing()
-	if(SSair.current_cycle%4==2 || failed_last_breath || (health < CONFIG_GET(number/health_threshold_crit))) 	//First, resolve location and get a breath
+	if(SSair.current_cycle%4==2 || failed_last_breath || (health < get_crit_point())) 	//First, resolve location and get a breath
 		breathe()
 
 /mob/living/carbon/proc/breathe()
@@ -12,7 +12,7 @@
 	var/datum/gas_mixture/breath = null
 
 	//First, check if we can breathe at all
-	if(health < CONFIG_GET(number/health_threshold_crit) && !(CE_STABLE in chem_effects)) //crit aka circulatory shock
+	if(health < get_crit_point() && !(CE_STABLE in chem_effects)) //crit aka circulatory shock
 		AdjustLosebreath(1)
 
 	if(losebreath>0) //Suffocating so do not take a breath

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -165,11 +165,11 @@
 	return shock_damage
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
-	if (src.health >= CONFIG_GET(number/health_threshold_crit))
+	if (health >= get_crit_point())
 		if(src == M && ishuman(src))
 			var/mob/living/carbon/human/H = src
 			var/datum/gender/T = GLOB.gender_datums[H.get_visible_gender()]
-			src.visible_message( \
+			visible_message( \
 				span_notice("[src] examines [T.himself]."), \
 				span_notice("You check yourself for injuries.") \
 				)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -628,7 +628,7 @@
 			// A bit of sanity.
 			var/brain_damage = between(getBrainLoss(), damage_calc, brain.max_damage)
 			setBrainLoss(brain_damage)
-	else if(health > CONFIG_GET(number/health_threshold_dead))
+	else if(health > -getMaxHealth())
 		adjustOxyLoss(-(min(getOxyLoss(), 5)))
 		updatehealth()
 		to_chat(src, span_notice("You feel a breath of fresh air enter your lungs. It feels good."))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -116,7 +116,7 @@
 		return FALSE;
 
 	//todo: make this whole CPR check into it's own individual proc instead of hogging up attack_hand_help_intent
-	if((istype(H) && (health < CONFIG_GET(number/health_threshold_crit)) || stat == DEAD) && !on_fire) //Only humans can do CPR.
+	if((istype(H) && (health < get_crit_point()) || stat == DEAD) && !on_fire) //Only humans can do CPR.
 		if(!H.check_has_mouth())
 			to_chat(H, span_danger("You don't have a mouth, you cannot perform CPR!"))
 			return FALSE
@@ -576,7 +576,7 @@
 				chest.fracture()
 
 	// standard CPR ahead, adjust oxy and refresh health
-	if(health > CONFIG_GET(number/health_threshold_crit) && prob(10))
+	if(health > get_crit_point() && prob(10))
 		if(get_xenochimera_component())
 			visible_message(span_danger("\The [src]'s body twitches and gurgles a bit."))
 			to_chat(reviver, span_danger("You get the feeling [src] can't be revived by CPR alone."))

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -18,7 +18,7 @@
 	health = getMaxHealth() - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 
 	//TODO: fix husking
-	if( ((getMaxHealth() - total_burn) < CONFIG_GET(number/health_threshold_dead) * huskmodifier) && stat == DEAD)
+	if( ((getMaxHealth() - total_burn) < (-getMaxHealth()) * huskmodifier) && stat == DEAD)
 		ChangeToHusk()
 	return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1288,7 +1288,7 @@
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
 
-		if(health <= CONFIG_GET(number/health_threshold_dead) || (should_have_organ(O_BRAIN) && !has_brain()))
+		if(health <= (-getMaxHealth()) || (should_have_organ(O_BRAIN) && !has_brain()))
 			death()
 			blinded = 1
 			silent = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -609,7 +609,7 @@
 
 	if(!breath || (breath.total_moles == 0))
 		failed_last_breath = 1
-		if(health > CONFIG_GET(number/health_threshold_crit))
+		if(health > get_crit_point())
 			adjustOxyLoss(HUMAN_MAX_OXYLOSS)
 		else
 			adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
@@ -1296,7 +1296,7 @@
 			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > (species.total_health/2)) || (health <= (CONFIG_GET(number/health_threshold_crit) * species.crit_mod)))
+		if((getOxyLoss() > (species.total_health/2)) || (health <= (get_crit_point() * species.crit_mod)))
 			Paralyse(3)
 
 		if(hallucination)
@@ -2104,7 +2104,7 @@
 		if(stat == DEAD)
 			holder.icon_state = "-100" 	// X_X
 		else
-			holder.icon_state = RoundHealth((health-CONFIG_GET(number/health_threshold_crit))/(getMaxHealth()-CONFIG_GET(number/health_threshold_crit))*100)
+			holder.icon_state = RoundHealth((health-get_crit_point())/(getMaxHealth()-get_crit_point())*100)
 		if(block_hud)
 			holder.icon_state = "hudblank"
 		health_us.icon_state = holder.icon_state

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -323,7 +323,7 @@
 
 	H.maxHealth = total_health
 
-	H.health = H.maxHealth
+	H.health = H.getMaxHealth()
 
 /datum/species/shadekin/produceCopy(var/list/traits, var/mob/living/carbon/human/H, var/custom_base, var/reset_dna = TRUE) // Traitgenes reset_dna flag required, or genes get reset on resleeve
 

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -138,7 +138,7 @@
 
 	if(!breath || (breath.total_moles == 0))
 		H.failed_last_breath = 1
-		if(H.health > CONFIG_GET(number/health_threshold_crit))
+		if(H.health > H.get_crit_point())
 			H.adjustOxyLoss(ALRAUNE_MAX_OXYLOSS)
 		else
 			H.adjustOxyLoss(ALRAUNE_CRIT_MAX_OXYLOSS)

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -266,7 +266,7 @@
 	pseudodead = 1
 
 /datum/species/protean/handle_environment_special(var/mob/living/carbon/human/H)
-	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.maxHealth*0.5 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever)
+	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.getMaxHealth()*0.5 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever)
 		return ..() //Any instakill shot runtimes since there are no organs after this. No point to not skip these checks, going to nullspace anyway.
 
 	var/obj/item/organ/internal/nano/refactory/refactory = locate() in H.internal_organs

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -268,7 +268,7 @@
 				amount *= M.incoming_healing_percent
 
 	if(tf_mob_holder && tf_mob_holder.loc == src)
-		var/dmgmultiplier = tf_mob_holder.maxHealth / maxHealth
+		var/dmgmultiplier = tf_mob_holder.getMaxHealth() / getMaxHealth()
 		dmgmultiplier *= amount
 		tf_mob_holder.adjustBruteLoss(dmgmultiplier)
 
@@ -358,7 +358,7 @@
 			if(!isnull(M.incoming_healing_percent))
 				amount *= M.incoming_healing_percent
 	if(tf_mob_holder && tf_mob_holder.loc == src)
-		var/dmgmultiplier = tf_mob_holder.maxHealth / maxHealth
+		var/dmgmultiplier = tf_mob_holder.getMaxHealth() / getMaxHealth()
 		dmgmultiplier *= amount
 		tf_mob_holder.adjustFireLoss(dmgmultiplier)
 	fireloss = min(max(fireloss + amount, 0),(getMaxHealth()*2))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -442,6 +442,16 @@
 			result *= M.max_health_percent
 	return result
 
+///Use this proc to get the damage in which the mob will be put into critical condition (hardcrit)
+/mob/living/proc/get_crit_point()
+	return -(getMaxHealth()*0.5)
+
+/mob/living/carbon/human/get_crit_point()
+	var/crit_point = -(getMaxHealth()*0.5)
+	if(species.crit_mod)
+		crit_point *= species.crit_mod
+	return crit_point
+
 /mob/living/proc/setMaxHealth(var/newMaxHealth)
 	var/h_mult = maxHealth / newMaxHealth	//Calculate change multiplier
 	if(bruteloss)							//In case a damage value is 0, divide by 0 bad
@@ -1240,7 +1250,7 @@
 				add_attack_logs(src,M,"Thrown via grab to [end_T.x],[end_T.y],[end_T.z]")
 			if(ishuman(M))
 				var/mob/living/carbon/human/N = M
-				if((N.health + N.halloss) < CONFIG_GET(number/health_threshold_crit) || N.stat == DEAD)
+				if((N.health + N.halloss) < N.get_crit_point() || N.stat == DEAD)
 					N.adjustBruteLoss(rand(10,30))
 			src.drop_from_inventory(G)
 

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -105,7 +105,7 @@
 
 // Returns percentage of AI's remaining hardware integrity (maxhealth - (bruteloss + fireloss))
 /mob/living/silicon/ai/proc/hardware_integrity()
-	return (health - CONFIG_GET(number/health_threshold_dead)) / 2
+	return (health - (-getMaxHealth())) / 2
 
 // Shows capacitor charge and hardware integrity information to the AI in Status tab.
 /mob/living/silicon/ai/show_system_integrity()

--- a/code/modules/mob/living/silicon/decoy/life.dm
+++ b/code/modules/mob/living/silicon/decoy/life.dm
@@ -2,7 +2,7 @@
 	if (src.stat == 2)
 		return
 	else
-		if (src.health <= CONFIG_GET(number/health_threshold_dead) && src.stat != 2)
+		if (src.health <= (-getMaxHealth()) && src.stat != 2)
 			death()
 			return
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -80,7 +80,7 @@
 	//if(resting) // VOREStation edit. Our borgos would rather not.
 	//	Weaken(5)
 
-	if(health < CONFIG_GET(number/health_threshold_dead) && stat != 2) //die only once
+	if(health < (-getMaxHealth()) && stat != 2) //die only once
 		death()
 
 	if (stat != 2) //Alive.
@@ -242,7 +242,7 @@
 					healths.icon_state = "health3"
 				else if(health >= 0)
 					healths.icon_state = "health4"
-				else if(health >= CONFIG_GET(number/health_threshold_dead))
+				else if(health >= (-getMaxHealth()))
 					healths.icon_state = "health5"
 				else
 					healths.icon_state = "health6"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/carrier.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/carrier.dm
@@ -51,7 +51,7 @@
 		for(var/i = 1 to spiderling_count)
 			if(prob(swarmling_prob) && src)
 				var/mob/living/simple_mob/animal/giant_spider/swarmling = new swarmling_type(src.loc)
-				var/swarm_health = FLOOR(swarmling.maxHealth * 0.4, 1)
+				var/swarm_health = FLOOR(swarmling.getMaxHealth() * 0.4, 1)
 				var/swarm_dam_lower = FLOOR(melee_damage_lower * 0.4, 1)
 				var/swarm_dam_upper = FLOOR(melee_damage_upper * 0.4, 1)
 				swarmling.name = "spiderling"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/grafadreka.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_EMPTY(wounds_being_tended_by_drakes)
 		return critter.health < (critter.getMaxHealth() * critter.sap_heal_threshold)
 
 	// Other animals just need to be injured.
-	return (friend.health < friend.maxHealth)
+	return (friend.health < friend.getMaxHealth())
 
 /mob/living/simple_mob/animal/sif/grafadreka/Initialize(mapload)
 
@@ -435,12 +435,12 @@ GLOBAL_LIST_EMPTY(wounds_being_tended_by_drakes)
 
 		if(!can_tend_wounds(friend))
 			if(friend == src)
-				if(health == maxHealth)
+				if(health == getMaxHealth())
 					to_chat(src, span_warning("You are unwounded."))
 				else
 					to_chat(src, span_warning("You cannot tend any of your wounds."))
 			else
-				if(friend.health == friend.maxHealth)
+				if(friend.health == friend.getMaxHealth())
 					return ..()
 				to_chat(src, span_warning("You cannot tend any of \the [friend]'s wounds."))
 			return TRUE

--- a/code/modules/mob/living/simple_mob/subtypes/glamour/blaidd.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/blaidd.dm
@@ -236,7 +236,7 @@
 //				return FALSE
 		//VOREStation add start
 		else if(forgive_resting && !isbelly(holder.loc))	//Doing it this way so we only think about the other conditions if the var is actually set
-			if((holder.health == holder.maxHealth) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
+			if((holder.health == holder.getMaxHealth()) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
 				var/mob/living/simple_mob/vore/eater = holder
 				if(!eater.will_eat(L))		//We forgive people we can eat by eating them
 					set_stance(STANCE_IDLE)

--- a/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
@@ -319,7 +319,7 @@
 		set_stance(STANCE_FLEE)
 		return
 
-	if((holder.health < (holder.maxHealth / 4)) && !used_invis)
+	if((holder.health < (holder.getMaxHealth() / 4)) && !used_invis)
 		holder.cloak()
 		used_invis = 1
 		step_away(holder, target, 8)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -939,7 +939,7 @@ I think I covered everything.
 				return
 			if(P.suiciding)
 				return
-			if(P.health <= (P.maxHealth * 0.95))	//Nom em'
+			if(P.health <= (P.getMaxHealth() * 0.95))	//Nom em'
 				if(vocal)
 					if(last_speak + 30 SECONDS < world.time)
 						var/message_options = list(

--- a/code/modules/mob/living/simple_mob/subtypes/vore/devil.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/devil.dm
@@ -181,7 +181,7 @@
 //				return FALSE
 		//VOREStation add start
 		else if(forgive_resting && !isbelly(holder.loc))	//Doing it this way so we only think about the other conditions if the var is actually set
-			if((holder.health == holder.maxHealth) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
+			if((holder.health == holder.getMaxHealth()) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
 				var/mob/living/simple_mob/vore/eater = holder
 				if(!eater.will_eat(L))		//We forgive people we can eat by eating them
 					set_stance(STANCE_IDLE)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -261,7 +261,7 @@
 /mob/living/simple_mob/shadekin/Found(var/atom/A)
 	if(specific_targets && isliving(A)) //Healing!
 		var/mob/living/L = A
-		var/health_percent = (L.health/L.maxHealth)*100
+		var/health_percent = (L.health/L.getMaxHealth())*100
 		if(health_percent <= 50 && will_eat(A))
 			return A
 	. = ..()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/stalker.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/stalker.dm
@@ -191,7 +191,7 @@
 //				return FALSE
 		//VOREStation add start
 		else if(forgive_resting && !isbelly(holder.loc))	//Doing it this way so we only think about the other conditions if the var is actually set
-			if((holder.health == holder.maxHealth) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
+			if((holder.health == holder.getMaxHealth()) && !hostile && (L.resting || L.weakened || L.stunned))	//If our health is full, no one is fighting us, we can forgive
 				var/mob/living/simple_mob/vore/eater = holder
 				if(!eater.will_eat(L))		//We forgive people we can eat by eating them
 					set_stance(STANCE_IDLE)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -603,7 +603,7 @@ This function completely restores a damaged organ to perfect condition.
 //Burn damage can cause fluid loss due to blistering and cook-off
 
 	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(data.get_species_flags() & NO_BLOOD))
-		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
+		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - (-owner.getMaxHealth()))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal)
 		owner.remove_blood(fluid_loss)
 
 	// first check whether we can widen an existing wound

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -460,7 +460,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
 		M.druggy = max(M.druggy, 20)
-		if(M.health < M.maxHealth)
+		if(M.health < M.getMaxHealth())
 			to_chat(target, span_notice("As the beam strikes you, you feel a little healthier!"))
 			M.adjustBruteLoss(-5)
 			M.adjustFireLoss(-5)
@@ -530,7 +530,7 @@
 /obj/item/projectile/beam/medigun/on_hit(var/atom/target, var/blocked = 0)
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
-		if(M.health < M.maxHealth)
+		if(M.health < M.getMaxHealth())
 			var/obj/effect/overlay/pulse = new /obj/effect/overlay(get_turf(M))
 			pulse.icon = 'icons/effects/effects.dmi'
 			pulse.icon_state = XENO_CHEM_HEAL

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -94,7 +94,7 @@
 		H.dna.digitigrade = R.dna.digitigrade // ensure cloned DNA is set appropriately from record??? for some reason it doesn't get set right despite the override to datum/dna/Clone()
 
 	//Apply damage
-	H.adjustCloneLoss((H.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))*-0.75)
+	H.adjustCloneLoss((H.getMaxHealth() - (H.getMaxHealth()))*-0.75)
 	H.Paralyse(4)
 	H.updatehealth()
 
@@ -178,7 +178,7 @@
 			use_power(7500) //This might need tweaking.
 			return
 
-		else if(((occupant.health == occupant.maxHealth)) && (!eject_wait))
+		else if(((occupant.health == occupant.getMaxHealth())) && (!eject_wait))
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			audible_message("\The [src] signals that the growing process is complete.", runemessage = "ding")
 			connected_message("Growing Process Complete.")
@@ -197,7 +197,7 @@
 
 /obj/machinery/clonepod/transhuman/get_completion()
 	if(occupant)
-		return 100 * ((occupant.health + abs(CONFIG_GET(number/health_threshold_dead))) / (occupant.maxHealth + abs(CONFIG_GET(number/health_threshold_dead))))
+		return 100 * ((occupant.health + (occupant.getMaxHealth()))) / (occupant.getMaxHealth() + abs(occupant.getMaxHealth()))
 	return 0
 
 /obj/machinery/clonepod/transhuman/examine(mob/user, infix, suffix)
@@ -506,7 +506,7 @@
 	if(occupant)
 		data["name"] = occupant.name
 		data["health"] = occupant.health
-		data["maxHealth"] = occupant.maxHealth
+		data["maxHealth"] = occupant.getMaxHealth()
 		data["stat"] = occupant.stat
 		data["mindStatus"] = !!occupant.mind
 		data["mindName"] = occupant.mind?.name

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -191,14 +191,14 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
 				if(B.health_impacts_size)
 					B.owner.handle_belly_update()
-			if(L.health < L.maxHealth)
+			if(L.health < L.getMaxHealth())
 				L.adjustToxLoss(-2)
 				L.adjustOxyLoss(-2)
 				L.adjustCloneLoss(-1)
 				B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
 				if(B.health_impacts_size)
 					B.owner.handle_belly_update()
-	if(B.owner.nutrition > 90 && (L.health < L.maxHealth) && !H.isSynthetic())
+	if(B.owner.nutrition > 90 && (L.health < L.getMaxHealth()) && !H.isSynthetic())
 		L.adjustBruteLoss(-2.5)
 		L.adjustFireLoss(-2.5)
 		L.adjustToxLoss(-5)
@@ -396,11 +396,11 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/new_percent
 
 	if(ishuman(L))
-		old_percent = ((old_health + 50) / (L.maxHealth + 50)) * 100
-		new_percent = ((L.health + 50) / (L.maxHealth + 50)) * 100
+		old_percent = ((old_health + 50) / (L.getMaxHealth() + 50)) * 100
+		new_percent = ((L.health + 50) / (L.getMaxHealth() + 50)) * 100
 	else
-		old_percent = (old_health / L.maxHealth) * 100
-		new_percent = (L.health / L.maxHealth) * 100
+		old_percent = (old_health / L.getMaxHealth()) * 100
+		new_percent = (L.health / L.getMaxHealth()) * 100
 
 	var/lets_announce = FALSE
 	if(new_percent <= 95 && old_percent > 95)
@@ -427,11 +427,11 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/new_percent
 
 	if(ishuman(L))
-		old_percent = ((old_health + 50) / (L.maxHealth + 50)) * 100
-		new_percent = ((L.health + 50) / (L.maxHealth + 50)) * 100
+		old_percent = ((old_health + 50) / (L.getMaxHealth() + 50)) * 100
+		new_percent = ((L.health + 50) / (L.getMaxHealth() + 50)) * 100
 	else
-		old_percent = (old_health / L.maxHealth) * 100
-		new_percent = (L.health / L.maxHealth) * 100
+		old_percent = (old_health / L.getMaxHealth()) * 100
+		new_percent = (L.health / L.getMaxHealth()) * 100
 
 	var/lets_announce = FALSE
 	if(new_percent >= 100 && old_percent < 100)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -289,9 +289,9 @@
 			M.digestion_in_progress = TRUE
 			if(M.health > -36 || (ishuman(M) && M.health > -136))
 				to_chat(M, span_vnotice("(Your predator has enabled gradual body digestion. Stick around for a second round of churning to reach the true finisher.)"))
-		if(M.health < M.maxHealth * -1) //Siplemobs etc
+		if(M.health < M.getMaxHealth() * -1) //Siplemobs etc
 			if(ishuman(M))
-				if(M.health < (M.maxHealth * -1) -100) //Spacemans can go much deeper. Jank but maxHealth*-2 doesn't work with flat standard -100hp death threshold.
+				if(M.health < (M.getMaxHealth() * -1) -100) //Spacemans can go much deeper. Jank but maxHealth*-2 doesn't work with flat standard -100hp death threshold.
 					if(slow_brutal)
 						var/mob/living/carbon/human/P = M
 						var/vitals_only = TRUE
@@ -315,7 +315,7 @@
 			return
 	var/digest_alert_owner = span_vnotice(belly_format_string(digest_messages_owner, M))
 	var/digest_alert_prey = span_vnotice(belly_format_string(digest_messages_prey, M))
-	var/compensation = M.maxHealth / 5 //Dead body bonus.
+	var/compensation = M.getMaxHealth() / 5 //Dead body bonus.
 	if(ishuman(M))
 		compensation += M.getOxyLoss() //How much of the prey's damage was caused by passive crit oxyloss to compensate the lost nutrition.
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1589,7 +1589,7 @@
 			return TRUE
 		if("Health")
 			var/mob/living/ourtarget = target
-			to_chat(user, span_notice("Current health reading for \The [ourtarget]: [ourtarget.health] / [ourtarget.maxHealth] "))
+			to_chat(user, span_notice("Current health reading for \The [ourtarget]: [ourtarget.health] / [ourtarget.getMaxHealth()] "))
 			return TRUE
 		if("Process")
 			var/mob/living/ourtarget = target

--- a/code/modules/xenoarcheaology/effects/resurrect.dm
+++ b/code/modules/xenoarcheaology/effects/resurrect.dm
@@ -52,7 +52,7 @@
 		target.adjustToxLoss(-5)
 		stored_life = max(0, stored_life - 5)
 
-		if(target.health > (target.maxHealth / 4))
+		if(target.health > (target.getMaxHealth() / 4))
 			attempt_revive(target)
 			stored_life = 0
 

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -3,12 +3,6 @@
 ## level of health at which a mob goes into continual shock (soft crit)
 HEALTH_THRESHOLD_SOFTCRIT 0
 
-## level of health at which a mob becomes unconscious (crit)
-HEALTH_THRESHOLD_CRIT -50
-
-## level of health at which a mob becomes dead
-HEALTH_THRESHOLD_DEAD -100
-
 ## Determines whether bones can be broken through excessive damage to the organ
 ## 0 means bones can't break, 1 means they can
 BONES_CAN_BREAK 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Replaces checks for 'maxHealth' in the code with the more proper 'getMaxHealth()', which actually gives the proper max health one has at that current moment, taking things such as modifiers into account.
Fixes High Endurance, Low Endurance, 'Low Endurance, Major', and Glass Endurance to do as they say and adjust MaxHealth properly.
Makes maxHealth be properly calculated when it comes to death & HardCrit.
Gets rid of the hardcoded / config values for Death and Hard-crit. Soft-crit / Shock-Crit (0 hp) didn't need any touching, so it was left as is.

Also fixes xenochimera moving while dead


<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
fix: Endurance traits now are properly calculated when it comes to death & crit.
fix: Xenochimera can no longer move while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
