### PR TITLE
Nutrition Resizing Component

### DIFF
--- a/code/datums/components/traits/nutrition_size_change.dm
+++ b/code/datums/components/traits/nutrition_size_change.dm
@@ -1,0 +1,54 @@
+#define GROWMODE_SHRINK 1
+#define GROWMODE_GROW 2
+
+/datum/component/nutrition_size_change
+	var/mob/living/owner
+	var/grow_mode = 0 // Don't use base component
+
+/datum/component/nutrition_size_change/growing
+	grow_mode = GROWMODE_GROW
+
+/datum/component/nutrition_size_change/shrinking
+	grow_mode = GROWMODE_SHRINK
+
+/datum/component/nutrition_size_change/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+	owner = parent
+	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(process_component))
+
+/datum/component/nutrition_size_change/proc/process_component()
+	if(QDELETED(parent))
+		return
+	if(owner.stat == DEAD)
+		return
+	if(owner.nutrition <= 0 && grow_mode == GROWMODE_SHRINK && owner.size_multiplier > RESIZE_TINY)
+		owner.nutrition = 0.1
+	if(owner.nutrition <= 0)
+		return
+	// Species controls hunger rate for humans, otherwise use defaults
+	var/nutrition_reduction = DEFAULT_HUNGER_FACTOR
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		nutrition_reduction = H.species.hunger_factor
+	// Modifiers can increase or decrease nutrition cost
+	for(var/datum/modifier/mod in owner.modifiers)
+		if(!isnull(mod.metabolism_percent))
+			nutrition_reduction *= mod.metabolism_percent
+	// Time to change size!
+	if(owner.nutrition > 1000 && grow_mode == GROWMODE_GROW) //Removing the strict check against normal max/min size to support dorms/VR oversizing
+		nutrition_reduction *= 5
+		owner.resize(owner.size_multiplier+0.01, animate = FALSE, uncapped = owner.has_large_resize_bounds()) //Bringing this code in line with micro and macro shrooms
+	if(owner.nutrition < 50 && grow_mode == GROWMODE_SHRINK)
+		nutrition_reduction *= 0.3
+		owner.resize(owner.size_multiplier-0.01, animate = FALSE, uncapped = owner.has_large_resize_bounds()) //Bringing this code in line with micro and macro shrooms
+	// Apply hunger costs
+	owner.adjust_nutrition(-nutrition_reduction)
+
+/datum/component/nutrition_size_change/Destroy(force = FALSE)
+	UnregisterSignal(owner, COMSIG_LIVING_LIFE)
+	owner = null
+	. = ..()
+
+#undef GROWMODE_SHRINK
+#undef GROWMODE_GROW

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1173,22 +1173,6 @@
 			light_amount = T.get_lumcount() / 10
 		adjust_nutrition(light_amount)
 	// nutrition decrease
-	if(nutrition <= 0 &&  species.shrinks && size_multiplier > RESIZE_TINY)
-		nutrition = 0.1
-	if(nutrition > 0 && stat != DEAD)
-		var/nutrition_reduction = species.hunger_factor
-
-		for(var/datum/modifier/mod in modifiers)
-			if(!isnull(mod.metabolism_percent))
-				nutrition_reduction *= mod.metabolism_percent
-		if(nutrition > 1000 && species.grows) //Removing the strict check against normal max/min size to support dorms/VR oversizing
-			nutrition_reduction *= 5
-			resize(size_multiplier+0.01, animate = FALSE, uncapped = has_large_resize_bounds()) //Bringing this code in line with micro and macro shrooms
-		if(nutrition < 50 && species.shrinks)
-			nutrition_reduction *= 0.3
-			resize(size_multiplier-0.01, animate = FALSE, uncapped = has_large_resize_bounds()) //Bringing this code in line with micro and macro shrooms
-		adjust_nutrition(-nutrition_reduction)
-
 	if(noisy == TRUE && nutrition < 250 && prob(10))
 		var/sound/growlsound = sound(get_sfx("hunger_sounds"))
 		var/growlmultiplier = 100 - (nutrition / 250 * 100)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -245,8 +245,6 @@
 	var/soft_landing = FALSE								// Can fall down and land safely on small falls.
 
 	var/photosynthesizing = FALSE							// If we get nutrition from light or not.
-	var/shrinks = FALSE										// If we shrink when we have no nutrition. Not added but here for downstream's sake.
-	var/grows = FALSE										// Same as above but if we grow when >1000 nutrition.
 	var/crit_mod = 1										// Used for when we go unconscious. Used downstream.
 	var/list/env_traits = list()
 	var/pixel_offset_x = 0									// Used for offsetting 64x64 and up icons.

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1692,3 +1692,19 @@
 	..()
 	var/datum/component/waddle_trait/G = H.GetComponent(added_component_path)
 	G.waddling = trait_prefs["waddler"]
+
+/datum/trait/neutral/nutritiongrow
+	name = "Growing"
+	desc = "After you consume enough nutrition, you start to slowly grow while metabolizing nutrition faster."
+	excludes = list(/datum/trait/neutral/nutritionshrink)
+	cost = 0
+	hidden = TRUE //Disabled on Virgo
+	added_component_path = /datum/component/nutrition_size_change/growing
+
+/datum/trait/neutral/nutritionshrink
+	name = "Shrinking"
+	desc = "If you don't eat enough, your body starts shrinking to make up the difference!"
+	excludes = list(/datum/trait/neutral/nutritiongrow)
+	cost = 0
+	hidden = TRUE //Disabled on Virgo
+	added_component_path = /datum/component/nutrition_size_change/shrinking

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -517,6 +517,7 @@
 #include "code\datums\components\disabilities\tourettes.dm"
 #include "code\datums\components\traits\drippy.dm"
 #include "code\datums\components\traits\gargoyle.dm"
+#include "code\datums\components\traits\nutrition_size_change.dm"
 #include "code\datums\components\traits\waddle.dm"
 #include "code\datums\components\traits\weaver.dm"
 #include "code\datums\components\species\shadekin.dm"


### PR DESCRIPTION
## About The Pull Request
A majority of simple trait and species functionality should be moved to components to ease memory use, and prepare for future species datum refactors.

## Changelog
Converts already present nutrition based resizing code to a component. Instead of always happening during the life() tick of all living mobs. Partially ports growing and shrinking traits from downstream for testing, but I have made them hidden, so they are not player accessible. There should be no player facing changes in this PR.

:cl:
add: Nutrition resizing traits, disabled on virgo
refactor: Moved nutrition resizing code to components
/:cl: