### PR TITLE
Airlocks trying to autoclose are no longer blocked by phased shadekin, nore do they crush them

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1379,7 +1379,7 @@ About the new airlock wires panel:
 	return 0
 
 /mob/living/blocks_airlock()
-	return 1
+	return !is_incorporeal()
 
 /atom/movable/proc/airlock_crush(var/crush_damage)
 	return 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1400,6 +1400,8 @@ About the new airlock wires panel:
 	return 1
 
 /mob/living/airlock_crush(var/crush_damage)
+	if(is_incorporeal())
+		return 0
 	. = ..()
 	var/turf/T = get_turf(src)
 	adjustBruteLoss(crush_damage)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1413,7 +1413,7 @@ About the new airlock wires panel:
 
 /mob/living/carbon/airlock_crush(var/crush_damage)
 	. = ..()
-	if(can_feel_pain())
+	if(. && can_feel_pain()) // Only scream if actually crushed!
 		emote("scream")
 
 /mob/living/silicon/robot/airlock_crush(var/crush_damage)


### PR DESCRIPTION
## About The Pull Request
Shadekin standing in airlocks that are attempting to close, will trigger the error noise and prevent the door from closing. Also fixes shadekin being crushed by airlocks that will do harmful crushing damage. This also includes blast doors.

## Changelog
Airlocks now ignore phased shadekin when trying to autoclose or crush mobs on its turf.

:cl:
fix: phased shadekin no longer prevent airlocks from closing
fix: phased shadekin are no longer crushed by dangerous airlocks closing
/:cl:
