### PR TITLE
Fix stuttering getting blocked by any jittering effects

### DIFF
--- a/code/datums/components/disabilities/nervousness.dm
+++ b/code/datums/components/disabilities/nervousness.dm
@@ -1,6 +1,5 @@
 /datum/component/nervousness_disability
 	var/mob/owner
-	var/gutdeathpressure = 0
 
 /datum/component/nervousness_disability/Initialize()
 	if (!ishuman(parent))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -133,7 +133,7 @@
 			message_data[2] = pick(M.say_verbs)
 			. = 1
 
-	else if((CE_SPEEDBOOST in chem_effects) || is_jittery) // motor mouth
+	else if((CE_SPEEDBOOST in chem_effects) || (is_jittery && !stuttering)) // motor mouth, check for stuttering so anxiety doesn't do hyperzine text
 		// Despite trying to url/html decode these, byond is just being bad and I dunno.
 		var/static/regex/speedboost_initial = new (@"&[a-z]{2,5};|&#\d{2};","g")
 		// Not herestring because bad vs code syntax highlight panics at apostrophe


### PR DESCRIPTION
## About The Pull Request
Many effects that cause stuttering also cause jittering at the same time, but the jitter effect overrides them. Causing effects like anxiety to always do hyperzine text. This makes it so that stuttering has precedence. Otherwise things that directly give just jittering or CE_SPEEDBOOST will give hyperzine text like intended. 

## Changelog
Made stuttering take precedence over jittering.
also removes an unused var from nervousness component

:cl:
fix: Stuttering text is no longer suppressed by jittering.
/:cl: