### PR TITLE
Feature/circuity overhaul

### DIFF
--- a/code/controllers/subsystems/circuits.dm
+++ b/code/controllers/subsystems/circuits.dm
@@ -84,7 +84,8 @@ SUBSYSTEM_DEF(circuit)
 		/obj/item/clothing/shoes/circuitry,
 		/obj/item/clothing/head/circuitry,
 		/obj/item/clothing/ears/circuitry,
-		/obj/item/clothing/suit/circuitry
+		/obj/item/clothing/suit/circuitry,
+		/obj/item/electronic_assembly/circuit_bug
 		)
 
 	circuit_fabricator_recipe_list["Tools"] = list(

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -264,15 +264,18 @@
 	IC.assembly = src
 
 /obj/item/electronic_assembly/afterattack(atom/target, mob/user, proximity)
+	var/scanned = FALSE
 	if(proximity)
-		var/scanned = FALSE
+		// Existing sensor support
 		for(var/obj/item/integrated_circuit/input/sensor/S in contents)
-//			S.set_pin_data(IC_OUTPUT, 1, WEAKREF(target))
-//			S.check_then_do_work()
 			if(S.scan(target))
 				scanned = TRUE
 		if(scanned)
 			visible_message(span_infoplain(span_bold("\The [user]") + " waves \the [src] around [target]."))
+
+	// Support for reference grabber + future ranged circuitry.
+	for(var/obj/item/integrated_circuit/input/reference_grabber/G in contents)
+		G.afterattack(target, user, proximity, null)
 
 /obj/item/electronic_assembly/attackby(var/obj/item/I, var/mob/user)
 	if(can_anchor && I.has_tool_quality(TOOL_WRENCH))

--- a/code/modules/integrated_electronics/core/assemblies/circuit_bug.dm
+++ b/code/modules/integrated_electronics/core/assemblies/circuit_bug.dm
@@ -1,0 +1,16 @@
+/obj/item/electronic_assembly/circuit_bug // A nerfed, circuitry version of the spy bug.
+	name = "electronic bug"
+	desc = "A tiny circuit assembly that looks perfect for hiding."
+	icon = 'icons/obj/integrated_electronics/electronic_setups.dmi'
+	icon_state = "setup_device_cylinder"
+	layer = TURF_LAYER+0.2 // Appears under many things, but with alt+click, unlike spy bug.
+	w_class = ITEMSIZE_TINY
+	slot_flags = SLOT_EARS
+	max_components = IC_COMPONENTS_BASE
+	max_complexity = 20 // Incredibly low complexity to prevent shenanigans.
+	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
+
+/obj/item/electronic_assembly/circuit_bug/examine(mob/user)
+	. = ..()
+	if(get_dist(user, src) == 0)
+		. += "It looks like it could be hidden easily..."

--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -100,6 +100,13 @@
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing)
 	return ..()
 
+/obj/item/clothing/under/circuitry/equipped(mob/user, slot) // Set wearer var when equiped.
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/under/circuitry/dropped(mob/user) // Remove wearer var.
+	wearer = null
+	..()
 
 // Gloves.
 /obj/item/clothing/gloves/circuitry
@@ -114,6 +121,13 @@
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/small)
 	return ..()
 
+/obj/item/clothing/gloves/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/gloves/circuitry/dropped(mob/user)
+	wearer = null
+	..()
 
 // Glasses.
 /obj/item/clothing/glasses/circuitry
@@ -128,6 +142,14 @@
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/small)
 	return ..()
 
+/obj/item/clothing/glasses/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/glasses/circuitry/dropped(mob/user)
+	wearer = null
+	..()
+
 // Shoes
 /obj/item/clothing/shoes/circuitry
 	name = "electronic boots"
@@ -140,6 +162,14 @@
 /obj/item/clothing/shoes/circuitry/Initialize(mapload)
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/small)
 	return ..()
+
+/obj/item/clothing/shoes/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/shoes/circuitry/dropped(mob/user)
+	wearer = null
+	..()
 
 // Head
 /obj/item/clothing/head/circuitry
@@ -154,6 +184,14 @@
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/small)
 	return ..()
 
+/obj/item/clothing/head/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/head/circuitry/dropped(mob/user)
+	wearer = null
+	..()
+
 // Ear
 /obj/item/clothing/ears/circuitry
 	name = "electronic earwear"
@@ -165,7 +203,17 @@
 
 /obj/item/clothing/ears/circuitry/Initialize(mapload)
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/small)
+	var/obj/item/integrated_circuit/built_in/earpiece_speaker/built_in_speaker = new(IC)
+	IC.force_add_circuit(built_in_speaker)
 	return ..()
+
+/obj/item/clothing/ears/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/ears/circuitry/dropped(mob/user)
+	wearer = null
+	..()
 
 // Exo-slot
 /obj/item/clothing/suit/circuitry
@@ -179,3 +227,11 @@
 /obj/item/clothing/suit/circuitry/Initialize(mapload)
 	setup_integrated_circuit(/obj/item/electronic_assembly/clothing/large)
 	return ..()
+
+/obj/item/clothing/suit/circuitry/equipped(mob/user, slot)
+	wearer = WEAKREF(user)
+	..()
+
+/obj/item/clothing/suit/circuitry/dropped(mob/user)
+	wearer = null
+	..()

--- a/code/modules/integrated_electronics/subtypes/built_in.dm
+++ b/code/modules/integrated_electronics/subtypes/built_in.dm
@@ -37,3 +37,24 @@
 
 /obj/item/integrated_circuit/built_in/action_button/do_work()
 	activate_pin(1)
+
+/obj/item/integrated_circuit/built_in/earpiece_speaker
+	name = "earpiece speaker"
+	desc = "This small speaker can be used to output sound to a person wearing an earpiece."
+	extended_desc = "This speaker can only be heard by the one wearing the earpiece."
+	inputs = list("displayed data" = IC_PINTYPE_STRING)
+	activators = list("load data" = IC_PINTYPE_PULSE_IN)
+	var/speaker_output = null
+
+/obj/item/integrated_circuit/built_in/earpiece_speaker/disconnect_all()
+	..()
+	speaker_output = null
+
+/obj/item/integrated_circuit/built_in/earpiece_speaker/do_work()
+	var/datum/integrated_io/I = inputs[1]
+	speaker_output = I.data
+
+	var/obj/item/clothing/ears/circuitry/ep = assembly.loc
+	var/mob/wearer = ep.wearer?.resolve()
+	if(wearer && ismob(wearer)) // Only allow the wearer to hear the earpiece exclusive speaker
+		to_chat(wearer, span_notice("[icon2html(ep, wearer.client)] [speaker_output]"))

--- a/code/modules/integrated_electronics/subtypes/logic.dm
+++ b/code/modules/integrated_electronics/subtypes/logic.dm
@@ -223,3 +223,30 @@
 
 /obj/item/integrated_circuit/logic/unary/not/do_check(var/datum/integrated_io/A)
 	return !A.data
+
+/obj/item/integrated_circuit/logic/toggler // Allows parts of circuits to be toggled on/off.
+	name = "circuit toggler"
+	desc = "Outputs its input data if enabled, otherwise does nothing. Used for enable/disabling parts of your circuit boards"
+	icon_state = "toggle_button"
+	inputs = list(
+		"input" = IC_PINTYPE_ANY,
+		"enabled" = IC_PINTYPE_BOOLEAN,
+		"toggle enable" = IC_PINTYPE_PULSE_IN,
+	)
+	inputs_default = list("2" = TRUE)
+	outputs = list("output" = IC_PINTYPE_ANY)
+	activators = list(
+		"pulse in" = IC_PINTYPE_PULSE_IN,
+		"pulse out" = IC_PINTYPE_PULSE_OUT
+		)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/logic/toggler/do_work()
+	pull_data()
+	var/enabled_input = get_pin_data(IC_INPUT, 2)
+	if(!enabled_input)
+		return
+	else
+		set_pin_data(IC_OUTPUT, 1, get_pin_data(IC_INPUT, 1))
+		push_data()
+		activate_pin(2)

--- a/code/modules/research/designs/circuit_assembly.dm
+++ b/code/modules/research/designs/circuit_assembly.dm
@@ -97,3 +97,12 @@
 	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/implant/integrated_circuit
 	sort_string = "UDAAF"
+
+/datum/design/item/integrated_circuitry/assembly/circuit_bug
+	name = "Circuitry Bug"
+	desc = "A tiny circuit assembly that can easily be hidden."
+	id = "circuit-bug"
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 2)
+	materials = list(MAT_STEEL = 2000)
+	build_path = /obj/item/electronic_assembly/circuit_bug
+	sort_string = "UDAAG"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2833,6 +2833,7 @@
 #include "code\modules\integrated_electronics\core\pins.dm"
 #include "code\modules\integrated_electronics\core\printer.dm"
 #include "code\modules\integrated_electronics\core\tools.dm"
+#include "code\modules\integrated_electronics\core\assemblies\circuit_bug.dm"
 #include "code\modules\integrated_electronics\core\assemblies\clothing.dm"
 #include "code\modules\integrated_electronics\core\assemblies\device.dm"
 #include "code\modules\integrated_electronics\core\assemblies\generic.dm"


### PR DESCRIPTION
## About The Pull Request

Some major improvements, and fixed to circuitry, as well as minor additions.
Reagent consuming circuits can now use the reagents in reagent storage circuitry, as was likely intended.
EPV2 circuit can send messages to communicators more intuitively.
Toggle circuit was added, allowing circuits to be disabled if it is toggled off.
Improved the afterattack() for circuitry assemblies.
Added reference grabber circuit, able to grab references of things within sight and 7 range.
Fixed text constraint issue on Text Pad when using TGUI.
Added circuitry bug assembly. This assembly appears beneath some sprites, like tables. It still appears when the tile is inspected, so it is weaker than the spy bug. Also has very low complexity for balancing reasons.
Added an electronic earpiece exclusive circuit that cannot be removed. Allows the wearer to hear messages, but not anyone sharing the tile.


## Changelog

:cl: Zizzi
add: Added a new circuitry assembly.
add: Added two new circuits
add: Added unique speaker to electronic earpiece.
fix: Fixed reagent using circuitry having no reagent input.
/:cl:
