### PR TITLE
Circuit Board Badel Fix

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -19,7 +19,8 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 
 /obj/item/circuitboard/Destroy()
-	QDEL_NULL(board_type)
+	if(isobject(board_type)) // Some boards use text instead of an instance...
+		QDEL_NULL(board_type)
 	return ..()
 
 //Called when the circuitboard is used to contruct a new machine.


### PR DESCRIPTION
## About The Pull Request
qdel() does not like receiving text to delete, it must be an instance. Some circuit boards use text placeholders as the board_type, resulting in a bad delete when destroyed.

## Changelog
Added an instance check to circuit board's Destroy() proc.

:cl:
fix: Circuit boards no longer bad-del
/:cl:
