### PR TITLE
Allows virologists to change viruses names

### DIFF
--- a/code/game/machinery/pandemic.dm
+++ b/code/game/machinery/pandemic.dm
@@ -222,7 +222,7 @@
 		traits["name"] = disease.name
 		if(istype(disease, /datum/disease/advance))
 			var/datum/disease/advance/adv_disease = disease
-			traits["can_rename"] = (adv_disease.name == "Unknown")
+			traits["can_rename"] = TRUE // Allow for all diseases to change currently. Mutable trait maybe?
 			traits["name"] = disease.name
 			traits["is_adv"] = TRUE
 			traits["symptoms"] = list()


### PR DESCRIPTION

## About The Pull Request

Oops, random naming broke this... This should allow any virologist to change the name of viruses, as long as they make a sample out of them.

## Changelog
:cl:
fix: Virologists can change the name of their viruses now
/:cl:
