### PR TITLE
Add preference datum for Balloon prompts

### DIFF
--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -35,6 +35,11 @@
 /atom/proc/balloon_alert_perform(mob/viewer, text)
 
 	var/client/viewer_client = viewer?.client
+
+	if(!viewer_client?.prefs?.read_preference(/datum/preference/toggle/runechat_balloon_messages))
+		return //no! I don't want that.
+
+
 	if (isnull(viewer_client))
 		return
 

--- a/code/modules/client/preferences/types/game/runechat.dm
+++ b/code/modules/client/preferences/types/game/runechat.dm
@@ -21,3 +21,9 @@
 	savefile_key = "RUNECHAT_LONG"
 	default_value = FALSE
 	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/runechat_balloon_messages
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "RUNECHAT_BALLOON_MESSAGES"
+	default_value = TRUE
+	savefile_identifier = PREFERENCE_PLAYER

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/runechat.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/runechat.tsx
@@ -27,3 +27,11 @@ export const RUNECHAT_LONG: FeatureToggle = {
   description: 'Sets runechat to show more characters.',
   component: CheckboxInput,
 };
+
+export const RUNECHAT_BALLOON_MESSAGES: FeatureToggle = {
+  name: 'Runechat: Balloon Messages',
+  category: 'RUNECHAT',
+  description:
+    'Enables or Disables the "Balloon Messages" performed by visible actions.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/d65705b5-b42d-4944-a40f-f1fcdbc44095)

Before: (ae, pref on, all other prefs as shown)
![image](https://github.com/user-attachments/assets/05c37ead-27cb-4cd8-b080-df15b90b1116)

After:

![image](https://github.com/user-attachments/assets/7acc7a65-7e3d-4783-ac82-6ed25e02ad66)

Can be enabled and disabled in game without any issues.

## Changelog
:cl:
qol: You can configure whether or not you want the runechat "Balloon Messages" to appear to you or not
/:cl:
