### PR TITLE
loot element uses proper global lists

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -579,10 +579,10 @@ GLOBAL_LIST_EMPTY(random_maps)
 GLOBAL_LIST_EMPTY(map_count)
 GLOBAL_LIST_EMPTY(narsie_list)
 GLOBAL_LIST_EMPTY(id_card_states)
-GLOBAL_LIST_EMPTY(allocated_gamma)
+GLOBAL_LIST_EMPTY(allocated_gamma_loot)
 GLOBAL_LIST_EMPTY(semirandom_mob_spawner_decisions)
 
-GLOBAL_LIST_INIT(unique_gamma, list(
+GLOBAL_LIST_INIT(unique_gamma_loot, list(
 	/obj/item/perfect_tele,
 	/obj/item/bluespace_harpoon,
 	/obj/item/clothing/glasses/thermal/syndi,

--- a/code/datums/elements/lootable/_lootable.dm
+++ b/code/datums/elements/lootable/_lootable.dm
@@ -1,13 +1,3 @@
-GLOBAL_LIST_INIT(allocated_gamma_loot,list())
-GLOBAL_LIST_INIT(unique_gamma_loot,list(\
-		/obj/item/perfect_tele,\
-		/obj/item/bluespace_harpoon,\
-		/obj/item/clothing/glasses/thermal/syndi,\
-		/obj/item/gun/energy/netgun,\
-		/obj/item/gun/projectile/dartgun,\
-		/obj/item/clothing/gloves/black/bloodletter,\
-		/obj/item/gun/energy/mouseray/metamorphosis))
-
 /datum/element/lootable
 	var/chance_nothing = 0			// Unlucky people might need to loot multiple spots to find things.
 	var/chance_uncommon = 10		// Probability of pulling from the uncommon_loot list.


### PR DESCRIPTION
## About The Pull Request
Oops, the global lists were moved around before the looting element was merged. Corrected the lists.

## Changelog
Global lists in proper files, no player facing changes.

:cl:
code: Gamma loot global list moved to proper file
/:cl: