### PR TITLE
Fix new players runtiming in pai

### DIFF
--- a/code/modules/client/preference_setup/general/07_antagonism.dm
+++ b/code/modules/client/preference_setup/general/07_antagonism.dm
@@ -4,6 +4,10 @@
 
 	var/datum/paiCandidate/candidate
 
+/datum/category_item/player_setup_item/general/basic_antagonism/New()
+	. = ..()
+	candidate = new()
+
 /datum/category_item/player_setup_item/general/basic_antagonism/load_character(list/save_data)
 	pref.exploit_record = save_data["exploit_record"]
 	pref.antag_faction  = save_data["antag_faction"]
@@ -17,6 +21,7 @@
 /datum/category_item/player_setup_item/general/basic_antagonism/load_preferences(datum/json_savefile/savefile)
 	if(!candidate)
 		candidate = new()
+
 	var/preference_mob = preference_mob()
 	if(!preference_mob)// No preference mob - this happens when we're called from client/New() before it calls ..()  (via datum/preferences/New())
 		spawn()

--- a/code/modules/client/preferences/types/game/sound.dm
+++ b/code/modules/client/preferences/types/game/sound.dm
@@ -175,6 +175,8 @@
 /datum/preference/volume_channels/is_valid(value)
 	return islist(value)
 
+/datum/preference/volume_channels/create_default_value()
+	return list()
 
 /mob/proc/get_preference_volume_channel(volume_channel)
 	if(!client)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/SubtabSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/SubtabSettings.tsx
@@ -401,22 +401,22 @@ export const SubtabSettings = (props: {
                 <LabeledList>
                   <LabeledList.Item label="Name">
                     <Button onClick={() => act('option', { option: 'name' })}>
-                      {pai_name}
+                      {pai_name || 'None Set'}
                     </Button>
                   </LabeledList.Item>
                   <LabeledList.Item label="Description">
                     <Button onClick={() => act('option', { option: 'desc' })}>
-                      {pai_desc}
+                      {pai_desc || 'None Set'}
                     </Button>
                   </LabeledList.Item>
                   <LabeledList.Item label="Role">
                     <Button onClick={() => act('option', { option: 'role' })}>
-                      {pai_role}
+                      {pai_role || 'None Set'}
                     </Button>
                   </LabeledList.Item>
                   <LabeledList.Item label="OOC Comments">
                     <Button onClick={() => act('option', { option: 'ooc' })}>
-                      {pai_comments}
+                      {pai_comments || 'None Set'}
                     </Button>
                   </LabeledList.Item>
                 </LabeledList>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/general/data.ts
@@ -236,10 +236,10 @@ export type AntagonismData = {
   uplink_type: string;
   record_banned: BooleanLike;
   exploitable_record?: string;
-  pai_name: string;
-  pai_desc: string;
-  pai_role: string;
-  pai_comments: string;
+  pai_name?: string;
+  pai_desc?: string;
+  pai_role?: string;
+  pai_comments?: string;
   syndicate_ban: BooleanLike;
   special_roles: SpecialRole[];
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/occupation/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/bay_prefs/occupation/data.ts
@@ -35,7 +35,7 @@ export type Job = {
 
 export type OccupationData = {
   alternate_option: AlternateOption;
-  jobs: Job[];
+  jobs: Record<string, Job[]>;
 };
 
 export type OccupationDataStatic = {};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I'm still not sure about the root cause of this, but this fixes the problem!

## Changelog

:cl:
fix: New players runtiming in preferences loading due to pAI nonsense
/:cl:
