### PR TITLE
Made backup batteries a bit more useful

### DIFF
--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -219,7 +219,7 @@
 	icon = 'icons/obj/power_cells.dmi'
 	icon_state = "backup"
 	w_class = ITEMSIZE_SMALL
-	var/amount = 100
+	var/amount = 150
 	var/used = FALSE
 
 /obj/item/fbp_backup_cell/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

Changed the level that you can use backup batteries as a synth to 150 nutrition, and it also gives you 150 nutrition back. This means you can use it as soon as you reach slowdown levels of hunger and it fills you up a decent amount. Previously you had to wait until you went down to 100 nutrition and it would only fill up to 200 max, which means you'd be back in red soon after.

## Changelog
:cl:
balance: Changed the level that you can use backup batteries as a synth to 150 nutrition, and it also gives you 150 nutrition back. This means you can use it as soon as you reach slowdown levels of hunger and it fills you up a decent amount.
/:cl:
