### PR TITLE
Containment field exploit fix

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -47,10 +47,18 @@
 /obj/machinery/containment_field/ex_act(severity)
 	return 0
 
-/obj/machinery/containment_field/Crossed(mob/living/L)
-	if(!istype(L) || L.is_incorporeal())
+/obj/machinery/containment_field/Crossed(atom/A)
+	if(!istype(A) || A.is_incorporeal())
 		return
-	shock(L)
+	if(isliving(A))
+		var/mob/living/L = A
+		shock(L)
+		return
+	if(A.density)
+		if(istype(A,/obj/machinery/containment_field) || istype(A,/obj/effect) || istype(A,/obj/singularity))
+			return
+		else
+			Destroy()
 
 /obj/machinery/containment_field/HasProximity(turf/T, datum/weakref/WF, old_loc)
 	if(isnull(WF))


### PR DESCRIPTION

## About The Pull Request

Fixed an exploit that allowed dense objects to be pushed in front of the containment field when it was already active. It already had a check on startup to prevent starting with a dense object in the way, but did not check afterwards. It now instantly shuts off when a dense object crosses over it.

## Changelog
:cl:
fix: Fixed an exploit that allowed dense objects to be pushed in front of the containment field when it was already active. It now instantly shuts off when a dense object crosses over it.
/:cl:
