### PR TITLE
Gene Scanner Tool

### DIFF
--- a/code/game/objects/items/devices/scanners/gene.dm
+++ b/code/game/objects/items/devices/scanners/gene.dm
@@ -1,0 +1,90 @@
+/obj/item/gene_scanner
+	name = "DNA identifier"
+	desc = "Assess the cargo sale value of items."
+	icon = 'icons/obj/device_alt.dmi'
+	icon_state = "health"
+	flags = NOBLUDGEON
+	slot_flags = SLOT_BELT
+	w_class = ITEMSIZE_SMALL
+	origin_tech = list(TECH_DATA = 1)
+
+// Always face the user when put on a table
+/obj/item/gene_scanner/afterattack(atom/movable/AM, mob/user, proximity)
+	if(!proximity)
+		return
+	if(!ismob(AM) && !istype(AM,/obj/item/organ))
+		return
+
+	to_chat(user,span_boldnotice("You assesses \the [AM]'s genetic traits."))
+	playsound(src, 'sound/misc/bloop.ogg', 50, 1)
+	flick("health2", src)
+
+	if(do_after(user,6 SECONDS,AM))
+		scan_genes(AM,user)
+
+/obj/item/gene_scanner/proc/scan_genes(atom/movable/AM,mob/user)
+	var/obj/item/organ/O = AM
+	var/mob/living/L = AM
+	var/output = ""
+
+	// Actually do the scan
+	if(isliving(L)) // Mobs
+		if(!L.dna)
+			output += span_danger("Inconclusive.")
+			to_chat(user,output)
+			return
+
+		if(SKELETON in L.mutations)
+			output += span_vdanger("SUBJECT IS SPOOKY SCARY SKELETON")
+			to_chat(user,output)
+			return
+
+		var/mob/living/carbon/human/H = L
+		if(ishuman(L))
+			if(H.species.flags & NO_DNA)
+				output += span_warning("Subject incompatible.")
+				to_chat(user,output)
+				return
+			if(H.species.flags & NO_SLEEVE)
+				output += span_danger("!!Subject incompatible with cloning!!") + "<br>"
+		output += span_infoplain("Unique enzymes: [L.dna.unique_enzymes]") + "<br>"
+		output += span_infoplain("Bloodtype: [L.dna.b_type]") + "<br>"
+
+		if(L.radiation > 0)
+			if(L.radiation > 200)
+				output += span_danger("Subject is severely irradiated") + "<br>"
+			else
+				output += span_warning("Subject is irradiated") + "<br>"
+		if(L.getCloneLoss())
+			if(L.getCloneLoss() > 50)
+				output += span_danger("[L.getCloneLoss()] Genetic damage") + "<br>"
+			else
+				output += span_warning("[L.getCloneLoss()] Genetic damage") + "<br>"
+
+		if(NOCLONE in L.mutations)
+			output += span_warning("Subject's dna is unstable") + "<br>"
+		if(HUSK in L.mutations)
+			output += span_warning("Subject's anatomical structure is destroyed") + "<br>"
+
+		output += span_boldnotice("Detected genes:") + "<br>"
+		for(var/datum/gene/G in GLOB.dna_genes)
+			if(!L.dna.GetSEState(G.block))
+				continue
+			if(istype(G,/datum/gene/trait))
+				var/datum/gene/trait/TG = G
+				output += span_info("-[TG.linked_trait.name]") + "<br>"
+				output += span_infoplain("  [TG.linked_trait.desc]") + "<br>"
+			else
+				output += span_info("-[G.name]") + "<br>"
+				output += span_infoplain("  [G.desc]") + "<br>"
+
+	else if(istype(O)) // Organs
+		if(!O.data)
+			output += span_danger("Inconclusive.")
+			to_chat(user,output)
+			return
+
+		output += span_infoplain("Unique enzymes: [O.data.unique_enzymes]") + "<br>"
+		output += span_infoplain("Bloodtype: [O.data.b_type]") + "<br>"
+
+	to_chat(user,output)

--- a/code/game/objects/items/devices/scanners/gene.dm
+++ b/code/game/objects/items/devices/scanners/gene.dm
@@ -72,7 +72,10 @@
 				continue
 			if(istype(G,/datum/gene/trait))
 				var/datum/gene/trait/TG = G
-				output += span_info("-[TG.linked_trait.name]") + "<br>"
+				if(ishuman(L))
+					output += span_info("-[TG.linked_trait.name]") + span_warning((TG.has_conflict(H.species.traits) ? " (Suppressed)" : "")) + "<br>"
+				else
+					output += span_info("-[TG.linked_trait.name]") + "<br>"
 				output += span_infoplain("  [TG.linked_trait.desc]") + "<br>"
 			else
 				output += span_info("-[G.name]") + "<br>"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -248,7 +248,8 @@
 		/obj/item/mass_spectrometer,
 		/obj/item/surgical,
 		/obj/item/clothing/mask/chewable/candy/lolli,
-		/obj/item/extrapolator
+		/obj/item/extrapolator,
+		/obj/item/gene_scanner,
 		)
 
 /obj/item/storage/belt/medical/emt

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -159,6 +159,8 @@
 		/obj/item/taperoll/medical,
 		/obj/item/storage/box/freezer,
 		/obj/item/clothing/mask/chewable/candy/lolli,
+		/obj/item/extrapolator,
+		/obj/item/gene_scanner,
 	) //Vorestation add - added a bunch of misc medical stuff
 	max_storage_space = ITEMSIZE_COST_SMALL*3 //Vorestation Add - makes it slightly smaller since its a lot of stuff with pocket access
 	remove_delay = 5 //Vorestation Add - .5 second delay, get the medical things faster because there is no reason to use this otherwise. still gotta stop moving to take things out.

--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -383,6 +383,8 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 		/obj/item/cartridge/engineering,
 		/obj/item/analyzer,
 		/obj/item/healthanalyzer,
+		/obj/item/extrapolator,
+		/obj/item/gene_scanner,
 		/obj/item/robotanalyzer,
 		/obj/item/lightreplacer,
 		/obj/item/radio,

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -97,6 +97,13 @@
 	build_path = /obj/item/healthanalyzer/advanced
 	sort_string = "KBAAC"
 
+/datum/design/item/medical/gene_scanner
+	name = "Gene Scanner"
+	id = "gene_scanner"
+	req_tech = list(TECH_DATA = 1, TECH_BIO = 2)
+	build_path = /obj/item/gene_scanner
+	sort_string = "KBAAD"
+
 /datum/design/item/medical/advanced_roller
 	name = "advanced roller bed"
 	desc = "A more advanced version of the regular roller bed, with inbuilt surgical stabilisers and an improved folding system."

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1446,6 +1446,7 @@
 #include "code\game\objects\items\devices\radio\radio_vr.dm"
 #include "code\game\objects\items\devices\radio\radiopack.dm"
 #include "code\game\objects\items\devices\scanners\gas.dm"
+#include "code\game\objects\items\devices\scanners\gene.dm"
 #include "code\game\objects\items\devices\scanners\guide.dm"
 #include "code\game\objects\items\devices\scanners\halogen.dm"
 #include "code\game\objects\items\devices\scanners\health.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a tool for finding active genes in a scanned subject. Also reports the unique enzyme string and bloodtype for mobs and organs scanned. Only reports active genes, not all traits a mob has. Reports if a gene is blocked by another trait somehow. Adds it to lathe and some loot piles.

Note: Needs to be mapped in to genetics labs, otherwise the geneticist will need to find one themselves or ask sci.

## Changelog
Adds gene scanner item
Allows virolgists to put their extrapolator in their belt

:cl:
add: Gene scanner tool for genetics to detect traits in monkeys and humans.
qol: Virus extrapolator not being store-able in the medical belt and pouch
/:cl:
