### PR TITLE
Capsaicin Fix

### DIFF
--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -802,7 +802,7 @@
 	M.adjustToxLoss(0.5 * removed)
 
 /datum/reagent/capsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
+	// Do not call parent, we don't want this absorbed into our bloodstream!
 	handle_spicy(M, alien, removed)
 
 /datum/reagent/proc/handle_spicy(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
## About The Pull Request
A recent change to capsaicin made the reagent call the parent proc for handle_ingested() making the reagent enter the bloodstream, doing toxin damage.

## Changelog
Removed call to parent proc from /datum/reagent/capsaicin/affect_ingest()

:cl:
fix: Capsaicin no longer causes toxin damage when eaten
/:cl:

