### PR TITLE
Light-Based Damage Component For Zaddat and Shadows

### DIFF
--- a/code/datums/components/traits/burninlight.dm
+++ b/code/datums/components/traits/burninlight.dm
@@ -1,16 +1,16 @@
-// If a mob has this component, every life tick it will gain nutrition if it's standing in light up to nutrition_max.
-// Extremely good tutorial component if you need an example with no special bells and whistles, and no "gotcha" behaviors.
 /datum/component/burninlight
 	var/mob/living/owner
+	// This is a merge of the old shadow species light burning life code, and Zaddat's handle_environment_special() proc.
+	// It handles both cases, but shadows behave more like Zaddat do now. By default this code follows Zaddat damage with no healing.
 	var/threshold = 0.2 // percent from 0 to 1
-	// Damage or healing per life fick
-	var/damage_rate = 1
-	var/heal_rate = 1
+	// Damage or healing per life tick
+	var/damage_rate = 1.25
+	var/heal_rate = 0
 
-/datum/component/burninlight/zaddat
-	threshold = 0.1
-	damage_rate = 1.25
-	heal_rate = 0
+/datum/component/burninlight/shadow
+	threshold = 0.15
+	damage_rate = 1
+	heal_rate = 1
 
 /datum/component/burninlight/Initialize()
 	if(!isliving(parent))
@@ -28,23 +28,23 @@
 	if(owner.inStasisNow())
 		return
 
-	// This is a merge of the old shadow species light burning life code, and Zaddat's handle_environment_special() proc. It handles both cases, but shadows behave more like Zaddat do now.
 	var/light_amount = 0 //how much light there is in the place, affects damage
 	if(isturf(owner.loc)) //else, there's considered to be no light
 		var/turf/T = owner.loc
 		light_amount = T.get_lumcount(0,1)
 
 	// Apply damage if beyond the minimum light threshold, actually makes zaddat SLIGHTLY more forgiving!
-	if(light_amount > threshold)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			var/damageable = H.get_damageable_organs()
-			var/covered = H.get_coverage()
-			for(var/K in damageable)
-				if(!(K in covered))
-					H.apply_damage(light_amount * damage_rate, BURN, K, 0, 0)
-		else
-			owner.take_overall_damage(light_amount * damage_rate,light_amount * damage_rate)
+	if(light_amount > 0 && light_amount > threshold) // Checks light_amount, as threshold of 0 can pass 0s to the damage procs otherwise.
+		if(damage_rate > 0)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/H = owner
+				var/damageable = H.get_damageable_organs()
+				var/covered = H.get_coverage()
+				for(var/K in damageable)
+					if(!(K in covered))
+						H.apply_damage(light_amount * damage_rate, BURN, K, 0, 0)
+			else
+				owner.take_overall_damage(light_amount * damage_rate,light_amount * damage_rate)
 
 	// heal in the dark, if possible
 	else if(heal_rate > 0)

--- a/code/datums/components/traits/burninlight.dm
+++ b/code/datums/components/traits/burninlight.dm
@@ -1,0 +1,56 @@
+// If a mob has this component, every life tick it will gain nutrition if it's standing in light up to nutrition_max.
+// Extremely good tutorial component if you need an example with no special bells and whistles, and no "gotcha" behaviors.
+/datum/component/burninlight
+	var/mob/living/owner
+	var/threshold = 0.2 // percent from 0 to 1
+	// Damage or healing per life fick
+	var/damage_rate = 1
+	var/heal_rate = 1
+
+/datum/component/burninlight/zaddat
+	threshold = 0.1
+	damage_rate = 1.25
+	heal_rate = 0
+
+/datum/component/burninlight/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+	owner = parent
+	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(process_component))
+
+/datum/component/burninlight/proc/process_component()
+	if(QDELETED(parent))
+		return
+	if(owner.stat == DEAD)
+		return
+	if(!isturf(owner.loc))
+		return
+	if(owner.inStasisNow())
+		return
+
+	// This is a merge of the old shadow species light burning life code, and Zaddat's handle_environment_special() proc. It handles both cases, but shadows behave more like Zaddat do now.
+	var/light_amount = 0 //how much light there is in the place, affects damage
+	if(isturf(owner.loc)) //else, there's considered to be no light
+		var/turf/T = owner.loc
+		light_amount = T.get_lumcount(0,1)
+
+	// Apply damage if beyond the minimum light threshold, actually makes zaddat SLIGHTLY more forgiving!
+	if(light_amount > threshold)
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			var/damageable = H.get_damageable_organs()
+			var/covered = H.get_coverage()
+			for(var/K in damageable)
+				if(!(K in covered))
+					H.apply_damage(light_amount * damage_rate, BURN, K, 0, 0)
+		else
+			owner.take_overall_damage(light_amount * damage_rate,light_amount * damage_rate)
+
+	// heal in the dark, if possible
+	else if(heal_rate > 0)
+		owner.heal_overall_damage(heal_rate,heal_rate)
+
+/datum/component/burninlight/Destroy(force = FALSE)
+	UnregisterSignal(owner, COMSIG_LIVING_LIFE)
+	owner = null
+	. = ..()

--- a/code/datums/components/traits/drippy.dm
+++ b/code/datums/components/traits/drippy.dm
@@ -24,6 +24,8 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.inStasisNow())
+		return
 	var/turf/T = get_turf(owner.loc)
 	if(!isturf(T))
 		return

--- a/code/datums/components/traits/nutrition_size_change.dm
+++ b/code/datums/components/traits/nutrition_size_change.dm
@@ -22,6 +22,8 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.inStasisNow())
+		return
 	if(owner.nutrition <= 0 && grow_mode == GROWMODE_SHRINK && owner.size_multiplier > RESIZE_TINY)
 		owner.nutrition = 0.1
 	if(owner.nutrition <= 0)

--- a/code/datums/components/traits/photosynth.dm
+++ b/code/datums/components/traits/photosynth.dm
@@ -15,6 +15,8 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.inStasisNow())
+		return
 	if(!isturf(owner.loc))
 		return
 	if(owner.nutrition >= nutrition_max)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -233,7 +233,10 @@
 	return in_stasis
 
 //This determines if, RIGHT NOW, the life() tick is being skipped due to stasis
-/mob/living/carbon/human/proc/inStasisNow()
+/mob/proc/inStasisNow() // For components to be more easily compatible with both simple and human mobs, only humans can stasis.
+	return FALSE
+
+/mob/living/carbon/human/inStasisNow()
 	var/stasisValue = getStasis()
 	if(stasisValue && (life_tick % stasisValue))
 		return 1

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -232,7 +232,7 @@
 
 	return in_stasis
 
-//This determines if, RIGHT NOW, the life() tick is being skipped due to stasis
+/// This determines if, RIGHT NOW, the life() tick is being skipped due to stasis
 /mob/proc/inStasisNow() // For components to be more easily compatible with both simple and human mobs, only humans can stasis.
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1157,15 +1157,6 @@
 	if(status_flags & GODMODE)
 		return 0	//godmode
 
-	if(species.light_dam)
-		var/light_amount = 0
-		if(isturf(loc))
-			var/turf/T = loc
-			light_amount = T.get_lumcount() * 10
-		if(light_amount > species.light_dam) //if there's enough light, start dying
-			take_overall_damage(1,1)
-		else //heal in the dark
-			heal_overall_damage(1,1)
 	// nutrition decrease
 	if(noisy == TRUE && nutrition < 250 && prob(10))
 		var/sound/growlsound = sound(get_sfx("hunger_sounds"))

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -26,7 +26,7 @@
 
 	assisted_langs = list()
 
-	species_component = /datum/component/burninlight // Until a parent component like xenochimera have is needed, only handles burning in light.
+	species_component = /datum/component/burninlight/shadow // Until a parent component like xenochimera have is needed, only handles burning in light.
 
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -7,7 +7,6 @@
 
 	language = "Sol Common" //todo?
 	unarmed_types = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/sharp)
-	light_dam = 2
 	darksight = 8
 	has_organ = list()
 	siemens_coefficient = 0
@@ -26,6 +25,8 @@
 	genders = list(NEUTER)
 
 	assisted_langs = list()
+
+	species_component = /datum/component/burninlight // Until a parent component like xenochimera have is needed, only handles burning in light.
 
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -202,7 +202,6 @@
 	var/warning_low_pressure = WARNING_LOW_PRESSURE			// Low pressure warning.
 	var/hazard_low_pressure = HAZARD_LOW_PRESSURE			// Dangerously low pressure.
 	var/safe_pressure = ONE_ATMOSPHERE
-	var/light_dam											// If set, mob will be damaged in light over this value and heal in light below its negative.
 	var/minimum_breath_pressure = 16						// Minimum required pressure for breath, in kPa
 
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -489,7 +489,7 @@
 
 	reagent_tag = IS_ZADDAT
 
-	species_component = /datum/component/burninlight/zaddat // Until a parent component like xenochimera have is needed, only handles burning in light.
+	species_component = /datum/component/burninlight // Until a parent component like xenochimera have is needed, only handles burning in light.
 
 	heat_discomfort_strings = list(
 		"Your joints itch.",

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -489,6 +489,8 @@
 
 	reagent_tag = IS_ZADDAT
 
+	species_component = /datum/component/burninlight/zaddat // Until a parent component like xenochimera have is needed, only handles burning in light.
+
 	heat_discomfort_strings = list(
 		"Your joints itch.",
 		"You feel uncomfortably warm.",
@@ -530,24 +532,6 @@
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/zaddat/(H), slot_wear_mask) // mask has to come first or Shroud helmet will get in the way
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/void/zaddat/(H), slot_wear_suit)
-
-/datum/species/zaddat/handle_environment_special(var/mob/living/carbon/human/H)
-
-	if(H.inStasisNow())
-		return
-
-	var/damageable = H.get_damageable_organs()
-	var/covered = H.get_coverage()
-
-	var/light_amount = 0 //how much light there is in the place, affects damage
-	if(isturf(H.loc)) //else, there's considered to be no light
-		var/turf/T = H.loc
-		light_amount = T.get_lumcount() * 5
-
-
-	for(var/K in damageable)
-		if(!(K in covered))
-			H.apply_damage(light_amount/4, BURN, K, 0, 0)
 
 /datum/species/diona
 

--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -760,6 +760,14 @@
 	category = 0
 	custom_only = FALSE
 
+/datum/trait/negative/photodegeneration
+	name = "Photodegeneration"
+	desc = "Without the protection of darkness or a suit your body quickly begins to break down when exposed to light."
+	cost = -4
+	is_genetrait = TRUE // There is no upside, a neat landmine for genetics
+	hidden = TRUE //Disabled on Virgo
+	can_take = ORGANICS
+	added_component_path = /datum/component/burninlight // Literally just Zaddat, but you don't start with any suit. Good luck.
 
 // Addictions
 /datum/trait/neutral/addiction_alcohol

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -515,6 +515,7 @@
 #include "code\datums\components\disabilities\nervousness.dm"
 #include "code\datums\components\disabilities\rotting.dm"
 #include "code\datums\components\disabilities\tourettes.dm"
+#include "code\datums\components\traits\burninlight.dm"
 #include "code\datums\components\traits\drippy.dm"
 #include "code\datums\components\traits\gargoyle.dm"
 #include "code\datums\components\traits\nutrition_size_change.dm"


### PR DESCRIPTION
## About The Pull Request
A majority of simple trait and species functionality should be moved to components to ease memory use, and prepare for future species datum refactors. This code was previously only used on species/shadow, and zaddat handle_environment code. It has been consolidated into one component with similar damage to before. While it offers the ability to heal for shadows, this functionality is disabled for zaddat. Suits will protect you from damage, the same way they did before on zaddat.

Adds a genetrait for photodegeneration, giving you zaddat style light harming if you are not in darkness or a suit. Has no upsides, and is disabled from round-start picking. Can be removed from genetraits if requested.

## Changelog
Refactors species/shadow and zaddat light based harm code. Follows zaddat code the closest. Meaning that if you wear a suit you will be protected on any body part covered by that suit.
Moved the base proc of inStasisNow() to mob instead of human, returns false by default. Allows much easier compatibility of components that work for both simple mobs AND humans with minimal snowflake code.
Added inStasisNow() checks to several other trait components, this will fix drippy filling cryopods with goop drips.

:cl:
add: Photodegeneration genetrait, cannot be selected from round start
fix: Drippy trait will no longer drop drips into the cryopod when a human with it is in the pod
refactor: inStasisNow() has a base proc on mob, for ease of component compatibility between simple and human mobs
refactor: Moved species/shadow and zaddat light-based damage code to a component
/:cl: