### PR TITLE
starlight optimization

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -60,8 +60,6 @@
 #define DYNAMIC_LIGHTING_ENABLED 1
 /// dynamic lighting enabled even if the area doesn't require power
 #define DYNAMIC_LIGHTING_FORCED 2
-/// dynamic lighting enabled only if starlight is.
-#define DYNAMIC_LIGHTING_IFSTARLIGHT 3
 #define IS_DYNAMIC_LIGHTING(A) A.dynamic_lighting
 
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -581,7 +581,8 @@
 /datum/config_entry/flag/allow_url_links
 	default = TRUE // honestly if I were you i'd leave this one off, only use in dire situations
 
-/datum/config_entry/flag/starlight // Whether space turfs have ambient light or not
+/datum/config_entry/number/starlight // Whether space turfs have ambient light or not and how strong it is.
+	default = 0
 
 // FIXME: Unused
 ///datum/config_entry/str_list/ert_species

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -20,11 +20,6 @@ SUBSYSTEM_DEF(lighting)
 
 /datum/controller/subsystem/lighting/Initialize()
 	if(!subsystem_initialized)
-		if (CONFIG_GET(flag/starlight))
-			for(var/area/A in world)
-				if (A.dynamic_lighting == DYNAMIC_LIGHTING_IFSTARLIGHT)
-					A.luminosity = 0
-
 		subsystem_initialized = TRUE
 		create_all_lighting_objects()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -13,7 +13,7 @@
 	var/forced_dirs = 0 //Force this one to pretend it's an overedge turf
 
 /turf/space/Initialize(mapload)
-	if(CONFIG_GET(flag/starlight))
+	if(CONFIG_GET(number/starlight))
 		update_starlight()
 
 	//Sprite stuff only beyond here
@@ -75,7 +75,7 @@
 
 /turf/space/proc/update_starlight()
 	if(locate(/turf/simulated) in orange(src,1))
-		set_light(CONFIG_GET(flag/starlight))
+		set_light(CONFIG_GET(number/starlight))
 	else
 		set_light(0)
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -100,8 +100,9 @@
 	if(SSair)
 		SSair.mark_for_update(W)
 
-	for(var/turf/space/S in range(W, 1))
-		S.update_starlight()
+	if(CONFIG_GET(flag/starlight))
+		for(var/turf/space/S in range(W, 1))
+			S.update_starlight()
 	W.levelupdate()
 	W.update_icon(1)
 	W.post_change()
@@ -130,8 +131,9 @@
 		else if(lighting_object && !lighting_object.needs_update)
 			lighting_object.update()
 
-		for(var/turf/space/space_tile in RANGE_TURFS(1, src))
-			space_tile.update_starlight()
+		if(CONFIG_GET(flag/starlight))
+			for(var/turf/space/space_tile in RANGE_TURFS(1, src))
+				space_tile.update_starlight()
 
 	var/turf/simulated/sim_self = src
 	if(lighting_object && istype(sim_self) && sim_self.shandler) //sanity check, but this should never be null for either of the switch cases (lighting_object will be null during initializations sometimes)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -100,7 +100,7 @@
 	if(SSair)
 		SSair.mark_for_update(W)
 
-	if(CONFIG_GET(flag/starlight))
+	if(CONFIG_GET(number/starlight))
 		for(var/turf/space/S in range(W, 1))
 			S.update_starlight()
 	W.levelupdate()
@@ -131,7 +131,7 @@
 		else if(lighting_object && !lighting_object.needs_update)
 			lighting_object.update()
 
-		if(CONFIG_GET(flag/starlight))
+		if(CONFIG_GET(number/starlight))
 			for(var/turf/space/space_tile in RANGE_TURFS(1, src))
 				space_tile.update_starlight()
 

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -30,7 +30,7 @@
 	affected_turf.lighting_object = src
 	affected_turf.set_luminosity(0)
 
-	if(CONFIG_GET(flag/starlight))
+	if(CONFIG_GET(number/starlight))
 		for(var/turf/space/space_tile in RANGE_TURFS(1, affected_turf))
 			space_tile.update_starlight()
 


### PR DESCRIPTION
## About The Pull Request
Does some optimization of starlight config.
Suggestion: Setting starlight to '2' in the config gives a good medium for 'not too much light' and 'not too little light' and will allow for it to come through windows.

Makes it so we aren't doing unneeded config checks. Instead, we check it and THEN tell the tiles to update their light if we have starlight enabled.

Gets rid of the all areas check in the lighting subsystem. The value it was looking for isn't used anywhere.

WITH STARLIGHT:
<img width="638" alt="dreamseeker_2025-06-28_22-24-37" src="https://github.com/user-attachments/assets/d6e6b1de-3b3b-46a4-a9ae-c2c1b41aa9b4" />



WITHOUT STARLIGHT:
<img width="638" alt="dreamseeker_2025-06-28_22-28-48" src="https://github.com/user-attachments/assets/19d19f15-8636-4b28-95d4-21fdd440641f" />

With STARLIGHT set to 2
<img width="638" alt="dreamseeker_2025-06-29_10-25-28" src="https://github.com/user-attachments/assets/e6b2f118-9156-457f-b645-ba3268ae3b70" />

Starlight = 2, but illuminating some turf through a window;
<img width="638" alt="dreamseeker_2025-06-29_10-31-38" src="https://github.com/user-attachments/assets/7aa35f5b-e86a-4eda-847e-a282e133e5d2" />



Won't actually do anything unless the STARLIGHT is set to 1 in the config (higher numbers result in the tiles near space tiles having a brighter glow)
## Changelog
:cl: Diana
add: Starlight will come through windows and illuminate areas exposed to space!
/:cl:
