### PR TITLE
Gargoyle adjustments & fixes

### DIFF
--- a/code/datums/components/traits/gargoyle.dm
+++ b/code/datums/components/traits/gargoyle.dm
@@ -45,8 +45,17 @@
 			unpause()
 		statue.damage(-0.5)
 		energy = min(energy+0.3, 100)
+
+		//This is where we do all the 'make sure we don't die in statue form' stuff (unless you succumb or take MASSIVE damage.)
+		//Bloodloss will still kill us, but if we are patient enough, we'll survive most other stuff.
+		//If we had 150 brute (crit for most species) it'll take 3000 seconds (50 minutes) to heal back to full hp...So yes, while you can heal, it's not a good idea.
+		if(gargoyle.health < gargoyle.getMaxHealth())
+			gargoyle.adjustBruteLoss(-0.1)
+			gargoyle.adjustFireLoss(-0.1)
+			gargoyle.adjustOxyLoss(-1) //So you don't suffocate to death.
+			gargoyle.adjustToxLoss(-0.1)
+			gargoyle.adjustCloneLoss(-0.02) //yeah this is uber slow, no cheese allowed by combining it with bad genetics.
 		return //Early return. If we're transformed, we can stop, we don't need to check anything else.
-	//99% of the time we'll be walking around w/ + energy, so let's check that first.
 	if(energy > 0)
 		if(!transformed && !paused)
 			energy = max(0,energy-0.05)

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -17,18 +17,16 @@
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		AdjustLosebreath(-1)
-		if (prob(10) && !isbelly(loc)) //Gasp per 10 ticks? Sounds about right. //VOREStation Add
+		if (prob(10) && !isbelly(loc)) //Gasp per 10 ticks? Sounds about right.
 			spawn emote("gasp")
 	else
 		//Okay, we can breathe, now check if we can get air
 		breath = get_breath_from_internal() //First, check for air from internals
-		//VOREStation Add - Respirocytes as a NIF implant
 		if(!breath && ishuman(src))
 			var/mob/living/carbon/human/H = src
 			if(H.nif && H.nif.flag_check(NIF_H_SPAREBREATH,NIF_FLAGS_HEALTH))
 				var/datum/nifsoft/spare_breath/SB = H.nif.imp_check(NIF_SPAREBREATH)
 				breath = SB.resp_breath()
-		//VOREStation Add End
 		if(!breath)
 			breath = get_breath_from_environment() //No breath from internals so let's try to get air from our location
 		if(!breath)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -86,11 +86,9 @@
 
 	var/name_ender = ""
 	if(!((skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)))
-		//VOREStation Add Start
 		if(custom_species)
 			name_ender = ", a " + span_bold("[src.custom_species]")
 		else if(looks_synth)
-		//VOREStation Add End
 			var/use_gender = "a synthetic"
 			if(gender == MALE)
 				use_gender = "an android"
@@ -275,7 +273,6 @@
 	if(suiciding)
 		msg += span_warning("[T.He] appears to have commited suicide... there is no hope of recovery.")
 
-	//VOREStation Add
 	var/list/vorestrings = list()
 	vorestrings += examine_weight()
 	vorestrings += examine_nutrition()
@@ -289,7 +286,6 @@
 		if(entry == "" || entry == null)
 			vorestrings -= entry
 	msg += vorestrings
-	//VOREStation Add End
 
 	if(mSmallsize in mutations)
 		msg += "[T.He] [T.is] very short!"
@@ -318,14 +314,12 @@
 			msg += span_deadsay("[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.")
 		else if(!client)
 			msg += span_deadsay("[T.He] [T.is] [ssd_msg].")
-		//VOREStation Add Start
 		if(client && away_from_keyboard && manual_afk)
 			msg += "\[Away From Keyboard for [round((client.inactivity/10)/60)] minutes\]"
 		else if(client && ((client.inactivity / 10) / 60 > 10)) //10 Minutes
 			msg += "\[Inactive for [round((client.inactivity/10)/60)] minutes\]"
 		else if(disconnect_time)
 			msg += "\[Disconnected/ghosted [round(((world.realtime - disconnect_time)/10)/60)] minutes ago\]"
-		//VOREStation Add End
 
 	var/list/wound_flavor_text = list()
 	var/list/is_bleeding = list()
@@ -366,7 +360,7 @@
 					wound_flavor_text["[temp.name]"] = span_warning("[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.name].")
 			else
 				wound_flavor_text["[temp.name]"] = ""
-			if(temp.dislocated == 1) //VOREStation Edit Bugfix
+			if(temp.dislocated == 1)
 				wound_flavor_text["[temp.name]"] += span_warning("[T.His] [temp.joint] is dislocated!")
 			if(temp.brute_dam > temp.min_broken_damage || (temp.status & (ORGAN_BROKEN | ORGAN_MUTATED)))
 				wound_flavor_text["[temp.name]"] += span_warning("[T.His] [temp.name] is dented and swollen!")
@@ -442,14 +436,12 @@
 		flavor_text = replacetext(flavor_text, "||", "")
 		msg += "[flavor_text]"
 
-	// VOREStation Start
 	if(custom_link)
 		msg += "Custom link: " + span_linkify("[custom_link]")
 
 	if(ooc_notes)
 		msg += "OOC Notes: <a href='byond://?src=\ref[src];ooc_notes=1'>\[View\]</a> - <a href='byond://?src=\ref[src];print_ooc_notes_chat=1'>\[Print\]</a>"
 	msg += "<a href='byond://?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a>"
-	// VOREStation End
 	msg = list(span_info(jointext(msg, "<br>")))
 	if(applying_pressure)
 		msg += applying_pressure
@@ -465,7 +457,7 @@
 /proc/hasHUD(mob/M as mob, hudtype)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(hasHUD_vr(H,hudtype)) return 1 //VOREStation Add - Added records access for certain modes of omni-hud glasses
+		if(hasHUD_vr(H,hudtype)) return 1 //Added records access for certain modes of omni-hud glasses
 		switch(hudtype)
 			if("security")
 				return istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud)
@@ -473,4 +465,4 @@
 				return istype(H.glasses, /obj/item/clothing/glasses/hud/health)
 	else if(isrobot(M))
 		var/mob/living/silicon/robot/R = M
-		return R.sensor_type //VOREStation Add - Borgo sensors are now binary so just have them on or off
+		return R.sensor_type //Borgo sensors are now binary so just have them on or off


### PR DESCRIPTION
## About The Pull Request
Makes gargoyle no longer give you godmode.
Fixes it so gargoyle no longer has hard refs.
Fixes it so gargoyle no longer leaves lingering signals.
Swaps paused to a COMSIG MOVE vs a COMSIG ENTER
Gargoyle now heals VERY slowly (Takes 50 minutes of gargoyle state to heal 150 brute damage)
Gargoyle statue now burns under extremely high temperatures (Google said rock melts between 600C to 1600C, so I made them start to melt at 1600C)
Gargoyle statues no longer hold a hardref to the person inside. Is now a weakref.


## Changelog

:cl: Diana
fix: Gargoyle statues now regenerate energy properly
balance: Gargoyle statues now burn under extreme temperatures (>1600C)
balance: Gargoyle statues now regenerate health VERY slowly when in statue state (150 hp will take 50 minutes)
code: Gargoyle code quality increased in general.
/:cl: