### PR TITLE
lint for icon and icon_state on turfs

### DIFF
--- a/tools/maplint/lints/turf_varedits.yml
+++ b/tools/maplint/lints/turf_varedits.yml
@@ -1,0 +1,4 @@
+/turf:
+  banned_variables:
+  - icon
+  - icon_state


### PR DESCRIPTION
There's no way for change turf to know what a mapper had set. So those vars are banned. 