### PR TITLE
dump reagents instead of just fuel from fuel dispensers

### DIFF
--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -279,10 +279,8 @@
 /obj/structure/reagent_dispensers/fueltank/proc/leak_fuel(amount)
 	if (reagents.total_volume == 0)
 		return
-
 	amount = min(amount, reagents.total_volume)
-	reagents.remove_reagent(REAGENT_ID_FUEL,amount)
-	new /obj/effect/decal/cleanable/liquid_fuel(src.loc, amount,1)
+	reagents.trans_to_turf(get_turf(src),amount)
 
 /obj/structure/reagent_dispensers/peppertank
 	name = "Pepper Spray Refiller"


### PR DESCRIPTION
## About The Pull Request
Wrenching a fuel dispenser open results in only fuel dumping out, even if no fuel is present in the tank. As long as the tank has reagents it will dump out fuel.

## Changelog
Fuel tanks now drains reagents onto the floor indiscriminately. 

:cl:
fix: reagent dispenser tanks no longer perform alchemy, turning all reagents into fuel spills
/:cl: