### PR TITLE
Xenochimer Component application bugfix

### DIFF
--- a/code/datums/components/species/xenochimera.dm
+++ b/code/datums/components/species/xenochimera.dm
@@ -18,8 +18,9 @@
 		return COMPONENT_INCOMPATIBLE
 	owner = parent
 	RegisterSignal(owner, COMSIG_XENOCHIMERA_COMPONENT, PROC_REF(handle_comp))
-	handle_record()
 	RegisterSignal(owner, COMSIG_HUMAN_DNA_FINALIZED, PROC_REF(handle_record))
+	if(owner.dna)
+		handle_record()
 	add_verb(owner, /mob/living/carbon/human/proc/reconstitute_form)
 
 /datum/component/xenochimera/Destroy(force)


### PR DESCRIPTION

## About The Pull Request
Fixes an issue where when xenochimera component was applied midround and nothing updated their DNA, they couldn't revive
## Changelog
:cl: Diana
fix: Xenochimera component can be applied midround
/:cl:
