### PR TITLE
Photosynthesis Component

### DIFF
--- a/code/datums/components/traits/photosynth.dm
+++ b/code/datums/components/traits/photosynth.dm
@@ -1,0 +1,28 @@
+// If a mob has this component, every life tick it will gain nutrition if it's standing in light up to nutrition_max.
+// Extremely good tutorial component if you need an example with no special bells and whistles, and no "gotcha" behaviors.
+/datum/component/photosynth
+	var/mob/living/owner
+	var/nutrition_max = 1000
+
+/datum/component/photosynth/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+	owner = parent
+	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(process_component))
+
+/datum/component/photosynth/proc/process_component()
+	if(QDELETED(parent))
+		return
+	if(owner.stat == DEAD)
+		return
+	if(!isturf(owner.loc))
+		return
+	if(owner.nutrition >= nutrition_max)
+		return
+	var/turf/T = owner.loc
+	owner.adjust_nutrition(T.get_lumcount() / 10)
+
+/datum/component/photosynth/Destroy(force = FALSE)
+	UnregisterSignal(owner, COMSIG_LIVING_LIFE)
+	owner = null
+	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1166,12 +1166,6 @@
 			take_overall_damage(1,1)
 		else //heal in the dark
 			heal_overall_damage(1,1)
-	if(species.photosynthesizing && nutrition < 1000)
-		var/light_amount = 0
-		if(isturf(loc))
-			var/turf/T = loc
-			light_amount = T.get_lumcount() / 10
-		adjust_nutrition(light_amount)
 	// nutrition decrease
 	if(nutrition <= 0 &&  species.shrinks && size_multiplier > RESIZE_TINY)
 		nutrition = 0.1

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -244,7 +244,6 @@
 	var/gluttonous											// Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
 	var/soft_landing = FALSE								// Can fall down and land safely on small falls.
 
-	var/photosynthesizing = FALSE							// If we get nutrition from light or not.
 	var/shrinks = FALSE										// If we shrink when we have no nutrition. Not added but here for downstream's sake.
 	var/grows = FALSE										// Same as above but if we grow when >1000 nutrition.
 	var/crit_mod = 1										// Used for when we go unconscious. Used downstream.

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -352,8 +352,8 @@
 	name = "Photosynthesis"
 	desc = "Your body is able to produce nutrition from being in light."
 	cost = 3
-	var_changes = list("photosynthesizing" = TRUE)
 	can_take = ORGANICS|SYNTHETICS //Synths actually use nutrition, just with a fancy covering.
+	added_component_path = /datum/component/photosynth
 
 /datum/trait/positive/rad_resistance
 	name = "Radiation Resistance"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -516,6 +516,7 @@
 #include "code\datums\components\disabilities\tourettes.dm"
 #include "code\datums\components\traits\drippy.dm"
 #include "code\datums\components\traits\gargoyle.dm"
+#include "code\datums\components\traits\photosynth.dm"
 #include "code\datums\components\traits\waddle.dm"
 #include "code\datums\components\traits\weaver.dm"
 #include "code\datums\components\species\shadekin.dm"


### PR DESCRIPTION
## About The Pull Request
A majority of simple trait and species functionality should be moved to components to ease memory use, and prepare for future species datum refactors.

## Changelog
Converts photosynthesis code from life tick code to a component added by a trait or species. No player facing changes. Theoretically this could be made into a gene-trait in the future to let genetics give people photosynthesis powers, but that is not present in this PR.

:cl:
refactor: Photosynthesis code moved to component
/:cl: