### PR TITLE
Makes bodystyle count towards whitelisted items

### DIFF
--- a/code/modules/client/preference_setup/loadout/02_loadout.dm
+++ b/code/modules/client/preference_setup/loadout/02_loadout.dm
@@ -69,8 +69,8 @@ var/list/gear_datums = list()
 	save_data["gear_slot"] = pref.gear_slot
 
 /datum/category_item/player_setup_item/loadout/loadout/proc/is_valid_gear(datum/gear/G, max_cost)
-	if(G.whitelisted && CONFIG_GET(flag/loadout_whitelist) != LOADOUT_WHITELIST_OFF && pref.client) //VOREStation Edit.
-		if(CONFIG_GET(flag/loadout_whitelist) == LOADOUT_WHITELIST_STRICT && G.whitelisted != pref.species)
+	if(G.whitelisted && CONFIG_GET(flag/loadout_whitelist) != LOADOUT_WHITELIST_OFF && pref.client)
+		if(CONFIG_GET(flag/loadout_whitelist) == LOADOUT_WHITELIST_STRICT && (G.whitelisted != pref.species && G.whitelisted != pref.custom_base))
 			return FALSE
 		if(CONFIG_GET(flag/loadout_whitelist) == LOADOUT_WHITELIST_LAX && !is_alien_whitelisted(pref.client, GLOB.all_species[G.whitelisted]))
 			return FALSE

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -225,7 +225,7 @@
 						if(previewJob.title == job_name)
 							permitted = 1
 
-				if(G.whitelisted && (G.whitelisted != mannequin.species.name))
+				if(G.whitelisted && (G.whitelisted != mannequin.species.name && G.whitelisted != mannequin.species.base_species))
 					permitted = 0
 
 				if(!permitted)


### PR DESCRIPTION

## About The Pull Request
Makes whitelisted items (such as teshari cloak) able to be selected if you're, say, a promethean or protean with a teshari custom base.
## Changelog
:cl: Diana
fix: Whitelisted items can be selected if you're the shape of that species if not that species exactly.
/:cl:
