### PR TITLE
dangerously set html change

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -47,7 +47,7 @@
 				"useHookAtTopLevel": "off"
 			},
 			"security": {
-				"noDangerouslySetInnerHtml": "off"
+				"noDangerouslySetInnerHtml": "warn"
 			},
 			"style": {
 				"noNonNullAssertion": "off",

--- a/tgui/packages/tgui/interfaces/GuestPass.tsx
+++ b/tgui/packages/tgui/interfaces/GuestPass.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
 import { Box, Button, LabeledList, Section } from 'tgui-core/components';
@@ -45,9 +44,9 @@ export const GuestPass = (props) => {
               Print
             </Button>
             <Section title="Logs">
-              {/* These are internally generated only. */}
               {(log.length &&
                 log.map((l) => (
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: These are internally generated only.
                   <div key={l} dangerouslySetInnerHTML={{ __html: l }} />
                 ))) || <Box>No logs.</Box>}
             </Section>

--- a/tgui/packages/tgui/interfaces/NtosEmailClient.tsx
+++ b/tgui/packages/tgui/interfaces/NtosEmailClient.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { useBackend } from 'tgui/backend';
 import { NtosWindow } from 'tgui/layouts';
 import {
@@ -324,9 +323,8 @@ export const NtosEmailClientViewMessage = (props: {
           ''}
         <LabeledList.Item label="Message" verticalAlign="top">
           <Section>
-            {/* This dangerouslySetInnerHTML is only ever passed data that has passed through pencode2html
-             * It should be safe enough to support pencode in this way.
-             */}
+            {/** biome-ignore lint/security/noDangerouslySetInnerHtml: is only ever passed data that has passed through pencode2html
+             * It should be safe enough to support pencode in this way. */}
             <div dangerouslySetInnerHTML={{ __html: cur_body! }} />
           </Section>
         </LabeledList.Item>
@@ -448,6 +446,8 @@ const NtosEmailClientNewMessage = (props) => {
           <Stack>
             <Stack.Item grow>
               <Section width="99%" inline>
+                {/** biome-ignore lint/security/noDangerouslySetInnerHtml: is only ever passed data that has passed through pencode2html
+                 * It should be safe enough to support pencode in this way. */}
                 <div dangerouslySetInnerHTML={{ __html: msg_body! }} />
               </Section>
             </Stack.Item>

--- a/tgui/packages/tgui/interfaces/NtosFileManager.tsx
+++ b/tgui/packages/tgui/interfaces/NtosFileManager.tsx
@@ -1,5 +1,3 @@
-/* eslint react/no-danger: "off" */
-
 import { useBackend } from 'tgui/backend';
 import { NtosWindow } from 'tgui/layouts';
 import { Button, Section, Stack, Table } from 'tgui-core/components';
@@ -60,9 +58,8 @@ export const NtosFileManager = (props) => {
               </Stack>
             }
           >
-            {/* This dangerouslySetInnerHTML is only ever passed data that has passed through pencode2html
-             * It should be safe enough to support pencode in this way.
-             */}
+            {/** biome-ignore lint/security/noDangerouslySetInnerHtml: is only ever passed data that has passed through pencode2html
+             * It should be safe enough to support pencode in this way. */}
             {filedata && <div dangerouslySetInnerHTML={{ __html: filedata }} />}
           </Section>
         )) || (

--- a/tgui/packages/tgui/interfaces/NtosNewsBrowser.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNewsBrowser.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { resolveAsset } from 'tgui/assets';
 import { useBackend } from 'tgui/backend';
 import { NtosWindow } from 'tgui/layouts';
@@ -88,9 +87,8 @@ const SelectedArticle = (props) => {
       }
     >
       {!!cover && <Image src={resolveAsset(cover)} />}
-      {/* News articles are written in premade .html files and cannot be edited by players, so it should be
-       * safe enough to use dangerouslySetInnerHTML here.
-       */}
+      {/** biome-ignore lint/security/noDangerouslySetInnerHtml: News articles are written in premade .html files and cannot be edited by players, so it should be
+       * safe enough to use dangerouslySetInnerHTML here. */}
       <div dangerouslySetInnerHTML={{ __html: content }} />
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/NtosWordProcessor.tsx
+++ b/tgui/packages/tgui/interfaces/NtosWordProcessor.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { useBackend } from 'tgui/backend';
 import { NtosWindow } from 'tgui/layouts';
 import { Box, Button, Section, Table } from 'tgui-core/components';
@@ -95,10 +94,9 @@ export const NtosWordProcessor = (props) => {
                   Print
                 </Button>
               </Box>
-              {/* This dangerouslySetInnerHTML is only ever passed data that has passed through pencode2html
-               * It should be safe enough to support pencode in this way.
-               */}
               <Section mt={1}>
+                {/** biome-ignore lint/security/noDangerouslySetInnerHtml: is only ever passed data that has passed through pencode2html
+                 * It should be safe enough to support pencode in this way.*/}
                 <div dangerouslySetInnerHTML={{ __html: filedata! }} />
               </Section>
             </Section>

--- a/tgui/packages/tgui/interfaces/Pda/pda_screens/pda_notekeeper.tsx
+++ b/tgui/packages/tgui/interfaces/Pda/pda_screens/pda_notekeeper.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { useBackend } from 'tgui/backend';
 import { Box, Button, Section, Table } from 'tgui-core/components';
 
@@ -92,9 +91,7 @@ export const pda_notekeeper = (props) => {
         </Button>
       </Section>
       <Section>
-        {/* As usual with dangerouslySetInnerHTML,
-            this notekeeper was designed to use HTML injection.
-            Fix when markdown is easier. */}
+        {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Markdown in PDA notes */}
         <div dangerouslySetInnerHTML={{ __html: note }} />
       </Section>
     </Box>

--- a/tgui/packages/tgui/interfaces/Ticket.tsx
+++ b/tgui/packages/tgui/interfaces/Ticket.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { type RefObject, useEffect, useRef, useState } from 'react';
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
@@ -128,6 +127,7 @@ export const Ticket = (props) => {
                   <Stack>
                     <Stack.Item>#{id}:</Stack.Item>
                     <Stack.Item>
+                      {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data */}
                       <div dangerouslySetInnerHTML={{ __html: name }} />
                     </Stack.Item>
                   </Stack>
@@ -160,6 +160,7 @@ export const Ticket = (props) => {
                   </LabeledList.Item>
                 )}
                 <LabeledList.Item label="Actions">
+                  {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data */}
                   <div dangerouslySetInnerHTML={{ __html: actions }} />
                 </LabeledList.Item>
               </LabeledList>
@@ -175,6 +176,7 @@ export const Ticket = (props) => {
                     .map((L, i) => (
                       <div
                         key={i}
+                        // biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data
                         dangerouslySetInnerHTML={{ __html: log[L] }}
                       />
                     ))}

--- a/tgui/packages/tgui/interfaces/TicketChat.tsx
+++ b/tgui/packages/tgui/interfaces/TicketChat.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { type RefObject, useEffect, useRef, useState } from 'react';
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
@@ -99,6 +98,7 @@ export const TicketChat = (props) => {
                     .map((L, i) => (
                       <div
                         key={i}
+                        // biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket Chat
                         dangerouslySetInnerHTML={{ __html: log[L] }}
                       />
                     ))}

--- a/tgui/packages/tgui/interfaces/TicketsPanel.tsx
+++ b/tgui/packages/tgui/interfaces/TicketsPanel.tsx
@@ -1,4 +1,3 @@
-/* eslint react/no-danger: "off" */
 import { type RefObject, useEffect, useRef, useState } from 'react';
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
@@ -269,6 +268,7 @@ export const TicketsPanel = (props) => {
                           <Stack.Item>#{selected_ticket.id}:</Stack.Item>
                           <Stack.Item>
                             <div
+                              // biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data
                               dangerouslySetInnerHTML={{
                                 __html: selected_ticket.name,
                               }}
@@ -321,6 +321,7 @@ export const TicketsPanel = (props) => {
                       )}
                       <LabeledList.Item label="Actions">
                         <div
+                          // biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data
                           dangerouslySetInnerHTML={{
                             __html: selected_ticket.actions,
                           }}
@@ -339,6 +340,7 @@ export const TicketsPanel = (props) => {
                           .map((L, i) => (
                             <div
                               key={i}
+                              // biome-ignore lint/security/noDangerouslySetInnerHtml: Ticket data
                               dangerouslySetInnerHTML={{
                                 __html: selected_ticket.log[L],
                               }}


### PR DESCRIPTION
noDangerouslySetInnerHtml is set to warn. We use it in a few places. But we usually should provide a reason and know what for...