### PR TITLE
Init holomaps before SSpoints_of_interest to avoid revealing them

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -141,7 +141,8 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_ALARM			16 // Must initialize before atoms.
 #define INIT_ORDER_TRANSCORE		15
 #define INIT_ORDER_ATOMS			14
-#define INIT_ORDER_POIS				13
+#define INIT_ORDER_HOLOMAPS			13
+#define INIT_ORDER_POIS				12
 #define INIT_ORDER_MACHINES			10
 #define INIT_ORDER_STARMOVER		4
 #define INIT_ORDER_SHUTTLES			3
@@ -149,7 +150,6 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_DEFAULT			0
 #define INIT_ORDER_LIGHTING			0
 #define INIT_ORDER_AIR				-1
-#define INIT_ORDER_HOLOMAPS			-3
 #define INIT_ORDER_ASSETS			-5
 #define INIT_ORDER_NIGHTSHIFT		-6
 #define INIT_ORDER_OVERLAY			-7


### PR DESCRIPTION

## About The Pull Request

Title

## Changelog
:cl:
fix: Holomaps/Nanomaps no longer show POI walls
/:cl:
