### PR TITLE
Better stairs handling for climbable objects

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -111,16 +111,15 @@
 	return 1
 
 /// Shakes an object, called from movement so it needs to be cleaned up a bit!
-/datum/element/climbable/proc/move_shaken(var/obj/climbed_thing, var/mob/user)
+/datum/element/climbable/proc/move_shaken(obj/climbed_thing, atom/oldloc, direction, forced, list/old_locs, momentum_change)
 	SIGNAL_HANDLER
-	shaken(climbed_thing, null)
+	if(!forced) // Don't perform this if going up stairs
+		shaken(climbed_thing, null)
 
 /// Shakes an object, if anyone is climbing it, causes them to fall off it.
 /datum/element/climbable/proc/shaken(var/obj/climbed_thing, var/mob/user)
 	SIGNAL_HANDLER
 	var/list/climbers = LAZYACCESS(current_climbers, climbed_thing)
-	for(var/i in climbers)
-
 	// You cannot shake yourself
 	if(user) // Crates pass null on open because no user
 		if(!LAZYLEN(climbers) || (user in climbers))
@@ -136,6 +135,8 @@
 		if(M.is_incorporeal())
 			continue
 		if(M.lying) //No spamming this on people.
+			continue
+		if(M.pulling == climbed_thing) // Pulling stuff up stairs can get weird
 			continue
 
 		M.Weaken(3)


### PR DESCRIPTION
## About The Pull Request
Climbable objects being pulled up stairs would always trigger knockdown.

## Changelog
Makes objects no longer trigger knockdown if you are the one pulling them, or if they are forcibly moved, such as being moved up or down stairs.

:cl:
qol: climbable objects being pulled up or down stairs no longer knock you around
/:cl:
