### PR TITLE
Antag examine fix

### DIFF
--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -106,7 +106,7 @@
 				title = "🔍 | Flavor Text"
 
 		. += span_details(title,fluff_info_temp)
-	var/is_antagish = ((mind && mind.special_role) || isobserver(src)) //ghosts don't have minds
+	var/is_antagish = antag_check()
 	var/antag_info_temp = A.get_description_antag()
 	if(is_antagish && antag_info_temp)
 		. += span_details("🏴‍☠️ | Antag Information",antag_info_temp)
@@ -117,17 +117,19 @@
 			temp += a + "\n"
 		. += span_details("🛠️ | Interaction Information",temp)
 
+/mob/proc/antag_check()
+	if(mind && (mind.special_role || mind.antag_holder.is_antag())) //We're a /mob and have a mind and antag status.
+		return TRUE
+	if(isobserver(src)) //We're an observer. We always are able to see stuff antags see.
+		return TRUE
+	var/datum/component/antag/comp = GetComponent(/datum/component/antag)
+	if(comp)
+		return TRUE
+	return FALSE
+
 /mob/proc/update_examine_panel(var/atom/A)
 	if(client)
-		var/is_antag
-		if((mind && mind.special_role) || isobserver(src)) //todo: Phase out special_role entirely and make it check for component/antag entirely.
-			is_antag = TRUE
-		else if(isliving(src))
-			var/datum/component/antag/comp = GetComponent(/datum/component/antag)
-			if(comp)
-				is_antag = TRUE
-			else if(mind && mind.antag_holder.is_antag())
-				is_antag = TRUE
+		var/is_antag = antag_check()
 		client.update_description_holders(A, is_antag)
 		SSstatpanels.set_examine_tab(client)
 


### PR DESCRIPTION

## About The Pull Request
Makes it so antags get the antag examine in the text chat instead of just the examine menu.
## Changelog
:cl: Diana
fix: Antags will now properly get antag-only text when examining things.
/:cl:
