### PR TITLE
More gripper fixes v2.0

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -418,7 +418,11 @@
 	return
 
 /obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/stack))
+	if(istype(W, /obj/item/gripper))
+		var/obj/item/gripper/G = W
+		G.consolidate_stacks(src)
+
+	else if(istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
 		src.transfer_to(S)
 

--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -53,7 +53,14 @@
 	if(!T.AdjacentQuick(user)) // So people aren't messing with these from across the room
 		return FALSE
 	var/obj/item/I = user.get_active_hand() // ctrl-shift-click doesn't give us the item, we have to fetch it
-	if(!I)
+
+	if(isrobot(user)) //snowflake gripper BS because it can't be done in get_active_hand without breaking everything
+		var/mob/living/silicon/robot/robot = user
+		if(istype(robot.module_active, /obj/item/gripper))
+			var/obj/item/gripper/gripper = robot.module_active
+			I = gripper.get_current_pocket()
+
+	else if(!I)
 		return FALSE
 	return IC.attackby(I, user)
 

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1446,7 +1446,7 @@
 /datum/trait/neutral/gargoyle/apply(var/datum/species/S,var/mob/living/carbon/human/H, var/list/trait_prefs)
 	..()
 	var/datum/component/gargoyle/G = H.GetComponent(added_component_path)
-	if (trait_prefs)
+	if(trait_prefs)
 		G.tint = trait_prefs["tint"]
 		G.material = lowertext(trait_prefs["material"])
 		G.identifier = lowertext(trait_prefs["identifier"])

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -202,8 +202,9 @@
 	if(S.get_bodytype() == SPECIES_VASILISSAN)
 		W.silk_reserve = 500
 		W.silk_max_reserve = 1000
-	W.silk_production = trait_prefs["silk_production"]
-	W.silk_color = lowertext(trait_prefs["silk_color"])
+	if(trait_prefs)
+		W.silk_production = trait_prefs["silk_production"]
+		W.silk_color = lowertext(trait_prefs["silk_color"])
 
 /datum/trait/positive/aquatic
 	name = "Aquatic"
@@ -336,7 +337,7 @@
 
 /datum/trait/positive/table_passer/apply(var/datum/species/S,var/mob/living/carbon/human/H, var/list/trait_prefs)
 	..()
-	if (trait_prefs?["pass_table"] || !trait_prefs)
+	if(trait_prefs?["pass_table"] || !trait_prefs)
 		H.pass_flags |= PASSTABLE
 	add_verb(H,/mob/living/proc/toggle_pass_table)
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -157,6 +157,9 @@
 	for(var/obj/item/robotic_multibelt/materials/material_belt in contents)
 		if(material_belt.selected_item == O)
 			return TRUE
+	for(var/obj/item/gripper/gripper in contents)
+		if(gripper.current_pocket == O)
+			return TRUE
 	return FALSE
 
 /mob/living/silicon/robot/proc/get_active_modules()

--- a/code/modules/mob/living/silicon/robot/robot_simple_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_simple_items.dm
@@ -488,7 +488,7 @@
 	//Has a list of items that it can hold.
 	var/list/can_hold = list(BASIC_GRIPPER)
 
-	var/obj/item/wrapped = null // Item currently being held.
+	var/obj/item/wrapped = null // Item currently being held. //Convert to weak-ref?
 
 	var/total_pockets = 5 //How many total inventory slots we want to have in the gripper
 
@@ -502,9 +502,6 @@
 
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
-
-/obj/item/gripper/proc/get_current_pocket() //done as a proc so snowflake code can be found later down the line and consolidated.
-	return wrapped
 
 /obj/item/storage/internal/gripper
 	max_w_class = ITEMSIZE_HUGE
@@ -660,7 +657,6 @@
 	return 0
 
 /obj/item/gripper/afterattack(var/atom/target, var/mob/living/user, proximity, params)
-
 	if(!proximity)
 		return // This will prevent them using guns at range but adminbuse can add them directly to modules, so eh.
 	var/current_pocket_full = FALSE
@@ -691,7 +687,9 @@
 
 	if(wrapped) //Already have an item.
 		//Temporary put wrapped into user so target's attackby() checks pass.
-		var/obj/previous_pocket = wrapped.loc
+		var/obj/previous_pocket
+		if(istype(wrapped.loc, /obj/item/storage/internal/gripper))
+			previous_pocket = wrapped.loc
 		wrapped.loc = user
 
 		//Pass the attack on to the target. This might delete/relocate wrapped.
@@ -699,13 +697,14 @@
 		if(!resolved && wrapped && target)
 			wrapped.afterattack(target,user,1)
 
-		//If wrapped was neither deleted nor put into target, put it back into the gripper.
-		if(wrapped && user && ((wrapped.loc == user) || wrapped.loc == previous_pocket))
+		if((QDELETED(wrapped))) //We put our wrapped thing INTO something!
+			wrapped = null
+			current_pocket = pick(pockets)
+			return
+		//If we had a previous pocket and the wrapped isn't put into something, put it back in our pocket.
+		else if((previous_pocket && wrapped.loc == user))
 			wrapped.loc = previous_pocket
 		else
-			wrapped = null
-			return
-		if((QDELETED(wrapped) || (wrapped.loc != current_pocket))) //We put our wrapped thing INTO something!
 			wrapped = null
 			current_pocket = pick(pockets)
 			return
@@ -772,6 +771,28 @@
 				A.cell = null
 
 				user.visible_message(span_danger("[user] removes the power cell from [A]!"), "You remove the power cell.")
+
+//HELPER PROCS
+/obj/item/gripper/proc/get_current_pocket() //done as a proc so snowflake code can be found later down the line and consolidated.
+	return wrapped
+
+/// Consolidates material stacks by searching our pockets to see if we currently have any stacks. Done in /obj/item/stack/attackby
+/obj/item/gripper/proc/consolidate_stacks(var/obj/item/stack/stack_to_consolidate)
+	if(!stack_to_consolidate || !istype(stack_to_consolidate, /obj/item/stack))
+		return
+	var/stacked = FALSE //So we can break the for loop 2 forloops deep.
+	for(var/obj/item/storage/internal/gripper/pocket in pockets)
+		if(stacked) //We've stacked our item, break!
+			break
+
+		if(LAZYLEN(pocket.contents))
+			for(var/obj/item/stack/stack in pocket.contents)
+				if(istype(stack_to_consolidate, stack))
+					stack_to_consolidate.transfer_to(stack)
+					stacked = TRUE
+					break
+
+
 
 //Different types of grippers!
 

--- a/code/modules/mob/living/silicon/robot/robot_simple_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_simple_items.dm
@@ -209,7 +209,7 @@
 /obj/item/robotic_multibelt/medical
 	name = "Robotic surgical multitool"
 	desc = "An integrated surgical toolbelt."
-	icon_state = "toolkit_medborg"
+	icon_state = "toolkit_engiborg"
 
 	cyborg_integrated_tools = list(
 		/obj/item/surgical/retractor/cyborg = null,
@@ -292,7 +292,7 @@
 /obj/item/robotic_multibelt/botanical
 	name = "Botanical multitool"
 	desc = "An integrated botanical toolbelt."
-	icon_state = "toolkit_medborg"
+	icon_state = "toolkit_engiborg"
 
 	cyborg_integrated_tools = list(
 		/obj/item/material/minihoe/cyborg  = null,
@@ -502,6 +502,9 @@
 
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
+
+/obj/item/gripper/proc/get_current_pocket() //done as a proc so snowflake code can be found later down the line and consolidated.
+	return wrapped
 
 /obj/item/storage/internal/gripper
 	max_w_class = ITEMSIZE_HUGE


### PR DESCRIPTION

## About The Pull Request
You can't use material in your gripper to make things out of it, like steel to make frames and sofas
> FIXED

Science and engineering borgs cant put circuits into wearable assemblies, but they can with regular ones
> FIXED

Stacks are not automatically stacked, you need to manually reselet the current pocket to stack each time
> FIXED

If you place from a stack, every placement requires you to reselect
> FIXED

some icons are still badly offset (botanical multitool) 
> Multitool offset removed. Surgical offset removed as well (Unless you have a surgical tool selected) making it look nice in the inventory

if we deal with stacks, we should auto stack them or auto select the next if there is any from that stack
> FIXED

your last gripped item is not perseved for use
> FIXED
## Changelog
:cl: Diana
qol: Cyborg gripper will now smartly stack material stacks.
qol: Cyborg gripper will no longer unselect stacks when used
fix: Cyborg surgical and botany multibelt no longer have offset
/:cl:
