### PR TITLE
fixes vampire artifact forensics

### DIFF
--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -160,13 +160,13 @@
 		//leave some drips behind
 		if(prob(50))
 			var/obj/effect/decal/cleanable/blood/drip/D = new(src.loc)
-			D.add_blooddna(forensic_data)
+			D.init_forensic_data().merge_blooddna(forensic_data)
 			if(prob(50))
 				D = new(src.loc)
-				D.add_blooddna(forensic_data)
+				D.init_forensic_data().merge_blooddna(forensic_data)
 				if(prob(50))
 					D = new(src.loc)
-					D.add_blooddna(forensic_data)
+					D.init_forensic_data().merge_blooddna(forensic_data)
 	else
 		..()
 


### PR DESCRIPTION
## About The Pull Request
Vampire artifact's animated blood splatter effect was not correctly merging blood dna data, as it was expecting a mob.

## Changelog
Corrected animated blood splatter to not runtime by using the correct forensics data merging.

:cl:
fix: Fixed runtime on vampire xenoartifact's blood sucking effect
/:cl:
