### PR TITLE
More Mining Vendor & Kinetic Crusher adjustments

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -85,6 +85,7 @@
 		/obj/item/flashlight/lantern,
 		/obj/item/shovel,
 		/obj/item/pickaxe/drill,
+		/obj/item/kinetic_crusher,
 		/obj/item/clothing/glasses/material,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
 		/obj/item/clothing/shoes/boots/winter/mining,

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -1,6 +1,8 @@
 // ported from Citadel-Station-13/Citadel-Station-13-RP#3015, basically all the work done by silicons
 // thanks silicons
 
+//TODO: Two handed component. Update this file in its ENTIRETY to be 1:1 with TG.
+
 /*********************Mining Hammer****************/
 /obj/item/kinetic_crusher
 	icon = 'icons/obj/mining_vr.dmi'
@@ -13,24 +15,22 @@
 	name = "proto-kinetic crusher"
 	desc = "An early design of the proto-kinetic accelerator, it is little more than an combination of various mining tools cobbled together, forming a high-tech club. \
 	While it is an effective mining tool, it did little to aid any but the most skilled and/or suicidal miners against local fauna."
-	force = 20
+	force = 25
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
 	throwforce = 5
 	throw_speed = 4
 	armor_penetration = 10
-	//custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
-	sharp = TRUE
-	edge = TRUE
-	embed_chance = 0
+	sharp = FALSE //crushing damage
+	edge = FALSE
+	embed_chance = FALSE
 	actions_types = list(/datum/action/item_action/toggle_light)
-	// var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
-	var/detonation_damage = 50
-	var/backstab_bonus = 30
+	var/detonation_damage = 50 //75
+	var/backstab_bonus = 30 //105
 	/// does it have a light icon
 	var/integ_light_icon = TRUE
 	/// is the light on?
@@ -44,7 +44,7 @@
 	/// Damage penalty factor to backstab bonus damage to non simple mobs
 	var/human_backstab_nerf = 0.25
 	/// damage buff for throw impacts
-	var/thrown_bonus = 35
+	var/thrown_bonus = 35 //140
 	/// do we need to be wielded?
 	var/requires_wield = FALSE
 	/// do we have a charge overlay?
@@ -62,22 +62,7 @@
 	. = ..()
 	AddElement(/datum/element/conflict_checking, CONFLICT_ELEMENT_CRUSHER)
 
-/*
-/obj/item/kinetic_crusher/Initialize(mapload)
-	. = ..()
-	if(requires_Wield)
-		RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
-		RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-
-/obj/item/kinetic_crusher/ComponentInitialize()
-	. = ..()
-	if(requires_wield)
-		AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
-		AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
-*/
-
 /obj/item/kinetic_crusher/Destroy()
-	// QDEL_LIST(trophies)
 	return ..()
 
 /obj/item/kinetic_crusher/emag_act()
@@ -104,29 +89,6 @@
 	. = ..()
 	. += span_notice("Mark a[emagged ? "nything": " creature"] with the destabilizing force, then hit them in melee to do <b>[force + detonation_damage]</b> damage.")
 	. += span_notice("Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.")
-/*
-	for(var/t in trophies)
-		var/obj/item/crusher_trophy/T = t
-		. += span_notice("It has \a [T] attached, which causes [T.effect_desc()].")
-*/
-
-/*
-/obj/item/kinetic_crusher/attackby(obj/item/I, mob/living/user)
-	if(I.tool_behaviour == TOOL_CROWBAR)
-		if(LAZYLEN(trophies))
-			to_chat(user, span_notice("You remove [src]'s trophies."))
-			I.play_tool_sound(src)
-			for(var/t in trophies)
-				var/obj/item/crusher_trophy/T = t
-				T.remove_from(src, user)
-		else
-			to_chat(user, span_warning("There are no trophies on [src]."))
-	else if(istype(I, /obj/item/crusher_trophy))
-		var/obj/item/crusher_trophy/T = I
-		T.add_to(src, user)
-	else
-		return ..()
-*/
 
 /obj/item/kinetic_crusher/attack(mob/living/target, mob/living/carbon/user)
 	if(!wielded && requires_wield)
@@ -136,11 +98,7 @@
 
 /obj/item/kinetic_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	. = ..()
-/*
-	if(istype(target, /obj/item/crusher_trophy))
-		var/obj/item/crusher_trophy/T = target
-		T.add_to(src, user)
-*/
+
 	if(requires_wield && !wielded)
 		return
 	if(!proximity_flag && charged)//Mark a target, or mine a tile.
@@ -148,11 +106,6 @@
 		if(!isturf(proj_turf))
 			return
 		var/obj/item/projectile/destabilizer/D = new /obj/item/projectile/destabilizer(proj_turf)
-/*
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_projectile_fire(D, user)
-*/
 		D.preparePixelProjectile(target, user, clickparams)
 		D.firer = user
 		D.hammer_synced = src
@@ -161,7 +114,6 @@
 		charged = FALSE
 		update_icon()
 		addtimer(CALLBACK(src, PROC_REF(Recharge)), charge_time)
-		// * (user?.ConflictElementCount(CONFLICT_ELEMENT_CRUSHER) || 1 - tentatively commented out
 		return
 	if(proximity_flag && isliving(target))
 		detonate(target, user)
@@ -247,11 +199,13 @@
 	attack_verb = list("cleaved", "chopped", "pulped", "stabbed", "skewered")
 	can_cleave = TRUE
 	requires_wield = FALSE
+	sharp = TRUE
+	edge = TRUE
 	// yeah yeah buff but polaris mobs are meatwalls.
 	force = 24
 	detonation_damage = 36 // 60
-	backstab_bonus = 40 // 100
-	thrown_bonus = 20 // 120
+	backstab_bonus = 80 // 140
+	thrown_bonus = 20 // 160
 	update_item_state = FALSE
 	slot_flags = SLOT_BELT
 
@@ -271,9 +225,9 @@
 	w_class = ITEMSIZE_NORMAL
 	can_cleave = FALSE
 	requires_wield = TRUE
-	force = 28
-	detonation_damage = 37 // 75
-	backstab_bonus = 55 // 130
+	force = 35
+	detonation_damage = 65 // 100
+	backstab_bonus = 25 // 125
 	var/obj/item/offhand/crushergauntlets/offhand
 	slot_flags = null
 
@@ -332,8 +286,6 @@
 	icon_state = "offhand"
 	name = "offhand that shouldn't exist doo dee doo"
 	w_class = ITEMSIZE_NO_CONTAINER
-	// var/linked - redefine this wherever
-	// man i really should try porting the twohand component this is hacky and Sucks
 
 /obj/item/offhand/crushergauntlets
 	var/obj/item/kinetic_crusher/machete/gauntlets/linked
@@ -377,10 +329,11 @@
 	charge_overlay = FALSE
 	charge_time = 10 // lowered charge in return for lowered damage
 	force = 18
+	armor_penetration = 50
 	detonation_damage = 27 // 45
-	backstab_bonus = 40 // 85
+	backstab_bonus = 30 // 75
 	// gimmick mode
-	thrown_bonus = 50 // 135 but you drop your knife because you threw it
+	thrown_bonus = 60 // 135 but you drop your knife because you threw it
 
 
 
@@ -394,7 +347,6 @@
 	check_armour = "bomb"
 	range = 6
 	accuracy = INFINITY	// NO.
-	// log_override = TRUE
 	var/obj/item/kinetic_crusher/hammer_synced
 
 /obj/item/projectile/destabilizer/Destroy()
@@ -414,12 +366,3 @@
 		if(hammer_synced.can_mark(L))
 			L.add_modifier(/datum/modifier/crusher_mark, 30 SECONDS, firer, TRUE)
 	..()
-
-/*
-//trophies
-
-there would be any if we had some
-but alas
-- hatterhat
-
-*/

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -225,6 +225,7 @@
 	w_class = ITEMSIZE_NORMAL
 	can_cleave = FALSE
 	requires_wield = TRUE
+	armor_penetration = 0
 	force = 35
 	detonation_damage = 65 // 100
 	backstab_bonus = 25 // 125

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -13,20 +13,18 @@
 	name = "proto-kinetic crusher"
 	desc = "An early design of the proto-kinetic accelerator, it is little more than an combination of various mining tools cobbled together, forming a high-tech club. \
 	While it is an effective mining tool, it did little to aid any but the most skilled and/or suicidal miners against local fauna."
-	force = 0 //You can't hit stuff unless wielded
+	force = 20
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
 	throwforce = 5
 	throw_speed = 4
-/*
-	armour_penetration = 10
-	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
-*/
+	armor_penetration = 10
+	//custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
 	sharp = TRUE
 	edge = TRUE
-	// sharpness = SHARP_EDGED
+	embed_chance = 0
 	actions_types = list(/datum/action/item_action/toggle_light)
 	// var/list/trophies = list()
 	var/charged = TRUE
@@ -48,7 +46,7 @@
 	/// damage buff for throw impacts
 	var/thrown_bonus = 35
 	/// do we need to be wielded?
-	var/requires_wield = TRUE
+	var/requires_wield = FALSE
 	/// do we have a charge overlay?
 	var/charge_overlay = TRUE
 	/// do we update item state?
@@ -223,16 +221,16 @@
 		if(integ_light_on)
 			add_overlay("[icon_state]_lit")
 
-/*
 /obj/item/kinetic_crusher/glaive
-	name = "proto-kinetic glaive"
-	desc = "A modified design of a proto-kinetic crusher, it is still little more of a combination of various mining tools cobbled together \
-	and kit-bashed into a high-tech cleaver on a stick - with a handguard and a goliath hide grip. While it is still of little use to any \
-	but the most skilled and/or suicidal miners against local fauna, it's an elegant weapon for a more civilized hunter."
-
-	look gary there i am
-	- hatterhat
-*/
+	name = "kinetic glaive"
+	icon_state = "crusher-glaive"
+	force = 20
+	detonation_damage = 20 // 40
+	backstab_bonus = 30 // 60
+	reach = 2
+	slot_flags = SLOT_BELT
+	w_class = ITEMSIZE_NORMAL
+	requires_wield = FALSE
 
 
 /obj/item/kinetic_crusher/machete

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -53,7 +53,7 @@
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Dagger",	/obj/item/kinetic_crusher/machete/dagger,					500),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Machete",	/obj/item/kinetic_crusher/machete,							1000),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Gauntlets",	/obj/item/kinetic_crusher/machete/gauntlets,				1000), //eh this is two-handed so whatever, same price for slight dmg increase!
-		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Glaive",	/obj/item/kinetic_crusher/machete/glaive,					10000), //strong spear. Pay up.
+		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Glaive",	/obj/item/kinetic_crusher/glaive,							10000), //strong spear. Pay up.
 		EQUIPMENT("Machete Holster",							/obj/item/clothing/accessory/holster/machete,				350),
 		EQUIPMENT("Defense Equipment - PSG-B (Melee)",			/obj/item/personal_shield_generator/belt/melee/loaded, 		5000),
 		EQUIPMENT("Defense Equipment - PSG-M (General)",		/obj/item/personal_shield_generator/belt/mining/loaded,		1000),

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -18,6 +18,17 @@
 	var/list/prize_list //Generated during Initialize
 	var/dirty_items = FALSE // Used to refresh the static/redundant data in case the machine gets VV'd
 
+/obj/machinery/mineral/equipment_vendor/Destroy()
+	if(inserted_id)
+		var/turf/T = get_turf(src)
+		if(T)
+			inserted_id.forceMove(T)
+			inserted_id = null
+		else
+			qdel_null(inserted_id)
+	QDEL_NULL_LIST(prize_list)
+	. = ..()
+
 /datum/data/mining_equipment
 	var/equipment_name = "generic"
 	var/equipment_path = null
@@ -38,9 +49,11 @@
 		EQUIPMENT("Defense Equipment - Sentry Drone Deployer",	/obj/item/grenade/spawnergrenade/ward,						1500),
 		EQUIPMENT("Defense Equipment - Smoke Bomb",				/obj/item/grenade/smokebomb,								100),
 		EQUIPMENT("Defense Equipment - Phase Pistol",			/obj/item/gun/energy/phasegun/pistol,						1500),
+		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Crusher",	/obj/item/kinetic_crusher,									1000),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Dagger",	/obj/item/kinetic_crusher/machete/dagger,					500),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Machete",	/obj/item/kinetic_crusher/machete,							1000),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Gauntlets",	/obj/item/kinetic_crusher/machete/gauntlets,				1000), //eh this is two-handed so whatever, same price for slight dmg increase!
+		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Glaive",	/obj/item/kinetic_crusher/machete/glaive,					10000), //strong spear. Pay up.
 		EQUIPMENT("Machete Holster",							/obj/item/clothing/accessory/holster/machete,				350),
 		EQUIPMENT("Defense Equipment - PSG-B (Melee)",			/obj/item/personal_shield_generator/belt/melee/loaded, 		5000),
 		EQUIPMENT("Defense Equipment - PSG-M (General)",		/obj/item/personal_shield_generator/belt/mining/loaded,		1000),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes kinetic crusher being unable to do any damage. (Gives it 25 damage instead of 0)
Adds Kinetic Crusher to the mining kiosk and also the mining closet. (This should honestly be linked to the mining vouchers, but that's a TODO for another time...I need to cross-port my mining voucher change sometime so miners start with them and can choose different 'starter packs' with them.)
Adds Kinetic Glaive - A 2 range weapon that does 20 force. Costs 10000 points in the mining kiosk.
Fixes Kinetic Crusher from doing edge+sharp damage. Does blunt instead.
Adjusts Kinetic Machete backstab damage. Backstab 40->80.
Adjusts Kinetic Dagger backstab & throw damage. Backstab 40->30 Throw 50->60. Now has 50% armor pen as well.
Adjusts Kinetic Gauntlets all around. Force 28->35, Detonation damage 37->65, backstab bonus 55->25 (It's two handed so it should have some good upside to it)

Gets rid of all the commented out code in the file as well...The entire file needs a fresh port from /tg/.

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
add: Kinetic Crusher and Kinetic Glaive now in mining vending machine
balance: Kinetic weapon damage variables shifted around. Gaunelts stronger, Dagger hits harder when thrown, Machete does more when backstabbing.
fix: Kinetic crusher now does 25 damage, up from 0
add: Miners now start with a kinetic crusher in their starting locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
