### PR TITLE
Gets rid of digi_allowed

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -178,10 +178,7 @@ var/const/preview_icons = 'icons/mob/human_races/preview.dmi'
 	character.b_type	= pref.b_type
 	character.synth_color = pref.synth_color
 	character.synth_markings = pref.synth_markings
-	if(character.species.digi_allowed)
-		character.digitigrade = pref.digitigrade
-	else
-		character.digitigrade = 0
+	character.digitigrade = pref.digitigrade
 
 	//sanity check
 	if(character.digitigrade == null)
@@ -351,8 +348,6 @@ var/const/preview_icons = 'icons/mob/human_races/preview.dmi'
 			"can_select" = can_select,
 		)
 	data["can_play"] = can_play_list
-
-	data["digi_allowed"] = GLOB.all_species[pref.species].digi_allowed
 
 	var/list/available_hair_styles = list()
 	for(var/path in pref.get_available_styles(hair_styles_list))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -628,7 +628,7 @@ var/list/preferences_datums = list()
 	character.custom_whisper	= lowertext(trim(custom_whisper))
 	character.custom_exclaim	= lowertext(trim(custom_exclaim))
 
-	character.digitigrade = selected_species.digi_allowed ? digitigrade : 0
+	character.digitigrade = digitigrade
 
 	for(var/obj/item/clothing/O in character.contents)
 		O.handle_digitigrade(character)

--- a/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/hanner.dm
@@ -20,8 +20,6 @@
 	min_age = 18
 	max_age = 200
 
-	digi_allowed = TRUE
-
 	//Specific abilities
 
 	burn_mod = 0.8 //Slightly resistant to fire

--- a/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
@@ -29,8 +29,6 @@
 
 	economic_modifier = 15
 
-	digi_allowed = TRUE
-
 	//Specific abilities
 
 	var/ring_cooldown = 0

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -62,7 +62,6 @@
 	var/max_age = 70
 
 	var/icodigi = 'icons/mob/human_races/r_digi.dmi'
-	var/digi_allowed = FALSE
 
 	// Language/culture vars.
 	var/default_language = LANGUAGE_GALCOM					// Default language is used when 'say' is used without modifiers.

--- a/code/modules/mob/living/carbon/human/species/station/custom.dm
+++ b/code/modules/mob/living/carbon/human/species/station/custom.dm
@@ -8,7 +8,6 @@
 	name_plural = "Custom"
 	selects_bodytype = SELECTS_BODYTYPE_CUSTOM
 	base_species = SPECIES_HUMAN
-	digi_allowed = TRUE
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
 

--- a/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -12,7 +12,6 @@
 
 	selects_bodytype = SELECTS_BODYTYPE_SHAPESHIFTER
 	base_species = SPECIES_HUMAN
-	digi_allowed = TRUE
 
 	blood_color = "#505050" //This is the same as the 80,80,80 below, but in hex
 	flesh_color = "#505050"

--- a/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
+++ b/code/modules/mob/living/carbon/human/species/station/replicant_crew.dm
@@ -14,7 +14,6 @@
 	siemens_coefficient = 1.5 //Don't get electrocuted
 
 	secondary_langs = list()	// None by default
-	digi_allowed = TRUE
 
 	has_organ = list(
 		O_HEART =		/obj/item/organ/internal/heart/replicant/rage/crew,

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -88,7 +88,6 @@
 	health_hud_intensity = 2.5
 	chem_strength_alcohol = 1.25
 	throwforce_absorb_threshold = 10
-	digi_allowed = TRUE
 	genders = list(MALE, FEMALE, PLURAL, NEUTER)
 
 	min_age = 18
@@ -225,7 +224,6 @@
 	species_language = LANGUAGE_SIIK
 	health_hud_intensity = 2.5
 	chem_strength_alcohol = 0.75
-	digi_allowed = TRUE
 	agility = 90
 	can_climb = TRUE
 	climbing_delay = 1.00 //Cats are good climbers.
@@ -726,7 +724,6 @@
 	species_language = LANGUAGE_SAGARU
 	color_mult = 1
 	inherent_verbs = list(/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	min_age = 18
 	max_age = 110
@@ -797,7 +794,6 @@
 	inherent_verbs = list(/mob/living/carbon/human/proc/tie_hair, /mob/living/carbon/human/proc/water_stealth, /mob/living/carbon/human/proc/underwater_devour)
 	min_age = 18
 	max_age = 80
-	digi_allowed = TRUE
 
 	blurb = "The Akula are a species of amphibious humanoids like the Skrell, but have an appearance very similar to that of a shark. \
 	They were first discovered as a primitive race of underwater dwelling tribal creatures by the Skrell. At first they were not believed \
@@ -850,7 +846,6 @@
 		/mob/living/carbon/human/proc/tie_hair)
 	min_age = 18
 	max_age = 80
-	digi_allowed = TRUE
 
 	blurb = "Nevreans are a race of avian and dinosaur-like creatures living on Tal. They belong to a group of races that hails from Eltus, \
 	in the Vilous system. Unlike sergals whom they share a star system with, their species is a very peaceful one. They possess remarkable \
@@ -893,7 +888,6 @@
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,
 		/mob/living/proc/shred_limb,
 		/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	min_age = 18
 	max_age = 80
@@ -948,7 +942,6 @@
 	color_mult = 1
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,
 		/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	wikilink="https://wiki.vore-station.net/Backstory#Vulpkanin"
 
@@ -1035,7 +1028,6 @@
 	color_mult = 1
 	genders = list(MALE, FEMALE, PLURAL, NEUTER)
 	inherent_verbs = list(/mob/living/proc/flying_toggle,/mob/living/proc/flying_vore_toggle,/mob/living/proc/start_wings_hovering,/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	min_age = 19 //not a typo, Rapala consider adult age to be 19
 	max_age = 80
@@ -1284,7 +1276,6 @@
 	taken to calling these creatures 'Shadekin', and the name has generally stuck and spread. "		//TODO: Something more fitting for black-eyes
 	wikilink = "https://wiki.vore-station.net/Shadekin"
 	catalogue_data = list(/datum/category_item/catalogue/fauna/shadekin)
-	digi_allowed = TRUE
 
 	language = LANGUAGE_SHADEKIN
 	name_language = LANGUAGE_SHADEKIN
@@ -1389,7 +1380,6 @@
 	name_language = LANGUAGE_TERMINUS
 	species_language = LANGUAGE_TERMINUS
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds,/mob/living/proc/shred_limb,/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	min_age = 18
 	max_age = 80
@@ -1421,7 +1411,6 @@
 	darksight = 4 //Better hunters in the dark.
 	hunger_factor = 0.1 //In exchange, they get hungry a tad faster.
 	num_alternate_languages = 3
-	digi_allowed = TRUE
 
 	min_age = 18
 	max_age = 80
@@ -1461,7 +1450,6 @@
 	name_language = null
 	color_mult = 1
 	inherent_verbs = list(/mob/living/carbon/human/proc/tie_hair)
-	digi_allowed = TRUE
 
 	min_age = 18
 	max_age = 80
@@ -1522,7 +1510,6 @@
 	brute_mod = 0.8		//20% brute damage reduction
 	burn_mod =  1.15	//15% burn damage increase. They're spiders. Aerosol can+lighter = dead spiders.
 	throwforce_absorb_threshold = 10
-	digi_allowed = TRUE
 
 	num_alternate_languages = 3
 	species_language = LANGUAGE_VESPINAE
@@ -1665,7 +1652,6 @@
 	burn_mod =  1.15	//As vulnerable to burn as a Tajara.
 	base_species = "Xenochimera"
 	selects_bodytype = SELECTS_BODYTYPE_CUSTOM
-	digi_allowed = TRUE
 	has_vibration_sense = TRUE
 
 	num_alternate_languages = 3
@@ -1776,7 +1762,6 @@
 	inherent_verbs = list(/mob/living/carbon/human/proc/tie_hair, /mob/living/proc/toggle_sparkles, /mob/living/proc/healing_rainbows, /mob/living/carbon/human/proc/play_dead)
 	min_age = 18
 	max_age = 21
-	digi_allowed = FALSE //No time for making rainbow legs for the meme, sorry!
 
 	pass_flags = PASSTABLE
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/SubtabBody.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/SubtabBody.tsx
@@ -52,7 +52,6 @@ export const SubtabBody = (props: {
     blood_reagents,
     emote_sound_mode,
   } = data;
-  const { digi_allowed } = staticData;
   const { species: species_list } = serverData;
   // if it's not there our entire UI is fucked anyways
   const our_species = species_list.find((x) => x.name === species) as Species;
@@ -122,7 +121,7 @@ export const SubtabBody = (props: {
                       </Button>
                     </LabeledList.Item>
                   ) : null}
-                  {digi_allowed ? (
+                  {
                     <LabeledList.Item label="Digitigrade">
                       <Button
                         inline
@@ -132,7 +131,7 @@ export const SubtabBody = (props: {
                         {digitigrade ? 'Yes' : 'No'}
                       </Button>
                     </LabeledList.Item>
-                  ) : null}
+                  }
                   <LabeledList.Item label="Blood Type">
                     <Button inline onClick={() => act('blood_type')}>
                       {b_type}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/data.ts
@@ -301,7 +301,6 @@ export type GeneralData = BasicData &
 export type GeneralDataStatic = {
   allow_metadata: BooleanLike;
   can_play: Record<string, { restricted: number; can_select: BooleanLike }>;
-  digi_allowed: BooleanLike;
   available_hair_styles: string[];
   available_facial_styles: string[];
   available_ear_styles: string[];


### PR DESCRIPTION

## About The Pull Request
Gets rid of old digi_allowed variable.
This more or less only caused confusion as to why someone couldn't take, say, a shadekin, select digi, and then select big leggies, even though there were others that had digi through some various methods and could do such.
All the selectable species barring shadekin already had digi_allowed = TRUE so this shouldn't change anything
Nothing player facing.
