### PR TITLE
Better handling for multiple hose connectors

### DIFF
--- a/code/__defines/hoses.dm
+++ b/code/__defines/hoses.dm
@@ -1,3 +1,5 @@
 #define HOSE_INPUT  "Input"// Only pull liquid.
 #define HOSE_OUTPUT "Output"// Only push liquid.
 #define HOSE_NEUTRAL "Neutral"// Equalize liquids, not super efficient, can waste reagents due to rounding.
+
+#define HOSE_MAX_DISTANCE 10

--- a/code/datums/components/reagent_hose/connector.dm
+++ b/code/datums/components/reagent_hose/connector.dm
@@ -1,5 +1,6 @@
 /datum/component/hose_connector
 	var/name = ""
+	dupe_mode = COMPONENT_DUPE_ALLOWED
 	VAR_PROTECTED/obj/carrier = null
 	VAR_PROTECTED/flow_direction = HOSE_NEUTRAL
 	VAR_PROTECTED/datum/hose/my_hose = null
@@ -42,6 +43,9 @@
 
 /datum/component/hose_connector/proc/get_flow_direction()
 	return flow_direction
+
+/datum/component/hose_connector/proc/get_id()
+	return "[name] #[connector_number]"
 
 /datum/component/hose_connector/output/process()
 	return
@@ -138,15 +142,16 @@
 	var/list/available_sockets = list()
 	for(var/datum/component/hose_connector/HC in GetComponents(/datum/component/hose_connector))
 		if(HC.get_hose())
-			available_sockets |= HC
+			available_sockets[HC.get_id()] = HC
 	if(!LAZYLEN(available_sockets))
 		return
 
 	if(available_sockets.len == 1)
-		var/datum/component/hose_connector/AC = available_sockets[1]
+		var/key = available_sockets[1]
+		var/datum/component/hose_connector/AC = available_sockets[key]
 		AC.disconnect_action(usr)
 	else
 		var/choice = tgui_input_list(usr, "Select a target hose connector.", "Socket Disconnect", available_sockets)
 		if(choice)
-			var/datum/component/hose_connector/AC = choice
+			var/datum/component/hose_connector/AC = available_sockets[choice]
 			AC.disconnect_action(usr)

--- a/code/datums/components/reagent_hose/datum.dm
+++ b/code/datums/components/reagent_hose/datum.dm
@@ -10,7 +10,7 @@
 
 	VAR_PRIVATE/hose_color = "#ffffff"
 
-	VAR_PRIVATE/initial_distance = 7
+	VAR_PRIVATE/initial_distance = HOSE_MAX_DISTANCE
 	VAR_PRIVATE/datum/beam/current_beam = null
 
 /datum/hose/proc/get_pairing(var/datum/component/hose_connector/target)
@@ -104,7 +104,7 @@
 			new_col = reagent_node2.get_color()
 
 		// We are in the beam!
-		qdel_swap(current_beam, A.Beam(B, icon_state = "hose", beam_color = new_col, maxdistance = world.view, beam_type = /obj/effect/ebeam/hose))
+		qdel_swap(current_beam, A.Beam(B, icon_state = "hose", beam_color = new_col, maxdistance = (HOSE_MAX_DISTANCE + 1), beam_type = /obj/effect/ebeam/hose))
 
 	return TRUE
 

--- a/code/datums/components/reagent_hose/item.dm
+++ b/code/datums/components/reagent_hose/item.dm
@@ -13,7 +13,7 @@
 	icon_state = "hose"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
 	amount = 1
-	max_amount = 10
+	max_amount = HOSE_MAX_DISTANCE
 	w_class = ITEMSIZE_SMALL
 	no_variants = TRUE
 	stacktype = /obj/item/stack/hose
@@ -54,7 +54,7 @@
 
 			else if(REMB && REMB.valid_connection(AC))
 				var/distancetonode = get_dist(REMB.get_carrier(),AC.get_carrier())
-				if(distancetonode > world.view)
+				if(distancetonode > HOSE_MAX_DISTANCE)
 					to_chat(user, span_notice("\The [src] would probably burst if it were this long. You wind \the [src] back up."))
 					remembered = null // Unintuitive if it does not reset state
 
@@ -83,7 +83,7 @@
 
 					else if(REMB.valid_connection(CC))
 						var/distancetonode = get_dist(REMB.get_carrier(), CC.get_carrier())
-						if(distancetonode > world.view)
+						if(distancetonode > HOSE_MAX_DISTANCE)
 							to_chat(user, span_notice("\The [src] would probably burst if it were this long. You wind \the [src] back up."))
 							remembered = null // Unintuitive if it does not reset state
 

--- a/code/datums/components/reagent_hose/item.dm
+++ b/code/datums/components/reagent_hose/item.dm
@@ -40,13 +40,14 @@
 		if(!HC.get_hose())
 			if(REMB)
 				if(HC.get_flow_direction() == HOSE_NEUTRAL || HC.get_flow_direction() != REMB.get_flow_direction())
-					available_sockets |= HC
+					available_sockets[HC.get_id()] = HC
 			else
-				available_sockets |= HC
+				available_sockets[HC.get_id()] = HC
 
 	if(LAZYLEN(available_sockets))
 		if(available_sockets.len == 1)
-			var/datum/component/hose_connector/AC = available_sockets[1]
+			var/key = available_sockets[1]
+			var/datum/component/hose_connector/AC = available_sockets[key]
 			if(REMB && REMB.get_carrier() == AC.get_carrier())
 				to_chat(user, span_notice("Connecting \the [REMB.get_carrier()] to itself seems like a bad idea. You wind \the [src] back up."))
 				remembered = null // Unintuitive if it does not reset state
@@ -74,7 +75,7 @@
 			var/choice = tgui_input_list(user, "Select a target hose connector.", "Socket Selection", available_sockets)
 
 			if(choice)
-				var/datum/component/hose_connector/CC = choice
+				var/datum/component/hose_connector/CC = available_sockets[choice]
 				if(REMB)
 					if(REMB.get_carrier() == CC.get_carrier())
 						to_chat(user, span_notice("Connecting \the [REMB.get_carrier()] to itself seems like a bad idea. You wind \the [src] back up."))

--- a/code/modules/reagents/machinery/pump.dm
+++ b/code/modules/reagents/machinery/pump.dm
@@ -33,6 +33,10 @@
 	RefreshParts()
 	update_icon()
 
+/obj/machinery/pump/Destroy()
+	QDEL_NULL(cell)
+	. = ..()
+
 /obj/machinery/pump/RefreshParts()
 	var/obj/item/stock_parts/manipulator/SM = locate() in component_parts
 	active_power_usage = initial(active_power_usage) / SM.rating


### PR DESCRIPTION
## About The Pull Request
While this doesn't affect anything currently ingame, this will be needed for anything added in the future with multiple hose connections of the same input/output/neutral type on the same object. Also includes some other small fixes.

## Changelog
Fixed objects with multiple reagent hose inputs and outputs not showing all of them when connecting or disconnecting.
Made max distance reagent hoses not turn invisible. 
The max distance is now the stack size instead of the view distance.
Fixed fluidpump destroy that was removed accidentally.

:cl: Will
fix: Multiple reagent hoses on one object are now properly usable
qol: The maximum distance of a reagent hose matches its stack size of 10
/:cl:
