### PR TITLE
airflow thrown objects shouldn't hit phased shadekin

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -95,6 +95,8 @@ Contains helper procs for airflow, handled in /connection_group.
 	airflow_dest = null
 
 /mob/airflow_hit(atom/A)
+	if(is_incorporeal())
+		return
 	for(var/mob/M in hearers(src))
 		M.show_message(span_danger("\The [src] slams into \a [A]!"),1,span_danger("You hear a loud slam!"),2)
 	playsound(src, "smash.ogg", 25, 1, -1)
@@ -113,6 +115,8 @@ Contains helper procs for airflow, handled in /connection_group.
 	airflow_dest = null
 
 /mob/living/carbon/human/airflow_hit(atom/A)
+	if(is_incorporeal())
+		return
 //	for(var/mob/M in hearers(src))
 //		M.show_message(span_danger("[src] slams into [A]!"),1,span_danger("You hear a loud slam!"),2)
 	playsound(src, "punch", 25, 1, -1)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

## Changelog
Airflow thrown objects could hit phased shadekin. This fixes that.

:cl:
fix: airflow thrown objects don't hit phased shadekin now
/:cl:
