### PR TITLE
simple mob adnmin spawn

### DIFF
--- a/code/modules/admin/verbs/randomverbs_vr.dm
+++ b/code/modules/admin/verbs/randomverbs_vr.dm
@@ -73,8 +73,10 @@
 			new_mob.vore_selected = new_mob.vore_organs[1]
 			if(isanimal(new_mob))
 				var/mob/living/simple_mob/Sm = new_mob
-				Sm.vore_active = TRUE
-				Sm.voremob_loaded = TRUE
+				if(!Sm.voremob_loaded || !Sm.vore_active)
+					Sm.vore_active = TRUE
+					Sm.voremob_loaded = TRUE
+					Sm.init_vore()
 
 	log_admin("[key_name_admin(src)] has spawned [new_mob.key] as mob [new_mob.type].")
 	message_admins("[key_name_admin(src)] has spawned [new_mob.key] as mob [new_mob.type].", 1)

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -219,6 +219,9 @@
 	add_verb(src, /mob/living/simple_mob/proc/toggle_digestion)
 	add_verb(src, /mob/living/simple_mob/proc/toggle_fancygurgle)
 	add_verb(src, /mob/living/proc/vertical_nom)
+	add_verb(src,/mob/living/simple_mob/proc/animal_nom)
+	add_verb(src,/mob/living/proc/shred_limb)
+	add_verb(src,/mob/living/simple_mob/proc/nutrition_heal)
 
 	if(LAZYLEN(vore_organs))
 		return

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -219,9 +219,9 @@
 	add_verb(src, /mob/living/simple_mob/proc/toggle_digestion)
 	add_verb(src, /mob/living/simple_mob/proc/toggle_fancygurgle)
 	add_verb(src, /mob/living/proc/vertical_nom)
-	add_verb(src,/mob/living/simple_mob/proc/animal_nom)
-	add_verb(src,/mob/living/proc/shred_limb)
-	add_verb(src,/mob/living/simple_mob/proc/nutrition_heal)
+	add_verb(src, /mob/living/simple_mob/proc/animal_nom)
+	add_verb(src, /mob/living/proc/shred_limb)
+	add_verb(src, /mob/living/simple_mob/proc/nutrition_heal)
 
 	if(LAZYLEN(vore_organs))
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolf.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolf.dm
@@ -34,18 +34,16 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/wolf)
 
 	allow_mind_transfer = TRUE
+	vore_active = TRUE
+	vore_capacity = 1
+	vore_icons = SA_ICON_LIVING
 
 	can_be_drop_prey = FALSE
 	species_sounds = "Canine"
 	pain_emote_1p = list("yelp", "whine", "bark", "growl")
 	pain_emote_3p = list("yelps", "whines", "barks", "growls")
 
-// Activate Noms!
-/mob/living/simple_mob/vore/wolf
-	vore_active = 1
-	vore_icons = SA_ICON_LIVING
-
-/mob/living/simple_mob/animal/wolf/init_vore()
+/mob/living/simple_mob/animal/vore/wolf/init_vore()
 	if(!voremob_loaded)
 		return
 	if(LAZYLEN(vore_organs))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
After making sure that init_vore is called instantly, we should recall it just to be safe that that admin spawned simple mobs get their verbs.

This works as mobs with bellies loaded the verbs already before the player has logged in. Passive mobs without bellies will only call the verb adding in the re init.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: admin spawned simple mobs not getting their vore verbs if they weren't vore mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
