### PR TITLE
Genetics Tweaks

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -721,7 +721,7 @@
 
 	// Cooldown
 	injector_ready = FALSE
-	addtimer(CALLBACK(src, PROC_REF(injector_cooldown_finish)), 30 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(injector_cooldown_finish)), 5 SECONDS)
 
 	// Create it
 	var/datum/transhuman/body_record/buf = buffers[buffer_id] // Traitgenes Use bodyrecords


### PR DESCRIPTION
## About The Pull Request
Genetics feedback from chompstation thread was that genes are still difficult to locate without self injection, and is heavily rng reliant without any clear understanding of what level a gene activates at. The injector production time is also on an excessively long cool down. This change should encourage geneticists to scan crew for potential easy to locate genes as well. Likely does not affect virgo due to low focus on genetics gameplay.

## Changelog
Genescanner can now scan dna injectors to find out what is in an unlabeled injector.
Genescanner now shows the current value of the block the gene is in, but not the block ID directly. This is so geneticists still need to find the active block, not just be told its ID directly.
DNA modification console injector cool down lowered from 30 seconds to 5.

:cl: Will
qol: dna modification console takes 5 seconds instead of 30 to make a new injector
qol: gene scanner provides the current value of an active gene, but not it's block ID
qol: gene scanner can now scan dna injectors to find out what unmarked injectors do
/:cl:
