### PR TITLE
Spider tweaks and Mob pulling

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
@@ -127,6 +127,8 @@
 	var/warning_warmup = 2 SECONDS // How long the leap telegraphing is.
 	var/warning_sound = 'sound/weapons/spiderlunge.ogg'
 
+	pulled_living = FALSE
+
 
 /mob/living/simple_mob/animal/giant_spider/Initialize(mapload)
 	. = ..()
@@ -204,7 +206,8 @@
 		break
 
 	if(victim)
-		A.reagents.add_reagent(REAGENT_ID_WARNINGTOXIN, poison_per_bite)
+		victim.reagents.add_reagent(REAGENT_ID_WARNINGTOXIN, poison_per_bite)
+		victim.AdjustWeakened(2)
 		victim.visible_message(span_danger("\The [src] has bitten \the [victim]!"))
 		to_chat(victim, span_critical("\The [src] bites you and retreats!"))
 		. = TRUE

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
@@ -127,7 +127,7 @@
 	var/warning_warmup = 2 SECONDS // How long the leap telegraphing is.
 	var/warning_sound = 'sound/weapons/spiderlunge.ogg'
 
-	pulled_living = FALSE
+	no_pull_when_living = TRUE
 
 
 /mob/living/simple_mob/animal/giant_spider/Initialize(mapload)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -607,6 +607,10 @@
 		else
 			M.LAssailant = usr
 
+		if(!M.pulled_living && !(M.stat == DEAD)) //If it's now allowed to be pulled when living, and it's not dead yet, deny.
+			to_chat(src, span_warning("\The [M] won't let you just pull them!"))
+			return
+
 	else if(isobj(AM))
 		var/obj/I = AM
 		if(!can_pull_size || can_pull_size < I.w_class)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -607,7 +607,7 @@
 		else
 			M.LAssailant = usr
 
-		if(!M.pulled_living && !(M.stat == DEAD)) //If it's now allowed to be pulled when living, and it's not dead yet, deny.
+		if(M.no_pull_when_living && !(M.stat == DEAD)) //If it's now allowed to be pulled when living, and it's not dead yet, deny.
 			to_chat(src, span_warning("\The [M] won't let you just pull them!"))
 			return
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -120,6 +120,7 @@
 	var/m_intent = I_RUN//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
+	var/pulled_living = TRUE //Test for if it can be pulled when alive
 
 	var/seer = 0 //for cult//Carbon, probably Human
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -120,7 +120,7 @@
 	var/m_intent = I_RUN//Living
 	var/lastKnownIP = null
 	var/obj/buckled = null//Living
-	var/pulled_living = TRUE //Test for if it can be pulled when alive
+	var/no_pull_when_living = FALSE //Test for if it can be pulled when alive
 
 	var/seer = 0 //for cult//Carbon, probably Human
 


### PR DESCRIPTION
## About The Pull Request

Added a small amount of weaken to spider warning bites to knock people over. 
Added a new variable to mobs that can prevent them from being pulled when alive, currently only applies to the spiders. (Idea is that it could be applied to any mob that we don't want to be dragged around the station).
Fixed an issue where spiders would sometimes try to inject poison where they couldn't and runtime.

## Changelog
:cl:
add: Added a small amount of weaken to spider warning bites to knock people over. 
add: Added a new variable to mobs that can prevent them from being pulled when alive, currently only applies to the spiders. 
fix: Fixed an issue where spiders would sometimes try to inject poison where they couldn't and runtime.
/:cl:
