### PR TITLE
modifies how punchdamage is handled

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -92,6 +92,8 @@
 
 	var/list/flavor_texts = list()
 	var/pulling_punches    // Are you trying not to hurt your opponent?
+	var/unarmed_bonus = 0 //do you have stronger unarmed attacks?
+	var/shredding = FALSE //do you shred when attacking? Affects escaping restraints, and punching normally unpunchable things
 	var/robolimb_count = 0 // Total number of external robot parts.
 	var/robobody_count = 0 // Counts torso, groin, and head, if they're robotic
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -622,7 +622,8 @@
 
 	if(!ignore_intent && H.a_intent != I_HURT)
 		return 0
-
+	if(H.shredding)
+		return 1
 	for(var/datum/unarmed_attack/attack in unarmed_attacks)
 		if(!attack.is_usable(H))
 			continue

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -165,7 +165,7 @@
 /datum/unarmed_attack/claws/chimera //special feral attack that gets stronger as they get angrier
 
 /datum/unarmed_attack/claws/chimera/get_unarmed_damage(var/mob/living/carbon/human/user)
-	return user.get_feralness()/5
+	return user.unarmed_bonus + (user.get_feralness()/5)
 
 /datum/unarmed_attack/claws/chimera/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
 	..()

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -27,6 +27,40 @@
 	banned_species = list(SPECIES_ALRAUNE, SPECIES_SHADEKIN_CREW, SPECIES_TESHARI, SPECIES_TAJARAN, SPECIES_DIONA, SPECIES_UNATHI, SPECIES_VASILISSAN, SPECIES_XENOCHIMERA, SPECIES_VOX) //i assume if a dev made your base slowdown different then you shouldn't have this.
 	excludes = list(/datum/trait/positive/speed_fast) // olympic sprinters don't naruto run
 
+/datum/trait/positive/punchdamage
+	name = "Strong Attacks"
+	desc = "Your unarmed attacks deal more damage"
+	cost = 2
+	custom_only = FALSE
+	var_changes = list("unarmed_bonus" = 5)
+	banned_species = list(SPECIES_TESHARI)
+
+/datum/trait/positive/punchdamageplus
+	name = "Crushing Attacks"
+	desc = "Your unarmed attacks deal high damage, and you're capable of escaping most restraints"
+	cost = 6
+	custom_only = FALSE
+	var_changes = list("unarmed_bonus" = 10, "shredding" = TRUE)
+	banned_species = list(SPECIES_TESHARI, SPECIES_VOX)
+
+/datum/trait/positive/strength //combine effects of hardy + strong punches, for if someone wants a generally "strong" character. Exists for the purposes of the trait limit
+	name = "High Strength"
+	desc = "Your unarmed attacks deal more damage, and you can carry heavy equipment with less slowdown."
+	cost = 3
+	custom_only = FALSE
+	var_changes = list("unarmed_bonus" = 5, "item_slowdown_mod" = 0.5)
+	excludes = list(/datum/trait/positive/punchdamage, /datum/trait/positive/hardy)
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN)
+
+/datum/trait/positive/strengthplus //see above comment
+	name = "Inhuman Strength"
+	desc = "You are unreasonably strong. Your unarmed attacks do high damage, you experience almost no slowdown from heavy equipment, and you can escape most restraints with ease."
+	cost = 8
+	custom_only = FALSE
+	var_changes = list("unarmed_bonus" = 10, "shredding" = TRUE, "item_slowdown_mod" = 0.25)
+	excludes = list(/datum/trait/positive/punchdamage, /datum/trait/positive/hardy, /datum/trait/positive/punchdamageplus, /datum/trait/positive/hardy_plus)
+	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN, SPECIES_VOX)
+
 /datum/trait/positive/hardy
 	name = "Hardy"
 	desc = "Allows you to carry heavy equipment with less slowdown."

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -40,8 +40,8 @@ var/global/list/sparring_attack_cache = list()
 
 	return FALSE
 
-/datum/unarmed_attack/proc/get_unarmed_damage()
-	return damage
+/datum/unarmed_attack/proc/get_unarmed_damage(var/mob/living/carbon/human/user)
+	return damage + user.unarmed_bonus
 
 /datum/unarmed_attack/proc/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
 

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -50,6 +50,17 @@
 				var/real_damage = rand_damage //Let's go ahead and start calculating our damage.
 				var/hit_dam_type = attack.damage_type //Let's get the type of damage. Brute? Burn? Defined by the unarmed_attack.
 				real_damage += attack.get_unarmed_damage(attacker) //Add the damage that their special attack has. Some have 0. Some have 15.
+				if(attacker.gloves && attack.is_punch)
+					if(istype(attacker.gloves, /obj/item/clothing/gloves))
+						var/obj/item/clothing/gloves/G = attacker.gloves
+						real_damage += G.punch_force
+						hit_dam_type = G.punch_damtype
+					else if(istype(attacker.gloves, /obj/item/clothing/accessory))
+						var/obj/item/clothing/accessory/G = attacker.gloves
+						real_damage += G.punch_force
+						hit_dam_type = G.punch_damtype
+					if(HULK in attacker.mutations)
+						real_damage *= 2
 				if(real_damage <= damage_threshold)
 					L.visible_message(span_warning("\The [L] uselessly hits \the [src]!"))
 					L.do_attack_animation(src)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Simplemobs now take unarmed damage modified by hulk/gloves
Adds traits that increase unarmed damage.
Tier 1 increases it by 5. Has a version that includes the effect of hardiness, for the purpose of simulating general high strength within the trait limit. Can't be taken by tesh.
Tier 2 increases it by 10, and adds Shredding. Shredding allows unarmed attacks to do things like break windows and damage borgs, as well as escape restraints quickly. Has a version that includes the effects of greater hardiness, for reasons listed above. Can't be taken by tesh or vox- with tier 1, vox have punch damage equivalent to a character with tier 2, and vox already have Shredding on their punch attacks..

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: new traits that increase unarmed damage. Traits have been added that combine with respective tiers of Hardy, to simulate high strength for species that should be inhumanly strong
fix: simplemobs should now take extra damage from hulk/knuckles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
