### PR TITLE
Erroneous Phased Shadekin Damage Sources

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -140,7 +140,8 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		set_light(3, 1)
 
 	for(var/mob/living/L in loc)
-		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!
+		if(!L.is_incorporeal())
+			L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!
 
 	loc.fire_act(air_contents, air_contents.temperature, air_contents.volume)
 	for(var/atom/A in loc)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -229,7 +229,7 @@ default behaviour is:
 		MB.runOver(src)
 
 	if(istype(AM, /obj/vehicle))
-		if(!istype(buckled, /obj/vehicle)) // Don't run ourselves over, needed for going down stairs in vehicles!
+		if(!istype(buckled, /obj/vehicle) && !is_incorporeal()) // Don't run ourselves over, needed for going down stairs in vehicles!
 			// Checks if we are riding a vehicle instead of our buckled vehicle, so that our trailers don't flatten us either!
 			var/obj/vehicle/V = AM
 			V.RunOver(src)


### PR DESCRIPTION
## About The Pull Request
Shadekin can be run over by vehicles, and set on fire by atmos fires. I am unsure if the fire is intended or not. This fixes that.

## Changelog
Fire and vehicles cannot harm phased shadekin now.

:cl:
fix: Phased shadekin can no longer be lit on fire by atmofires
fix: Phased shadekin can no longer be run over by vehicles 
/:cl:
