### PR TITLE
Reduced memory usage of gene conflicts

### DIFF
--- a/code/game/dna/genes/gene.dm
+++ b/code/game/dna/genes/gene.dm
@@ -94,22 +94,15 @@
 		if(P == path)
 			continue
 
-		// check if cached first...
-		if(!isnull(conflict_traits[P]))
-			if(quick_scan && conflict_traits[P])
-				return TRUE
-			continue
+		// Quickscan time
+		if(quick_scan)
+			return (P in conflict_traits)
 
 		// check trait if not. CONFLICT-O-TRON ENGAGE
-		conflict_traits[P] = FALSE
-
 		var/datum/trait/instance_test = GLOB.all_traits[P]
 		if(path in instance_test.excludes)
 			conflict_traits[P] = TRUE
 			has_conflict = TRUE
-			// depending on scan mode we want to scan all, or only the first failure
-			if(quick_scan)
-				return TRUE
 			continue
 		for(var/V in linked_trait.var_changes)
 			if(V == "flags")
@@ -117,17 +110,11 @@
 			if(V in instance_test.var_changes)
 				conflict_traits[P] = TRUE
 				has_conflict = TRUE
-				// depending on scan mode we want to scan all, or only the first failure
-				if(quick_scan)
-					return TRUE
 				continue
 		for(var/V in linked_trait.var_changes_pref)
 			if(V in instance_test.var_changes_pref)
 				conflict_traits[P] = TRUE
 				has_conflict = TRUE
-				// depending on scan mode we want to scan all, or only the first failure
-				if(quick_scan)
-					return TRUE
 				continue
 	return has_conflict
 

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -41,16 +41,10 @@
 	if(blocks_remaining.len < 10)
 		warning("DNA2: Blocks remaining is less than 10. The DNA_SE_LENGTH should be raised in dna.dm.")
 	// Run conflict-o-tron on each traitgene all other traits... Lets setup an initial database of conflicts.
-	// Any remaining conflicts will be handled by the conflict-o-tron midround using a quicker scan flag
 	log_world("DNA2: Checking trait gene conflicts")
-	var/list/compare_list = list()
-	for(var/datum/gene/trait/gene in GLOB.dna_genes) // was orginally all_traits, but having 300 entry lists for 50 genes at launch was pointless. the caches will fill as characters spawn with traits instead... A small tradeoff
-		if(gene.linked_trait)
-			compare_list.Add(gene.linked_trait.type)
 	for(var/datum/gene/trait/gene in GLOB.dna_genes)
-		gene.has_conflict( compare_list, FALSE )
+		gene.has_conflict( GLOB.all_traits, FALSE) // Check all traits beforehand to build the conflict list, so all future checks can be done with a quick contents check
 	log_world("DNA2: Initial Conflict summary")
-	// Future coders: Don't worry, has_conflict() is run whenever a traitgene tries to enable itself as well, and adds to the trait conflict lists in each gene...
 	// This is to setup the initial segments for the gene editing machines to sort gene segments with.
 	for(var/datum/gene/trait/gene in GLOB.dna_genes)
 		if(gene.conflict_traits.len)


### PR DESCRIPTION
## About The Pull Request
The gene conflict used to store a list of true/false if it conflicts. A more efficient way is to just check all traits anyway on startup and only store conflicts. This is to reduce memory usage.

## Changelog
Reduced memory usage of gene conflicts by altering the CONFLICTOTRON to only store traits that actually conflict, and quickscan is reduced to only a list contents check. As all genes are checked against all traits on startup.

:cl:
code: gene conflict list uses much less memory
/:cl: