### PR TITLE
Adjusts the unarmed unarmed traits,

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -29,39 +29,50 @@
 
 /datum/trait/positive/punchdamage
 	name = "Strong Attacks"
-	desc = "Your unarmed attacks deal more damage"
-	cost = 2
+	desc = "Your unarmed attacks deal more damage. (+5 per attack)"
+	cost = 1
 	custom_only = FALSE
 	hidden = TRUE //Disabled on Virgo.
 	var_changes = list("unarmed_bonus" = 5)
+	excludes = list(/datum/trait/positive/punchdamageplus)
 	banned_species = list(SPECIES_TESHARI)
 
 /datum/trait/positive/punchdamageplus
 	name = "Crushing Attacks"
-	desc = "Your unarmed attacks deal high damage, and you're capable of escaping most restraints"
-	cost = 6
+	desc = "Your unarmed attacks deal high damage. (+10 per attack)"
+	cost = 2
 	custom_only = FALSE
 	hidden = TRUE //Disabled on Virgo.
-	var_changes = list("unarmed_bonus" = 10, "shredding" = TRUE)
+	var_changes = list("unarmed_bonus" = 10)
+	excludes = list(/datum/trait/positive/punchdamage)
+	banned_species = list(SPECIES_TESHARI, SPECIES_VOX)
+
+/datum/trait/positive/shredding_attacks //Variant of plus
+	name = "Shredding Attacks"
+	desc = "Your unarmed attacks can break windows, APCs, deal massive damage to synthetics, and you can break out of restraints 24 times faster."
+	cost = 6
+	custom_only = FALSE
+	hidden = TRUE
+	var_changes = list("shredding" = TRUE)
 	banned_species = list(SPECIES_TESHARI, SPECIES_VOX)
 
 /datum/trait/positive/strength //combine effects of hardy + strong punches, for if someone wants a generally "strong" character. Exists for the purposes of the trait limit
 	name = "High Strength"
-	desc = "Your unarmed attacks deal more damage, and you can carry heavy equipment with less slowdown."
-	cost = 3
+	desc = "Your unarmed attacks deal more damage (+5), and you can carry heavy equipment with 50% less slowdown."
+	cost = 2
 	custom_only = FALSE
 	hidden = TRUE //Disabled on Virgo.
 	var_changes = list("unarmed_bonus" = 5, "item_slowdown_mod" = 0.5)
-	excludes = list(/datum/trait/positive/punchdamage, /datum/trait/positive/hardy)
+	excludes = list(/datum/trait/positive/punchdamage, /datum/trait/positive/hardy, /datum/trait/positive/hardy_plus)
 	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN)
 
 /datum/trait/positive/strengthplus //see above comment
 	name = "Inhuman Strength"
-	desc = "You are unreasonably strong. Your unarmed attacks do high damage, you experience almost no slowdown from heavy equipment, and you can escape most restraints with ease."
-	cost = 8
+	desc = "You are unreasonably strong. Your unarmed attacks do high damage (+10), you experience much less slowdown from heavy equipment (75% less)."
+	cost = 4
 	custom_only = FALSE
 	hidden = TRUE //Disabled on Virgo.
-	var_changes = list("unarmed_bonus" = 10, "shredding" = TRUE, "item_slowdown_mod" = 0.25)
+	var_changes = list("unarmed_bonus" = 10, "item_slowdown_mod" = 0.25)
 	excludes = list(/datum/trait/positive/punchdamage, /datum/trait/positive/hardy, /datum/trait/positive/punchdamageplus, /datum/trait/positive/hardy_plus)
 	banned_species = list(SPECIES_ALRAUNE, SPECIES_TESHARI, SPECIES_UNATHI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_PROTEAN, SPECIES_VOX)
 


### PR DESCRIPTION

## About The Pull Request
Disabled here so nothing player facing on Virgo.
Makes the descriptions inform you of HOW MUCH 'more' and 'high' means.
Splits punchdamageplus into two parts: Shredding and the +10 damage per attack.
Lowers the cost of +5 melee to 1 trait point and +10 melee to 2 trait points. Strength and Inhuman Strength adjusted appropriately.
## Changelog
nothing player facing here, these are traits that are disabled on virgo.
