### PR TITLE
implements unused digi leggies

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_markings.dm
+++ b/code/modules/mob/new_player/sprite_accessories_markings.dm
@@ -2721,6 +2721,30 @@ includes scars and tattoos
 	color_blend_mode = ICON_MULTIPLY
 	body_parts = list(BP_L_LEG,BP_L_FOOT,BP_R_LEG,BP_R_FOOT)
 
+/datum/sprite_accessory/marking/digi/hooves
+	name = "Digitigrade Hooves (Only works with digitigrade legs)"
+	icon_state = "deerhoof"
+	color_blend_mode = ICON_MULTIPLY
+	body_parts = list(BP_L_FOOT,BP_R_FOOT)
+
+/datum/sprite_accessory/marking/digi/fox
+	name = "Digitigrade fox legs (Only works with digitigrade legs)"
+	icon_state = "fox"
+	color_blend_mode = ICON_MULTIPLY
+	body_parts = list(BP_L_LEG,BP_L_FOOT,BP_R_LEG,BP_R_FOOT)
+
+/datum/sprite_accessory/marking/digi/tiger
+	name = "Digitigrade tiger legs (Only works with digitigrade legs)"
+	icon_state = "tiger"
+	color_blend_mode = ICON_MULTIPLY
+	body_parts = list(BP_L_LEG,BP_L_FOOT,BP_R_LEG,BP_R_FOOT)
+
+/datum/sprite_accessory/marking/digi/gloss
+	name = "Digitigrade leg and foot gloss (Only works with digitigrade legs)"
+	icon_state = "gloss"
+	color_blend_mode = ICON_MULTIPLY
+	body_parts = list(BP_L_LEG,BP_L_FOOT,BP_R_LEG,BP_R_FOOT)
+
 //Big Leggies!
 /datum/sprite_accessory/marking/bigleggy
 	name = "Big Leggies - Legs"


### PR DESCRIPTION

## About The Pull Request

Someone went through the effort of making a buncha digi leg markings but the sprites were ported over while the markings weren't implemented. I fix this now. Mostly because it means I don't have to make the hooves I was gonna make myself lol.
Added: hooves, fox, tiger, and gloss

there's also a tyranid, some digimon, and a hellscout (i think a prosthetics set we don't have from downstream) that I have left unimplemented but could easily implement if told to. 
Deer hooves:
![image](https://github.com/user-attachments/assets/681038fd-995e-4506-b0c3-c4c66fcbd543)
Gloss (it's hard to see but it's supposed to be subtle):
![image](https://github.com/user-attachments/assets/ee02a100-7c9a-4f7f-bf5e-a4d9c4c2196b)
Tiger:
![image](https://github.com/user-attachments/assets/6bed96ce-d774-47c0-b5b4-0166df4e680f)
Fox:
![image](https://github.com/user-attachments/assets/29420786-0c43-4f91-9c78-41393803701e)
## Changelog
:cl:
add: Implements digi sprite markings for hooves, fox legs, tiger stripes, and a gloss for toning.
/:cl:
