### PR TITLE
Add safewords to succubi

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/succubi.dm
@@ -156,6 +156,7 @@ GLOBAL_LIST_INIT(succubus_safewords, list(
 	var/string = multilingual_to_message(message_pieces)
 
 	if(findtext(lowertext(string), safeword))
+		vore_selected?.digest_mode = DM_DRAIN
 		release_vore_contents()
 		SetStunned(10)
 		say("I'm sorry sweetie, are you okay?")


### PR DESCRIPTION

## About The Pull Request

Succubi now select their own safeword when they're created, and whisper it to people that they eat. Saying the safeword will immediately eject everyone inside them, including absorbed people.

[dreamseeker_5o39JlcrT7[1].webm](https://github.com/user-attachments/assets/4d1d5b98-5274-4d3e-af33-2665065dc168)

## Changelog

:cl:
add: Succubi care about consent and have a safeword~ :heart:
/:cl:
