### PR TITLE
fixed incorrect arguments being sent to employment record computer

### DIFF
--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -216,7 +216,7 @@
 				set_temp("All employment records deleted.")
 			if("sync_r")
 				if(active1)
-					set_temp(client_update_record(src,active1,ui.user))
+					set_temp(client_update_record(src,ui.user))
 			if("edit_notes")
 				// The modal input in tgui is busted for this sadly...
 				var/new_notes = strip_html_simple(tgui_input_text(ui.user,"Enter new information here.","Character Preference", html_decode(active1.fields["notes"]), MAX_RECORD_LENGTH, TRUE, prevent_enter = TRUE), MAX_RECORD_LENGTH)

--- a/code/modules/client/record_updater.dm
+++ b/code/modules/client/record_updater.dm
@@ -19,7 +19,7 @@ var/global/client_record_update_lock = FALSE
 	if(!COM || QDELETED(COM))
 		return "Invalid console"
 
-	if(jobban_isbanned(user, "Records") )
+	if(jobban_isbanned(user, JOB_RECORDS) )
 		COM.visible_message(span_notice("\The [COM] buzzes!"))
 		playsound(COM, 'sound/machines/deniedbeep.ogg', 50, 0)
 		return "Update syncronization denied (OOC: You are banned from editing records)"


### PR DESCRIPTION
## About The Pull Request
The record data was being sent to the proc instead of the user. The proc itself gets the record. So the argument was incorrect.

## Changelog
Sends the correct data to the record update proc from the employment update console.
Also makes a proc use a define for JOB_RECORDS instead of a string.

:cl:
fix: fixed a crash when updating a player record from the employment records computer
/:cl:
