### PR TITLE
Virus Database fix

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -1233,3 +1233,5 @@ GLOBAL_LIST_INIT(material_synth_list, list(
 								WIRE_SYNTH = /datum/matter_synth/wire,
 								CLOTH_SYNTH = /datum/matter_synth/cloth
 							))
+
+GLOBAL_LIST_EMPTY(virusDB) // Stores discovered viruses

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -223,3 +223,23 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 // Called when the mob dies
 /datum/disease/proc/OnDeath()
 	return
+
+// Adds a virus to the virus DB
+// Currently it won't show on the Medical Computers because OLD interface, which needs to be updated
+/datum/disease/proc/addToDB()
+	if(GetDiseaseID() in GLOB.virusDB)
+		return FALSE
+
+	var/datum/data/record/v = new()
+
+	v.fields["id"] = GetDiseaseID()
+	v.fields["name"] = name
+	v.fields["description"] = desc
+	v.fields["form"] = form
+	v.fields["agent"] = agent
+	v.fields["cure"] = cure_text
+	v.fields["spread"] = spread_text
+
+	GLOB.virusDB["[GetDiseaseID()]"] = v
+
+	return TRUE

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -172,10 +172,7 @@
 					medical["empty"] = 1
 			if(MED_DATA_V_DATA)
 				data["virus"] = list()
-				for(var/datum/disease/D in GLOB.active_diseases)
-					if(!global_flag_check(D.virus_modifiers, DISCOVERED))
-						continue
-					var/datum/data/record/v = GLOB.active_diseases[D]
+				for(var/datum/data/record/v in GLOB.virusDB)
 					data["virus"] += list(list("name" = v.fields["name"], "D" = "\ref[v]"))
 			if(MED_DATA_MEDBOT)
 				data["medbots"] = list()

--- a/code/game/objects/items/devices/extrapolator.dm
+++ b/code/game/objects/items/devices/extrapolator.dm
@@ -172,6 +172,9 @@
 					message += "[symptom.name]"
 			else
 				message += span_info("<b>[disease.name]</b>, stage [disease.stage]/[disease.max_stages].")
+
+			disease.addToDB()
+
 	to_chat(user, examine_block(jointext(message, "\n")), avoid_highlighting = TRUE, trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /obj/item/extrapolator/proc/extrapolate(mob/living/user, atom/target, isolate = FALSE)


### PR DESCRIPTION

## About The Pull Request

Fixes a runtime when trying to open the virus database. Currently viruses won't show up on the Medical Computer, since it's an old interface and needs a bit of updating- This only fixes a runtime that occurs when opening it.

## Changelog
:cl:
fix: Fixed virus databases breaking in Medical Computers
/:cl:
