### PR TITLE
Global chem blacklist + SM addition to blacklist

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -414,7 +414,7 @@ var/global/list/item_digestion_blacklist = list(
 		/obj/item/rig/protean)
 
 ///A list of chemicals that are banned from being obtainable through means that generate chemicals. These chemicals are either lame, annoying, pref-breaking, or OP (This list does NOT include reactions)
-var/global/list/obtainable_chemical_blacklist = list(
+GLOBAL_LIST_INIT(obtainable_chemical_blacklist, list(
 	REAGENT_ID_ADMINORDRAZINE,
 	REAGENT_ID_NUTRIMENT,
 	REAGENT_ID_MACROCILLIN,
@@ -422,7 +422,7 @@ var/global/list/obtainable_chemical_blacklist = list(
 	REAGENT_ID_NORMALCILLIN,
 	REAGENT_ID_MAGICDUST,
 	REAGENT_ID_SUPERMATTER
-	)
+	))
 
 var/global/list/item_tf_spawnpoints = list() // Global variable tracking which items are item tf spawnpoints
 

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -413,6 +413,17 @@ var/global/list/item_digestion_blacklist = list(
 		/obj/item/mmi/digital/robot,
 		/obj/item/rig/protean)
 
+///A list of chemicals that are banned from being obtainable through means that generate chemicals. These chemicals are either lame, annoying, pref-breaking, or OP (This list does NOT include reactions)
+var/global/list/obtainable_chemical_blacklist = list(
+	REAGENT_ID_ADMINORDRAZINE,
+	REAGENT_ID_NUTRIMENT,
+	REAGENT_ID_MACROCILLIN,
+	REAGENT_ID_MICROCILLIN,
+	REAGENT_ID_NORMALCILLIN,
+	REAGENT_ID_MAGICDUST,
+	REAGENT_ID_SUPERMATTER
+	)
+
 var/global/list/item_tf_spawnpoints = list() // Global variable tracking which items are item tf spawnpoints
 
 // Options for transforming into a different mob in virtual reality.

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -461,23 +461,15 @@
 	var/additional_chems = rand(0,5)
 
 	if(additional_chems)
-		// VOREStation Edit Start: Modified exclusion list
-		var/list/banned_chems = list(
-			REAGENT_ID_ADMINORDRAZINE,
-			REAGENT_ID_NUTRIMENT,
-			REAGENT_ID_MACROCILLIN,
-			REAGENT_ID_MICROCILLIN,
-			REAGENT_ID_NORMALCILLIN,
-			REAGENT_ID_MAGICDUST
-			)
-		// VOREStation Edit End: Modified exclusion list
 
 		for(var/x=1;x<=additional_chems;x++)
 
 			var/new_chem = pick(SSchemistry.chemical_reagents)
-			if(new_chem in banned_chems)
+			var/list/currently_banned_chems = list()
+			currently_banned_chems += obtainable_chemical_blacklist
+			if(new_chem in obtainable_chemical_blacklist)
 				continue
-			banned_chems += new_chem
+			currently_banned_chems += new_chem
 			chems[new_chem] = list(rand(1,10),rand(10,20))
 
 	if(prob(5))

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -466,8 +466,8 @@
 
 			var/new_chem = pick(SSchemistry.chemical_reagents)
 			var/list/currently_banned_chems = list()
-			currently_banned_chems += obtainable_chemical_blacklist
-			if(new_chem in obtainable_chemical_blacklist)
+			currently_banned_chems += GLOB.obtainable_chemical_blacklist
+			if(new_chem in currently_banned_chems)
 				continue
 			currently_banned_chems += new_chem
 			chems[new_chem] = list(rand(1,10),rand(10,20))

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -617,21 +617,14 @@
 			//However, in that case Initialize will set the maximum volume to the volume for us, so we don't need to do anything.
 			S.reagents?.maximum_volume = 15
 			item_type = new_item.name
-			//Taken from hydroponics/seed.dm...This should be a global list at some point and reworked in both places.
-			var/list/banned_chems = list(
-				REAGENT_ID_ADMINORDRAZINE,
-				REAGENT_ID_NUTRIMENT,
-				REAGENT_ID_MACROCILLIN,
-				REAGENT_ID_MICROCILLIN,
-				REAGENT_ID_NORMALCILLIN,
-				REAGENT_ID_MAGICDUST
-				)
 			var/additional_chems = 5 //5 random chems added to the syringe! 15u of RANDOM stuff! (I tried to keep this 30, but this was...Horribly bugged. There is no icon_state for 16-30, so the icon was invisible when filled.)
 			for(var/x=1;x<=additional_chems;x++)
 				var/new_chem = pick(SSchemistry.chemical_reagents)
-				if(new_chem in banned_chems)
+				var/list/currently_banned_chems = list()
+				currently_banned_chems += obtainable_chemical_blacklist
+				if(new_chem in currently_banned_chems)
 					continue
-				banned_chems += new_chem
+				currently_banned_chems += new_chem
 				S.reagents.add_reagent(new_chem, 3)
 
 		if(ARCHAEO_RING)

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -621,7 +621,7 @@
 			for(var/x=1;x<=additional_chems;x++)
 				var/new_chem = pick(SSchemistry.chemical_reagents)
 				var/list/currently_banned_chems = list()
-				currently_banned_chems += obtainable_chemical_blacklist
+				currently_banned_chems += GLOB.obtainable_chemical_blacklist
 				if(new_chem in currently_banned_chems)
 					continue
 				currently_banned_chems += new_chem

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -1,6 +1,3 @@
-
-
-
 //endless reagents!
 /obj/item/reagent_containers/glass/replenishing
 	var/spawning_id
@@ -10,7 +7,7 @@
 	START_PROCESSING(SSobj, src)
 	for(var/x=1;x<=10;x++) //You got 10 chances to hit a reagent that is NOT banned.
 		var/new_chem = pick(SSchemistry.chemical_reagents)
-		if(new_chem in obtainable_chemical_blacklist)
+		if(new_chem in GLOB.obtainable_chemical_blacklist)
 			continue
 		else
 			spawning_id = new_chem

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -8,18 +8,9 @@
 /obj/item/reagent_containers/glass/replenishing/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	//Taken from hydroponics/seed.dm...This should be a global list at some point and reworked in both places.
-	var/list/banned_chems = list(
-		REAGENT_ID_ADMINORDRAZINE,
-		REAGENT_ID_NUTRIMENT,
-		REAGENT_ID_MACROCILLIN,
-		REAGENT_ID_MICROCILLIN,
-		REAGENT_ID_NORMALCILLIN,
-		REAGENT_ID_MAGICDUST
-		)
 	for(var/x=1;x<=10;x++) //You got 10 chances to hit a reagent that is NOT banned.
 		var/new_chem = pick(SSchemistry.chemical_reagents)
-		if(new_chem in banned_chems)
+		if(new_chem in obtainable_chemical_blacklist)
 			continue
 		else
 			spawning_id = new_chem


### PR DESCRIPTION

## About The Pull Request
Moves the chem blacklist for obtainable sources (Xenobotany & Xenoarcheology) to a global list instead of the same list in 4 different spots.
Adds REAGENT_ID_SUPERMATTER to the list of blacklisted reagents...It currently has no use in game other than instakilling people. (If there was a reason to obtain it such as a recipe, a reaction, or ANYTHING then it could make sense to be in there, but ATM it has 0 use other than "instakill everyone" which...Yeah.)
## Changelog
:cl: Diana
del: Supermatter is no longer obtainable via xenoarcheology & xenobotany
/:cl:
