### PR TITLE
Recycler hotfix

### DIFF
--- a/code/modules/maint_recycler/code/maint_vendor.dm
+++ b/code/modules/maint_recycler/code/maint_vendor.dm
@@ -134,10 +134,12 @@
 		purchase_failed(user, "Out of Stock")
 		return FALSE
 	if(LAZYLEN(attempted_entry.required_access)) //access check
-		req_access = attempted_entry.required_access
+		req_one_access = attempted_entry.required_access
 		if(!allowed(user))
 			purchase_failed(user, "Access Denied")
+			req_one_access = list()
 			return FALSE
+		req_one_access = list()
 
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Thx for pointing this out Kash :D

7 Toaster plushies died in the fixing of this bug.
## Changelog
:cl:
fix: fixed the recycler deciding plebeians weren't allowed to use it after someone tried to buy an access locked item.
/:cl:
