### PR TITLE
Fix lleill drain message

### DIFF
--- a/code/modules/mob/living/carbon/human/species/lleill/lleill_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/lleill_abilities.dm
@@ -313,9 +313,8 @@
 		if(contact_type == "Custom")
 			src.visible_message(span_infoplain("[custom_text]"))
 		if(!do_after(src, 10 SECONDS, chosen_target, exclusive = TASK_USER_EXCLUSIVE))
-			return
-		else
 			src.visible_message(span_infoplain(span_bold("\The [src]") + " and \the [chosen_target] break contact before energy has been transferred."))
+			return
 		src.visible_message(span_infoplain(span_bold("\The [src]") + " and \the [chosen_target] complete their contact."))
 		species.lleill_energy = species.lleill_energy_max
 		nutrition += (chosen_target.nutrition / 2)


### PR DESCRIPTION

## About The Pull Request

Fixes the glamour drain ability showing the "contact has been broken" message when it is successful.

## Changelog
:cl:
fix: Fixes the glamour drain ability showing the "contact has been broken" message when it is successful.
/:cl:
