### PR TITLE
Extra space heaters on SD

### DIFF
--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -3778,6 +3778,10 @@
 /obj/structure/low_wall/bay/reinforced/steel,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/portfore)
+"hP" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/atmos)
 "hQ" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/surgery,
@@ -3982,6 +3986,16 @@
 /obj/structure/low_wall/bay/reinforced/white,
 /turf/simulated/floor,
 /area/medical/psych)
+"iq" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/bomb_supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/atmos)
 "ir" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4159,6 +4173,13 @@
 	},
 /turf/simulated/floor,
 /area/stellardelight/deck2/starboardescape)
+"iM" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/atmos)
 "iN" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/angled_bay/standard/glass{
@@ -8131,6 +8152,7 @@
 /obj/machinery/alarm/angled{
 	dir = 4
 	},
+/obj/random/tank,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/atmos)
 "rt" = (
@@ -8573,6 +8595,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/random/trash_pile,
 /turf/simulated/wall/bay/r_wall/steel,
 /area/maintenance/stellardelight/deck2/atmos)
 "sy" = (
@@ -19158,6 +19181,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/atmos)
 "Qh" = (
@@ -22582,6 +22606,7 @@
 	nightshift_setting = 2
 	},
 /obj/structure/cable/orange,
+/obj/machinery/space_heater,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/atmos)
 "XX" = (
@@ -29590,10 +29615,10 @@ Jh
 Jh
 mI
 sx
-DB
+iq
 rs
-DB
-DB
+hP
+hP
 Hm
 Hm
 Hm
@@ -29874,7 +29899,7 @@ mI
 mI
 fQ
 th
-Wo
+iM
 XW
 Qg
 eq

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -556,6 +556,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/stellardelight/deck3/exterior)
+"bq" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck3/aftstarroom)
 "br" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -571,6 +575,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
+"bt" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/stellardelight/deck3/foreportroomb)
+"bu" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck3/foreportrooma)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/purcarpet,
@@ -21914,7 +21926,7 @@ MP
 hD
 zt
 dL
-xP
+bt
 pN
 pN
 zp
@@ -22762,7 +22774,7 @@ Zn
 zQ
 DM
 WI
-il
+bu
 hD
 ne
 vF
@@ -26180,7 +26192,7 @@ Ub
 Yj
 Yj
 Ef
-FE
+Ps
 Ps
 eE
 dx
@@ -27360,7 +27372,7 @@ CK
 CK
 by
 hQ
-lq
+bq
 lq
 rq
 lq


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added another 8 space heaters to the SD. Three of them in general maint, 5 of them specifically in a totally forgotten maint corner attached only to atmos.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
maptweak: Added another 8 space heaters to the SD. Three of them in general maint, 5 of them specifically in a totally forgotten maint corner attached only to atmos. Also generally spruced up that little room so it's not just blank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
