### PR TITLE
Bloody Vomit fix

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1013,7 +1013,7 @@
 		for(var/i=0 to distance)
 			if(blood)
 				if(T)
-					blood_splatter(T, large = TRUE)
+					blood_splatter(T, src, large = TRUE)
 				if(stun)
 					adjustBruteLoss(2)
 			else if(T)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -422,6 +422,11 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		if(M.isSynthetic()) synth = 1
 		source = M.get_blood(M.vessel)
 
+	//Someone fed us a weird source. Let's log it.
+	if(source && !istype(source, /datum/reagent/blood))
+		log_debug("A blood splatter was made using non-blood datum [source]!")
+		source = null //Clear the source since it's invalid. Fallback to non-source behavior.
+
 	// Are we dripping or splattering?
 	var/list/drips = list()
 	// Only a certain number of drips (or one large splatter) can be on a given turf.


### PR DESCRIPTION

## About The Pull Request
Makes bloody vomit be your proper blood color.
Also adds a failsafe so if anything funky gets passed into the bloodsplatter proc, it detects and fixes it, along with logging the error.
## Changelog
:cl: Diana
fix: Puking with a broken liver now properly makes you vomit the correct blood color
/:cl:
