### PR TITLE
Makes TTS device free

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -11,7 +11,7 @@
 /datum/gear/utility/tts_device
 	display_name = "text to speech device"
 	path = /obj/item/text_to_speech
-	cost = 3 //Not extremely expensive, but it's useful for mute chracters.
+	cost = 0
 
 /datum/gear/utility/communicator
 	display_name = "communicator selection"


### PR DESCRIPTION

## About The Pull Request
Makes TTS cost 0 points

I made the damned thing and I'm quickly realizing how penalizing 3 points is for a functionality piece of equipment...That's 20% of your points in just one item that lets you speak to people. That means you have 3 points less for actual fluff items, clothing, etc. 

Honestly I need to make it so if you're mute you just get it outright but eh, that is for another time.
## Changelog
:cl: Diana
qol: TTS device now costs 0 points
/:cl:
