### PR TITLE
gripper shows information on examine for robots

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -196,8 +196,18 @@
 		else
 			f_name += "oil-stained [name][infix]."
 
+	var/borg = "" // Borg grippers say if the item can be gripped
+	if(isrobot(user) && isitem(src))
+		borg = "None of your grippers can hold this."
+		var/mob/living/silicon/robot/R = user
+		if(R.module?.modules)
+			for(var/obj/item/gripper/G in R.module.modules)
+				if(is_type_in_list(src,G.can_hold))
+					borg = span_boldnotice("\The [G]") + span_notice(" can hold this.")
+					break
+
 	var/examine_text = replacetext(get_examine_desc(), "||", "")
-	var/list/output = list("[icon2html(src,user.client)] That's [f_name] [suffix]", examine_text)
+	var/list/output = list("[icon2html(src,user.client)] That's [f_name] [suffix] [borg]", examine_text)
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, output)
 	return output


### PR DESCRIPTION
## About The Pull Request
Knowing what items you can pick up with your grippers is impossible without trial and error. It is not possible to just display a list from the gripper either, as it uses base types. Meaning the list is often full of broken or unclear names. This is the best alternative I could come up with.

## Changelog
Inspecting items as a robot will show if you have a gripper capable of picking up the object. It makes no special distinctions currently, and only reports the first gripper capable of holding the item. Otherwise it will state you have no grippers that can hold the object. Only applies to items. Grippers do not need to be equipped.

:cl: Will
qol: Borgs can now examine items to know if any of their grippers can hold it.
/:cl: