### PR TITLE
Lights tubes respect lightswitch state on insertion

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -576,7 +576,7 @@ var/global/list/light_type_cache = list()
 	installed_light = L
 	L.loc = src //Move it into the socket!
 
-	on = powered()
+	on = powered() && !turned_off() // Do not instantly turn on lights if the area lightswitch is off
 	update()
 
 	if(on && rigged)


### PR DESCRIPTION
## About The Pull Request
Because lights ignore light switches, sabotaged light tubes will instantly detonate as soon as they are inserted. This makes it so that lights will only be turned on if the light switch of the room is also on when they are.

## Changelog
Lights check if a light switch is on before turning on when a bulb is inserted

:cl:
fix: lights do not ignore light switch state when a bulb is inserted
/:cl: