### PR TITLE
Changeling fix & Floortile Placement

### DIFF
--- a/code/datums/components/antags/changeling/powers/fleshmend.dm
+++ b/code/datums/components/antags/changeling/powers/fleshmend.dm
@@ -24,7 +24,6 @@
 	changeling.chem_charges -= 10
 
 	if(changeling.recursive_enhancement)
-		to_chat(src, span_notice("We will heal much faster."))
 		C.add_modifier(/datum/modifier/fleshmend/recursive, 50 SECONDS)
 	else
 		C.add_modifier(/datum/modifier/fleshmend, 50 SECONDS)
@@ -35,11 +34,13 @@
 /datum/modifier/fleshmend
 	name = "Fleshmend"
 	desc = "We are regenerating"
+	on_created_text "We have begun to regenerate our body."
+	on_expired_text "Our regeneration has ceased."
 
 // For changelings who bought the Recursive Enhancement evolution.
 /datum/modifier/fleshmend/recursive
 	name = "Advanced Fleshmend"
-	desc = "We are regenerating more rapidly."
+	desc = "We have begun regenerating our body, and more rapidly than normal."
 
 //These were previously 2 or 4 per second, now it's 4 or 8 per 2 seconds
 /datum/modifier/fleshmend/tick()

--- a/code/datums/components/antags/changeling/powers/fleshmend.dm
+++ b/code/datums/components/antags/changeling/powers/fleshmend.dm
@@ -34,8 +34,8 @@
 /datum/modifier/fleshmend
 	name = "Fleshmend"
 	desc = "We are regenerating"
-	on_created_text "We have begun to regenerate our body."
-	on_expired_text "Our regeneration has ceased."
+	on_created_text = "We have begun to regenerate our body."
+	on_expired_text = "Our regeneration has ceased."
 
 // For changelings who bought the Recursive Enhancement evolution.
 /datum/modifier/fleshmend/recursive

--- a/code/datums/components/antags/changeling/powers/lesser_form.dm
+++ b/code/datums/components/antags/changeling/powers/lesser_form.dm
@@ -19,8 +19,13 @@
 
 	var/mob/living/carbon/human/H = src
 
-	if(!istype(H) || !H.species.primitive_form)
-		to_chat(src, span_warning("We cannot perform this ability in this form!"))
+	if(!istype(H))
+		to_chat(src, span_warning("We must be a humanoid to use thia bility!!"))
+		return
+
+	else if(!H.species.primitive_form)
+		to_chat(src, span_warning("The species we are currently in the form of does not have a primitive form!"))
+		to_chat(src, span_info("NOTE: Species such as Unathi, Tajaran, Akula, and Human have primitive forms. Things such as custom species do not.")) //Let's add a warning...Ideally, we change primitive form to be based off body style, but we still run into the problem of some speices not having them.
 		return
 
 	changeling.chem_charges--

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -173,6 +173,11 @@
 		else
 			return 0
 		playsound(src, W.usesound, 80, 1)
+		if(isliving(user) && is_plating())
+			var/mob/living/deconstructor = user
+			var/obj/item/stack/tile/T = deconstructor.get_inactive_hand()
+			if(T)
+				attackby(T, user) // Replace the tile
 		return 1
 	else if(W.has_tool_quality(TOOL_SCREWDRIVER) && (flooring.flags & TURF_REMOVE_SCREWDRIVER))
 		if(broken || burnt)

--- a/code/modules/examine/descriptions/turfs.dm
+++ b/code/modules/examine/descriptions/turfs.dm
@@ -44,11 +44,13 @@
 			. += "Use a welder on it to repair the damage."
 		else
 			. += "Use a crowbar on it to remove it."
+			. += "If using a crowbar and holding a floor tile in your offhand, you will automatically replace the floor with that tile."
 	else if(flooring)
 		if(flooring.flags & TURF_IS_FRAGILE)
 			. += "You can use a crowbar on it to remove it, but this will destroy it!"
 		else if(flooring.flags & TURF_REMOVE_CROWBAR)
 			. += "Use a crowbar on it to remove it."
+			. += "If using a crowbar and holding a floor tile in your offhand, you will automatically replace the floor with that tile."
 		if(flooring.flags & TURF_REMOVE_SCREWDRIVER)
 			. += "Use a screwdriver on it to remove it."
 		if(flooring.flags & TURF_REMOVE_WRENCH)

--- a/code/modules/tickets/procs.dm
+++ b/code/modules/tickets/procs.dm
@@ -168,21 +168,21 @@ ADMIN_VERB(cmd_mentor_ticket_panel, (R_ADMIN|R_SERVER|R_MOD|R_MENTOR), "Mentor T
 
 	//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)
-		to_chat(usr, span_danger("Error: You cannot request spice (muted from adminhelps)."))
+		to_chat(src, span_danger("Error: You cannot request spice (muted from adminhelps)."))
 		return
 
-	if(tgui_alert(usr, "Are you sure you want to request the admins spice things up for you? You accept the consequences if you do.","Spicy!",list("Yes","No")) == "Yes")
-		message_admins("[ADMIN_FULLMONTY(usr)] has requested the round be spiced up a little.")
-		to_chat(usr, span_notice("You have requested some more spice in your round."))
+	if(tgui_alert(src, "Are you sure you want to request the admins spice things up for you? You accept the consequences if you do.","Spicy!",list("Yes","No")) == "Yes")
+		message_admins("[ADMIN_FULLMONTY(src)] has requested the round be spiced up a little.")
+		to_chat(src, span_notice("You have requested some more spice in your round."))
 	else
-		to_chat(usr, span_notice("Spice request cancelled."))
+		to_chat(src, span_notice("Spice request cancelled."))
 		return
 
 	//if they requested spice, then remove spice verb temporarily to prevent spamming
-	remove_verb(usr,/client/verb/adminspice)
+	remove_verb(src,/client/verb/adminspice)
 	spawn(10 MINUTES)
-		if(usr)		// In case we left in the 10 minute cooldown
-			add_verb(usr,/client/verb/adminspice	) // 10 minute cool-down for spice request
+		if(src)		// In case we left in the 10 minute cooldown
+			add_verb(src,/client/verb/adminspice) // 10 minute cool-down for spice request
 
 //
 // MENTOR PROCS

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -215,6 +215,7 @@
 	if(A.flag_check(AREA_FORBID_EVENTS))
 		return 0
 	var/protected = 0
+	var/susceptibility = 1
 
 	//anomaly suits give best protection, but excavation suits are almost as good
 	if(istype(H.back,/obj/item/rig/hazmat))
@@ -239,4 +240,5 @@
 	if(istype(H.glasses,/obj/item/clothing/glasses/science))
 		protected += 0.1
 
-	return 1 - protected
+	susceptibility = CLAMP(susceptibility - protected, 0, 1) //Clamp the susceptibility to be between 0 and 1. No negative numbers allowed.
+	return susceptibility

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -240,5 +240,5 @@
 	if(istype(H.glasses,/obj/item/clothing/glasses/science))
 		protected += 0.1
 
-	susceptibility = CLAMP(susceptibility - protected, 0, 1) //Clamp the susceptibility to be between 0 and 1. No negative numbers allowed.
+	susceptibility = CLAMP01(susceptibility - protected) //Clamp the susceptibility to be between 0 and 1. No negative numbers allowed.
 	return susceptibility

--- a/code/modules/xenoarcheaology/effects/resurrect.dm
+++ b/code/modules/xenoarcheaology/effects/resurrect.dm
@@ -25,8 +25,8 @@
 	if(target.stat != DEAD && stored_life < 200)
 		holder.Beam(target, icon_state = "drain_life", time = 1 SECOND)
 		if(!prob(susceptibility * 100)) //Inverse. If they are not susceptible, we don't steal life. We still beam them though.
-			target.apply_damage(5*susceptibility, SEARING, BP_TORSO)
-		return 25*susceptibility //nobody actually uses this god damned thing so I'm buffing it so maybe one day someone will ACTUALLY USE IT.
+			target.apply_damage(5 * susceptibility, SEARING, BP_TORSO)
+		return 25 * susceptibility //nobody actually uses this god damned thing so I'm buffing it so maybe one day someone will ACTUALLY USE IT.
 
 	return 0
 

--- a/code/modules/xenoarcheaology/effects/resurrect.dm
+++ b/code/modules/xenoarcheaology/effects/resurrect.dm
@@ -17,10 +17,16 @@
 	if(!istype(target))
 		return 0
 
+	var/susceptibility = 1
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		susceptibility = GetAnomalySusceptibility(H)
+
 	if(target.stat != DEAD && stored_life < 200)
 		holder.Beam(target, icon_state = "drain_life", time = 1 SECOND)
-		target.apply_damage(5, SEARING, BP_TORSO)
-		return 5
+		if(!prob(susceptibility * 100)) //Inverse. If they are not susceptible, we don't steal life. We still beam them though.
+			target.apply_damage(5*susceptibility, SEARING, BP_TORSO)
+		return 25*susceptibility //nobody actually uses this god damned thing so I'm buffing it so maybe one day someone will ACTUALLY USE IT.
 
 	return 0
 


### PR DESCRIPTION
## About The Pull Request
Fixes a bug where changeling fleshmend did not give you activation text
Clarifies changeling lesserform that you NEED to be a species with a lesser form to do so.
Adds (readds?) it so that you can immediately place floor tile if you crowbar a tile up with a floortile in your offhand
Fixes a xenoarch exploit pertaining to item stacking.
Makes the resurrection artifact respect anomaly clothing.
![dreamseeker_2025-07-16_16-52-19](https://github.com/user-attachments/assets/7ca2fae9-dfb0-48f5-85c4-bd91faba1973)
## Changelog
:cl: Diana
add: Auto floortile placement if crowbarring floor tiles up with a floor tile in your offhand
fix: Changeling fleshmend gives you activation text now
fix: Makes the resurrection artifact respect anomaly clothing.
fix: Fixes a xenoarch exploit pertaining to item stacking.
qol: Changeling lesserform informs you of its failstates
/:cl:
