### PR TITLE
Add output prediction to cooking machines

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/_cooker.dm
+++ b/code/modules/food/kitchen/cooking_machines/_cooker.dm
@@ -45,6 +45,7 @@
 				our_contents[i] = list()
 				our_contents[i]["progress"] = 0
 				our_contents[i]["progressText"] = report_progress_tgui(CI)
+				our_contents[i]["prediction"] = predict_cooking(CI)
 				if(CI.max_cookwork)
 					our_contents[i]["progress"] = CI.cookwork / CI.max_cookwork
 				if(CI.container)

--- a/tgui/packages/tgui/interfaces/CookingAppliance.tsx
+++ b/tgui/packages/tgui/interfaces/CookingAppliance.tsx
@@ -24,6 +24,7 @@ type Data = {
     empty: BooleanLike;
     progress: number;
     progressText: string;
+    prediction: string;
     container: string | null;
   }[];
 };
@@ -115,8 +116,13 @@ export const CookingAppliance = (props) => {
                   label={'Slot #' + (i + 1)}
                   verticalAlign="middle"
                   key={i}
+                  tooltip={
+                    content.prediction
+                      ? `Predicted Output: ${content.prediction}`
+                      : undefined
+                  }
                 >
-                  <Stack>
+                  <Stack align="center">
                     <Stack.Item>
                       <Button
                         disabled={!containersRemovable}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![https://i.tigercat2000.net/2025/06/QHqMOLZmTz.png](https://i.tigercat2000.net/2025/06/QHqMOLZmTz.png)
![https://i.tigercat2000.net/2025/06/dSV5Z6WLJp.png](https://i.tigercat2000.net/2025/06/dSV5Z6WLJp.png)

This makes it so the cooking machines will attempt to predict what they're going to output and display it in the UI. As usual with the cooking system, this prediction is best-effort and may not always reflect what will actually come out, because you can't know for sure unless you actually do the cooking operations.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: The cooking machines like the grill and deep fryer now attempt to predict what they will produce.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
