### PR TITLE
Extinguishing Paincrit Mobs or Bodies

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -165,7 +165,7 @@
 	return shock_damage
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
-	if (health >= get_crit_point())
+	if (health >= get_crit_point() || on_fire)
 		if(src == M && ishuman(src))
 			var/mob/living/carbon/human/H = src
 			var/datum/gender/T = GLOB.gender_datums[H.get_visible_gender()]


### PR DESCRIPTION
## About The Pull Request
The interaction to extinguish a mob on fire by hand was locked behind the mob being above critical hp. Meaning bodies or mobs in paincrit would ignore extinguishing attempts.

## Changelog
You will no longer watch as your companions turn to ash around you because help code refuses to be helpful.

:cl:
fix: mobs can be extinguished by hand when beneath paincrit threshold
/:cl: