### PR TITLE
Add Body Writing to humans

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -77,7 +77,6 @@
 		BP_L_LEG = skip_body & EXAMINE_SKIPLEGS,
 		BP_R_LEG = skip_body & EXAMINE_SKIPLEGS)
 
-
 	var/gender_hidden = (skip_gear & EXAMINE_SKIPJUMPSUIT) && (skip_body & EXAMINE_SKIPFACE)
 	var/gender_key = get_visible_gender(user, gender_hidden)
 	var/datum/gender/T = GLOB.gender_datums[gender_key]
@@ -282,6 +281,7 @@
 	vorestrings += examine_step_size()
 	vorestrings += examine_nif()
 	vorestrings += examine_chimera()
+	vorestrings += examine_body_writing(hidden, T)
 	for(var/entry in vorestrings)
 		if(entry == "" || entry == null)
 			vorestrings -= entry

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -138,3 +138,20 @@
 				return span_notice("[t_He] [t_appear] to be in some sort of torpor.")
 		else if(xc.feral)
 			return span_warning("[t_He] [t_has] a crazed, wild look in [t_his] eyes!")
+
+/mob/living/carbon/human/proc/examine_body_writing(list/hidden, datum/gender/G)
+	. = list()
+
+	for(var/bodypart in hidden)
+		var/is_hidden = hidden[bodypart]
+		if(is_hidden)
+			continue
+
+		var/writing = LAZYACCESS(body_writing, bodypart)
+		if(writing)
+			var/obj/item/organ/external/affecting = get_organ(bodypart)
+			if(!affecting || affecting.is_stump())
+				LAZYREMOVE(body_writing, bodypart)
+				continue
+
+			. += span_notice("[G.He] [G.has] \"[writing]\" written on [G.his] [parse_zone(bodypart)].")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1153,6 +1153,8 @@
 /mob/living/carbon/human/wash(clean_types)
 	. = ..()
 
+	LAZYCLEARLIST(body_writing)
+
 	//Always do hands (or whatever's on our hands)
 	if(gloves)
 		gloves.wash(clean_types)

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -12,3 +12,5 @@
 	var/low_sorting_priority = FALSE
 
 	tail_alt = TAIL_UPPER_LAYER // not a toggle for humans but a pointer for what layer the tail should be when facing North/East/West
+
+	var/list/body_writing // assoc list by BP_ key

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -181,6 +181,34 @@
 			else
 				return TRUE //You don't get to hit someone 'later'
 
+	// Body writing
+	else if(istype(I, /obj/item/pen))
+		// Avoids having an override on this proc because attempt_vr won't call the override
+		if(!ishuman(src))
+			return FALSE
+		var/mob/living/carbon/human/us = src
+
+		if(!isliving(user))
+			return FALSE
+		var/mob/living/attacker = user
+
+		if(attacker.a_intent != I_HELP)
+			return FALSE
+
+		var/hit_zone = attacker.zone_sel.selecting
+
+		var/obj/item/organ/external/affecting = get_organ(hit_zone)
+		if(!affecting || affecting.is_stump())
+			to_chat(attacker, span_danger("They are missing that limb!"))
+			return TRUE
+
+		var/message = tgui_input_text(attacker, "What would you like to write on [src]'s [affecting]? (This will replace existing writing.)", "Body Writing", "", 128, FALSE)
+		if(!message)
+			return TRUE
+
+		LAZYSET(us.body_writing, affecting.organ_tag, message)
+		return TRUE
+
 	return FALSE
 
 //


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![https://i.tigercat2000.net/2025/07/dreamseeker_gEyxBKP1dt.png](https://i.tigercat2000.net/2025/07/dreamseeker_gEyxBKP1dt.png)

Allows you to write on humans by targeting a limb with a pen in help intent. The limb must exist, and only one piece of writing can be on a limb at once (so just use commas if you want to cover them in writing)

## Changelog
:cl:
add: You can now write messages on people with a pen~
/:cl: