### PR TITLE
Embedded Examine Info

### DIFF
--- a/code/__defines/preferences.dm
+++ b/code/__defines/preferences.dm
@@ -1,10 +1,8 @@
 // Modes for examine text output
-#define EXAMINE_MODE_DEFAULT		 0
-#define EXAMINE_MODE_INCLUDE_USAGE	 1
-#define EXAMINE_MODE_SWITCH_TO_PANEL 2
+#define EXAMINE_MODE_SLIM		 "Slim"
+#define EXAMINE_MODE_VERBOSE	 "Verbose"
+#define EXAMINE_MODE_SWITCH_TO_PANEL "Switch To Panel"
 
-// Should be one higher than the above
-#define EXAMINE_MODE_MAX			 3
 
 // Modes for parsing multilingual speech
 #define MULTILINGUAL_DEFAULT			0

--- a/code/__defines/span.dm
+++ b/code/__defines/span.dm
@@ -3,6 +3,9 @@
 // Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define examine_block(str) ("<div class='examine_block'>" + str + "</div>")
 
+//for the foldout stuff
+#define span_details(title, content) ("<details>"+"<summary>" + title + "</summary>" + content + "</details>")
+
 // Filtered both under OOC!
 #define span_ooc(str) ("<span class='ooc'>" + str + "</span>")
 #define span_aooc(str) ("<span class='aooc'>" + str + "</span>")

--- a/code/controllers/subsystems/statpanel.dm
+++ b/code/controllers/subsystems/statpanel.dm
@@ -170,7 +170,11 @@ SUBSYSTEM_DEF(statpanels)
 	if(description_holders["antag"])
 		examine_update += span_red(span_bold("[description_holders["antag"]]")) + "<br />" //Red, malicious antag-related text
 
-	target.stat_panel.send_message("update_examine", list("EX" = examine_update, "UPD" = target.prefs.examine_text_mode == EXAMINE_MODE_SWITCH_TO_PANEL))
+	var/update_panel = FALSE
+	if(target.prefs?.read_preference(/datum/preference/choiced/examine_mode) == EXAMINE_MODE_SWITCH_TO_PANEL)
+		update_panel = TRUE
+
+	target.stat_panel.send_message("update_examine", list("EX" = examine_update, "UPD" = update_panel))
 
 /datum/controller/subsystem/statpanels/proc/set_tickets_tab(client/target)
 	var/list/tickets = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -199,9 +199,6 @@
 	var/examine_text = replacetext(get_examine_desc(), "||", "")
 	var/list/output = list("[icon2html(src,user.client)] That's [f_name] [suffix]", examine_text)
 
-	if(user.client?.prefs.examine_text_mode == EXAMINE_MODE_INCLUDE_USAGE)
-		output += description_info
-
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, output)
 	return output
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -120,7 +120,6 @@ var/list/preferences_datums = list()
 	var/lastnews // Hash of last seen lobby news content.
 	var/lastlorenews //ID of last seen lore news article.
 
-	var/examine_text_mode = 0 // Just examine text, include usage (description_info), switch to examine panel.
 	var/multilingual_mode = 0 // Default behaviour, delimiter-key-space, delimiter-key-delimiter, off
 
 	// THIS IS NOT SAVED

--- a/code/modules/client/preferences/types/game/chat.dm
+++ b/code/modules/client/preferences/types/game/chat.dm
@@ -61,3 +61,14 @@
 	savefile_key = "PAIN_FREQUENCY"
 	default_value = FALSE
 	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/choiced/examine_mode
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "EXAMINE_MODE"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/choiced/examine_mode/init_possible_values()
+	return list(EXAMINE_MODE_SLIM,EXAMINE_MODE_VERBOSE,EXAMINE_MODE_SWITCH_TO_PANEL)
+
+/datum/preference/choiced/examine_mode/create_default_value()
+	return EXAMINE_MODE_VERBOSE

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -14,24 +14,6 @@
 
 	feedback_add_details("admin_verb","TBeSpecial") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-// Not attached to a pref datum because those are strict binary toggles
-/client/verb/toggle_examine_mode()
-	set name = "Toggle Examine Mode"
-	set category = "Preferences.Game"
-	set desc = "Toggle the additional behaviour of examining things."
-
-	prefs.examine_text_mode++
-	prefs.examine_text_mode %= EXAMINE_MODE_MAX // This cycles through them because if you're already specifically being routed to the examine panel, you probably don't need to have the extra text printed to chat
-	switch(prefs.examine_text_mode)				// ... And I only wanted to add one verb
-		if(EXAMINE_MODE_DEFAULT)
-			to_chat(src, span_filter_system("Examining things will only output the base examine text, and you will not be redirected to the examine panel automatically."))
-
-		if(EXAMINE_MODE_INCLUDE_USAGE)
-			to_chat(src, span_filter_system("Examining things will also print any extra usage information normally included in the examine panel to the chat."))
-
-		if(EXAMINE_MODE_SWITCH_TO_PANEL)
-			to_chat(src, span_filter_system("Examining things will direct you to the examine panel, where you can view extended information about the thing."))
-
 /client/verb/toggle_multilingual_mode()
 	set name = "Toggle Multilingual Mode"
 	set category = "Preferences.Character"

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -76,16 +76,30 @@
 		return "an average attack speed"
 
 /obj/item/get_description_info()
-	var/weapon_stats = description_info + "\
-	<br>"
+	var/list/weapon_stats = list()
+
+	if(description_info)
+		weapon_stats += description_info
 
 	if(force)
-		weapon_stats += "\nIf used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
+		weapon_stats += "If used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
 	if(throwforce)
-		weapon_stats += "\nIf thrown, it would deal [describe_throwpower()] [sharp ? "sharp" : "blunt"] damage."
+		weapon_stats += "If thrown, it would deal [describe_throwpower()] [sharp ? "sharp" : "blunt"] damage."
 	if(can_cleave)
-		weapon_stats += "\nIt is capable of hitting multiple targets with a single swing."
+		weapon_stats += "It is capable of hitting multiple targets with a single swing."
 	if(reach > 1)
-		weapon_stats += "\nIt can attack targets up to [reach] tiles away, and can attack over certain objects."
+		weapon_stats += "It can attack targets up to [reach] tiles away, and can attack over certain objects."
 
-	return weapon_stats
+	if(weapon_stats.len < 1)
+		return ""
+
+	var/assembled_string = ""
+	for(var/index in 1 to weapon_stats.len)
+		var/msg = weapon_stats[index]
+		if(index > 1)
+			msg += "\n"
+		assembled_string += msg
+		if(msg == description_info) //keeping the formatting as identical as I can
+			assembled_string += "<br>"
+
+	return assembled_string

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1486,3 +1486,48 @@ $border-width-px: $border-width * 1px;
 .nif {
   color: hsla(180, 100%, 50%, 0.801);
 }
+
+details {
+  width: 80%;
+  background: #343b3d;
+  margin-bottom: 0.5rem;
+  box-shadow: 0 0.1rem 1rem -0.5rem rgba(0, 0, 0, 0.4);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+summary {
+  padding: 1rem;
+  display: block;
+
+  background: #505965;
+  padding-left: 2.2rem;
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+}
+
+summary:before {
+  content: '';
+  border-width: 0.4rem;
+  border-style: solid;
+  border-color: transparent transparent transparent #fff;
+  position: absolute;
+  top: 1.3rem;
+  left: 1rem;
+  transform: rotate(0);
+  transform-origin: 0.2rem 50%;
+  transition: 0.25s transform ease;
+}
+details[open] > summary:before {
+  transform: rotate(90deg);
+}
+
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+details > ul {
+  padding-bottom: 1rem;
+  margin-bottom: 0;
+}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/chat.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/chat.tsx
@@ -1,4 +1,9 @@
-import { CheckboxInput, type FeatureToggle } from '../base';
+import {
+  CheckboxInput,
+  type FeatureChoiced,
+  type FeatureToggle,
+} from '../base';
+import { FeatureDropdownInput } from '../dropdowns';
 
 export const CHAT_SHOWICONS: FeatureToggle = {
   name: 'Chat Tags',
@@ -70,4 +75,12 @@ export const PAIN_FREQUENCY: FeatureToggle = {
   description:
     'When enabled, reduces the amount of pain messages for minor wounds that you see.',
   component: CheckboxInput,
+};
+
+export const EXAMINE_MODE: FeatureChoiced = {
+  name: 'Examine Mode',
+  category: 'CHAT',
+  description:
+    'Choose how you want to examine items. "Verbose" will include all information found in the examine panel as foldable groups, "Switch To Panel" will switch you to the examine panel upon examining, and "Slim" will do neither. ',
+  component: FeatureDropdownInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Embeds extra information into the examine output based, using the existing examine tab information.
The Voodoo dolls/Remote scene tools kinda lead me to the conclusion that the tab was comically underused, as such the info was made more apparant. This is configurable, and about 2 clicks to disable on the user side.

![image](https://github.com/user-attachments/assets/c07cf0e1-65d6-4aec-aa00-f588d4dfa835)

![image](https://github.com/user-attachments/assets/8c3b4cec-a73e-49c7-8d71-2e27f8e36382)

The individual foldout groups can be folded out individually, and will only appear when relevant (AE, there's extra info). 
![image](https://github.com/user-attachments/assets/c90254ee-1150-4bbc-ad99-86cd54f83c08)
![image](https://github.com/user-attachments/assets/57e8037c-1858-4bc1-97ef-c926de73838e)

![image](https://github.com/user-attachments/assets/465bcf5f-bf12-4a96-b418-ec4073e4887c)

TODO:

- [ ]  Fix formatting issues
- [ ]  Make CSS for the other themes
- [ ]  Aughhh

- [ ] convert toggle_multilingual_mode() to a pref datum


<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Examines now embed extra information that used to be examine tab exclusive. This is a preference, so can be configured to remain as the old behavior.
del: Removed the old verb for setting examine mode
refactor: Examine Mode is now a TG preference
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
