### PR TITLE
Rare Door Crush Crash Fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1401,11 +1401,12 @@ About the new airlock wires panel:
 
 /mob/living/airlock_crush(var/crush_damage)
 	. = ..()
+	var/turf/T = get_turf(src)
 	adjustBruteLoss(crush_damage)
 	SetStunned(5)
 	SetWeakened(5)
-	var/turf/T = get_turf(src)
-	T.add_blood(src)
+	if(T)
+		T.add_blood(src)
 	return 1
 
 /mob/living/carbon/airlock_crush(var/crush_damage)


### PR DESCRIPTION
## About The Pull Request
Some specific mobs qdel on death, like the slime cube and some demons. If a door crushes them they will be sent to nullspace before their get_turf() check to bleed on the ground.

## Changelog
Door crushing living mobs now checks turf first, runs damage, and then checks if the turf exists before bleeding.

:cl:
fix: fixed mobs that qdel on death, causing crashes when crushed by doors and dying.
/:cl: