### PR TITLE
Add a new process option: Break Bone

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -358,6 +358,14 @@
 			parts += O
 	return parts
 
+//Returns a list of fracturable organs
+/mob/living/carbon/human/proc/get_fracturable_organs()
+	var/list/obj/item/organ/external/parts = list()
+	for(var/obj/item/organ/external/O in organs)
+		if(O.is_fracturable())
+			parts += O
+	return parts
+
 //Heals ONE external organ, organ gets randomly selected from damaged ones.
 //It automatically updates damage overlays if necesary
 //It automatically updates health status

--- a/code/modules/vore/eating/belly_actions.dm
+++ b/code/modules/vore/eating/belly_actions.dm
@@ -1,0 +1,81 @@
+/obj/belly/proc/instant_digest(mob/user, mob/living/target)
+	if(target.absorbed)
+		to_chat(user, span_vwarning("\The [target] is absorbed, and cannot presently be digested."))
+		return FALSE
+	if(tgui_alert(target, "\The [user] is attempting to instantly digest you. Is this something you are okay with happening to you?","Instant Digest", list("No", "Yes")) != "Yes")
+		to_chat(user, span_vwarning("\The [target] declined your digest attempt."))
+		to_chat(target, span_vwarning("You declined the digest attempt."))
+		return FALSE
+	// must be checked after alert
+	if(target.loc != src)
+		to_chat(user, span_vwarning("\The [target] is no longer in \the [src]."))
+		return FALSE
+
+	if(isliving(user))
+		var/mob/living/l = user
+		var/thismuch = target.health + 100
+		if(ishuman(l))
+			var/mob/living/carbon/human/h = l
+			thismuch = thismuch * h.species.digestion_nutrition_modifier
+		l.adjust_nutrition(thismuch)
+	target.death()		// To make sure all on-death procs get properly called
+	if(target)
+		if(target.check_sound_preference(/datum/preference/toggle/digestion_noises))
+			if(!fancy_vore)
+				SEND_SOUND(target, sound(get_sfx("classic_death_sounds")))
+			else
+				SEND_SOUND(target, sound(get_sfx("fancy_death_prey")))
+		target.mind?.vore_death = TRUE
+		handle_digestion_death(target)
+	return TRUE
+
+/obj/belly/proc/instant_break_bone(mob/user, mob/living/target)
+	if(!ishuman(target))
+		to_chat(user, span_vwarning("\The [target] has no breakable organs."))
+		return FALSE
+	if(target.absorbed)
+		to_chat(user, span_vwarning("\The [target] is absorbed, and cannot presently be broken."))
+		return FALSE
+	if(tgui_alert(target, "\The [user] is attempting to break one of your bones. Is this something you are okay with happening to you?","Break Bones", list("No", "Yes")) != "Yes")
+		to_chat(user, span_vwarning("\The [target] declined your breaking bones attempt."))
+		to_chat(target, span_vwarning("You declined the breaking bones attempt."))
+		return FALSE
+	if(target.loc != src)
+		to_chat(user, span_vwarning("\The [target] is no longer in \the [src]."))
+		return FALSE
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_organ = pick(human_target.get_fracturable_organs())
+	if(!target_organ)
+		to_chat(user, span_vwarning("\The [target] has no breakable organs."))
+		return FALSE
+	to_chat(user, span_vwarning("You break [target]'s [target_organ]!"))
+	target_organ.fracture()
+	return TRUE
+
+/obj/belly/proc/instant_absorb(mob/user, mob/living/target)
+	if(tgui_alert(target, "\The [user] is attempting to instantly absorb you. Is this something you are okay with happening to you?","Instant Absorb", list("No", "Yes")) != "Yes")
+		to_chat(user, span_vwarning("\The [target] declined your absorb attempt."))
+		to_chat(target, span_vwarning("You declined the absorb attempt."))
+		return FALSE
+	if(target.loc != src)
+		to_chat(user, span_vwarning("\The [target] is no longer in \the [src]."))
+		return FALSE
+	if(isliving(user))
+		var/mob/living/l = user
+		l.adjust_nutrition(target.nutrition)
+		var/n = 0 - target.nutrition
+		target.adjust_nutrition(n)
+	absorb_living(target)
+	return TRUE
+
+/obj/belly/proc/instant_knockout(mob/user, mob/living/target)
+	if(tgui_alert(target, "\The [user] is attempting to instantly make you unconscious, you will be unable until ejected from the pred. Is this something you are okay with happening to you?","Instant Knockout", list("No", "Yes")) != "Yes")
+		to_chat(user, span_vwarning("\The [target] declined your knockout attempt."))
+		to_chat(target, span_vwarning("You declined the knockout attempt."))
+		return FALSE
+	if(target.loc != src)
+		to_chat(user, span_vwarning("\The [target] is no longer in \the [src]."))
+		return FALSE
+	target.AdjustSleeping(500000)
+	to_chat(target, span_vwarning("\The [user] has put you to sleep, you will remain unconscious until ejected from the belly."))
+	return TRUE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1227,6 +1227,7 @@
 
 			if(ourtarget.digestable)
 				process_options += "Digest"
+				process_options += "Break Bone"
 
 			if(ourtarget.absorbable)
 				process_options += "Absorb"
@@ -1274,6 +1275,28 @@
 								SEND_SOUND(ourtarget, sound(get_sfx("fancy_death_prey")))
 						ourtarget.mind?.vore_death = TRUE
 						b.handle_digestion_death(ourtarget)
+				if("Break Bone")
+					if(!ishuman(ourtarget))
+						to_chat(user, span_vwarning("\The [ourtarget] has no breakable organs."))
+						return FALSE
+					if(ourtarget.absorbed)
+						to_chat(user, span_vwarning("\The [ourtarget] is absorbed, and cannot presently be broken."))
+						return FALSE
+					if(tgui_alert(ourtarget, "\The [user] is attempting to break one of your bones. Is this something you are okay with happening to you?","Break Bones", list("No", "Yes")) != "Yes")
+						to_chat(user, span_vwarning("\The [ourtarget] declined your breaking bones attempt."))
+						to_chat(ourtarget, span_vwarning("You declined the breaking bones attempt."))
+						return FALSE
+					if(ourtarget.loc != b)
+						to_chat(user, span_vwarning("\The [ourtarget] is no longer in \the [b]."))
+						return FALSE
+					var/mob/living/carbon/human/human_target = ourtarget
+					var/obj/item/organ/external/target_organ = pick(human_target.get_fracturable_organs())
+					if(!target_organ)
+						to_chat(user, span_vwarning("\The [ourtarget] has no breakable organs."))
+						return FALSE
+					to_chat(user, span_vwarning("You break [ourtarget]'s [target_organ]!"))
+					target_organ.fracture()
+					return TRUE
 				if("Absorb")
 					if(tgui_alert(ourtarget, "\The [user] is attempting to instantly absorb you. Is this something you are okay with happening to you?","Instant Absorb", list("No", "Yes")) != "Yes")
 						to_chat(user, span_vwarning("\The [ourtarget] declined your absorb attempt."))

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1247,80 +1247,18 @@
 				to_chat(user, span_vwarning("You cannot instantly process [ourtarget]."))
 				return FALSE
 			var/obj/belly/b = ourtarget.loc
+			if(!istype(b) || b.owner != user)
+				to_chat(user, span_vwarning("[ourtarget] isn't in your belly."))
+				return FALSE
 			switch(ourchoice)
 				if("Digest")
-					if(ourtarget.absorbed)
-						to_chat(user, span_vwarning("\The [ourtarget] is absorbed, and cannot presently be digested."))
-						return FALSE
-					if(tgui_alert(ourtarget, "\The [user] is attempting to instantly digest you. Is this something you are okay with happening to you?","Instant Digest", list("No", "Yes")) != "Yes")
-						to_chat(user, span_vwarning("\The [ourtarget] declined your digest attempt."))
-						to_chat(ourtarget, span_vwarning("You declined the digest attempt."))
-						return FALSE
-					if(ourtarget.loc != b)
-						to_chat(user, span_vwarning("\The [ourtarget] is no longer in \the [b]."))
-						return FALSE
-					if(isliving(user))
-						var/mob/living/l = user
-						var/thismuch = ourtarget.health + 100
-						if(ishuman(l))
-							var/mob/living/carbon/human/h = l
-							thismuch = thismuch * h.species.digestion_nutrition_modifier
-						l.adjust_nutrition(thismuch)
-					ourtarget.death()		// To make sure all on-death procs get properly called
-					if(ourtarget)
-						if(ourtarget.check_sound_preference(/datum/preference/toggle/digestion_noises))
-							if(!b.fancy_vore)
-								SEND_SOUND(ourtarget, sound(get_sfx("classic_death_sounds")))
-							else
-								SEND_SOUND(ourtarget, sound(get_sfx("fancy_death_prey")))
-						ourtarget.mind?.vore_death = TRUE
-						b.handle_digestion_death(ourtarget)
+					return b.instant_digest(user, ourtarget)
 				if("Break Bone")
-					if(!ishuman(ourtarget))
-						to_chat(user, span_vwarning("\The [ourtarget] has no breakable organs."))
-						return FALSE
-					if(ourtarget.absorbed)
-						to_chat(user, span_vwarning("\The [ourtarget] is absorbed, and cannot presently be broken."))
-						return FALSE
-					if(tgui_alert(ourtarget, "\The [user] is attempting to break one of your bones. Is this something you are okay with happening to you?","Break Bones", list("No", "Yes")) != "Yes")
-						to_chat(user, span_vwarning("\The [ourtarget] declined your breaking bones attempt."))
-						to_chat(ourtarget, span_vwarning("You declined the breaking bones attempt."))
-						return FALSE
-					if(ourtarget.loc != b)
-						to_chat(user, span_vwarning("\The [ourtarget] is no longer in \the [b]."))
-						return FALSE
-					var/mob/living/carbon/human/human_target = ourtarget
-					var/obj/item/organ/external/target_organ = pick(human_target.get_fracturable_organs())
-					if(!target_organ)
-						to_chat(user, span_vwarning("\The [ourtarget] has no breakable organs."))
-						return FALSE
-					to_chat(user, span_vwarning("You break [ourtarget]'s [target_organ]!"))
-					target_organ.fracture()
-					return TRUE
+					return b.instant_break_bone(user, ourtarget)
 				if("Absorb")
-					if(tgui_alert(ourtarget, "\The [user] is attempting to instantly absorb you. Is this something you are okay with happening to you?","Instant Absorb", list("No", "Yes")) != "Yes")
-						to_chat(user, span_vwarning("\The [ourtarget] declined your absorb attempt."))
-						to_chat(ourtarget, span_vwarning("You declined the absorb attempt."))
-						return FALSE
-					if(ourtarget.loc != b)
-						to_chat(user, span_vwarning("\The [ourtarget] is no longer in \the [b]."))
-						return FALSE
-					if(isliving(user))
-						var/mob/living/l = user
-						l.adjust_nutrition(ourtarget.nutrition)
-						var/n = 0 - ourtarget.nutrition
-						ourtarget.adjust_nutrition(n)
-					b.absorb_living(ourtarget)
+					return b.instant_absorb(user, ourtarget)
 				if("Knockout")
-					if(tgui_alert(ourtarget, "\The [user] is attempting to instantly make you unconscious, you will be unable until ejected from the pred. Is this something you are okay with happening to you?","Instant Knockout", list("No", "Yes")) != "Yes")
-						to_chat(user, span_vwarning("\The [ourtarget] declined your knockout attempt."))
-						to_chat(ourtarget, span_vwarning("You declined the knockout attempt."))
-						return FALSE
-					if(ourtarget.loc != b)
-						to_chat(user, span_vwarning("\The [ourtarget] is no longer in \the [b]."))
-						return FALSE
-					ourtarget.AdjustSleeping(500000)
-					to_chat(ourtarget, span_vwarning("\The [user] has put you to sleep, you will remain unconscious until ejected from the belly."))
+					return b.instant_knockout(user, ourtarget)
 				if("Cancel")
 					return FALSE
 		if("Health Check")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4414,6 +4414,7 @@
 #include "code\modules\vore\trycatch_vr.dm"
 #include "code\modules\vore\appearance\preferences_vr.dm"
 #include "code\modules\vore\appearance\update_icons_vr.dm"
+#include "code\modules\vore\eating\belly_actions.dm"
 #include "code\modules\vore\eating\belly_dat_vr.dm"
 #include "code\modules\vore\eating\belly_import.dm"
 #include "code\modules\vore\eating\belly_messages.dm"


### PR DESCRIPTION
## About The Pull Request
![https://i.tigercat2000.net/2025/06/Ox97WuNyCK.png](https://i.tigercat2000.net/2025/06/Ox97WuNyCK.png)
![https://i.tigercat2000.net/2025/06/nm2yROMJSH.png](https://i.tigercat2000.net/2025/06/nm2yROMJSH.png)

Additionally, you will now receive broken bone notifications while in a belly if you have digestion pain turned on. Previously, all broken bone messages would be suppressed when inside a belly. You still won't automatically `*scream` though.

## Changelog

:cl:
add: New process option, "Break Bone".
qol: If you have digestion pain turned on, you will receive broken bone notifications even inside a stomach.
/:cl:
