### PR TITLE
Patch for fake attackers crashing MC

### DIFF
--- a/code/modules/flufftext/fake_attacker.dm
+++ b/code/modules/flufftext/fake_attacker.dm
@@ -127,11 +127,13 @@
 		T = get_turf(clone)
 		var/turf/CT = T
 		for(var/i = 0 to 8)
+			if(!CT) // Emergency exit
+				return null
 			var/Cdir = pick(GLOB.cardinal)
 			if(prob(30))
 				Cdir = clone.dir // Results in hallucinations somewhat being in front of you
 			var/turf/NT = get_step(CT,Cdir)
-			if(!NT.density)
+			if(NT && !NT.density)
 				CT = NT
 		T = CT
 


### PR DESCRIPTION
## About The Pull Request
A loop needed more protection from invalid turfs

## Changelog
Fixed fake attackers attempting to spawn outside the map and crashing MC by runtiming in a loop.

:cl:
fix: Fake attackers crashing MC with invalid turfs
/:cl: