### PR TITLE
Long lasting emergency lights

### DIFF
--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -192,8 +192,8 @@
 /obj/item/cell/emergency_light
 	name = "miniature power cell"
 	desc = "A tiny power cell with a very low power capacity. Used in light fixtures to power them in the event of an outage."
-	charge = 120
-	maxcharge = 120 //Emergency lights use 0.2 W per tick, meaning ~10 minutes of emergency power from a cell
+	charge = 720
+	maxcharge = 720 //Emergency lights use 0.2 W per tick, meaning ~60 minutes of emergency power from a cell
 	matter = list(MAT_GLASS = 20)
 	icon_state = "em_light"
 	connector_type = "emergency"


### PR DESCRIPTION
## About The Pull Request
Multiplies the charge in the emergency light batteries by 6, from 10 to 60 minutes. Because 10 minutes out of a 6h shift is nothing.
This feature was straight up broken for a long time and now that it works I would like it to be useful.
A dark shift where all the light comes from dimly light emergency lights sounds fun, so I may  bump it to 2 or 3 hours.
## Changelog
:cl:Tost
balance: Emergency lights now last longer
/:cl:
