### PR TITLE
Fixes facility map telecomms

### DIFF
--- a/maps/redgate/facility.dmm
+++ b/maps/redgate/facility.dmm
@@ -2958,7 +2958,10 @@
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/office8)
 "eku" = (
-/obj/machinery/telecomms/allinone,
+/obj/structure/prop/machine/core{
+	icon = 'icons/obj/stationobjs_vr.dmi';
+	icon_state = "allinone"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/redgate/facility/lab3)
 "ekR" = (
@@ -14355,9 +14358,12 @@
 /turf/simulated/floor/tiled/white,
 /area/redgate/facility/entrance)
 "ulm" = (
-/obj/machinery/telecomms/bus,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/prop/machine/core{
+	icon = 'icons/obj/stationobjs_vr.dmi';
+	icon_state = "bus"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/redgate/facility/lab3)
@@ -14747,7 +14753,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/redgate/facility/cell9)
 "uMg" = (
-/obj/machinery/telecomms/server,
+/obj/structure/prop/machine/core{
+	icon = 'icons/obj/stationobjs_vr.dmi';
+	icon_state = "comm_server"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/redgate/facility/lab3)
 "uMq" = (


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Replaced telecomms machines in the facility redgate map with props that look like them instead.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
maptweak: Replaced telecomms machines in the facility redgate map with props that look like them instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
