### PR TITLE
desc not name!

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1168,4 +1168,4 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 	if(cleanname)
 		name = cleanname
 	if(cleandesc)
-		name = cleandesc
+		desc = cleandesc


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: cleaning applies description to desc, not to name!
/:cl: