### PR TITLE
Ghost spawn menu player fix

### DIFF
--- a/code/datums/ghost_spawn.dm
+++ b/code/datums/ghost_spawn.dm
@@ -50,8 +50,7 @@ GLOBAL_VAR_INIT(allowed_ghost_spawns, 2)
 
 	switch(action)
 		if("select_pod")
-			if(istype(observer))
-				jump_to_pod(ui.user, params["selected_pod"])
+			ghost_spawn("jump_to_pod", observer, params["selected_pod"])
 			. = TRUE
 		if("set_tab")
 			var/new_tab = text2num(params["val"])
@@ -59,40 +58,40 @@ GLOBAL_VAR_INIT(allowed_ghost_spawns, 2)
 				active_tab = new_tab
 			. = TRUE
 		if("soulcatcher_spawn")
-			soulcatcher_spawn(ui.user, params["selected_player"])
-			close_ui()
+			if(ghost_spawn("soulcatcher_spawn", observer, params["selected_player"]))
+				close_ui()
 			. = TRUE
 		if("soulcatcher_vore_spawn")
-			soulcatcher_vore_spawn(ui.user, params["selected_player"])
-			close_ui()
+			if(ghost_spawn("soulcatcher_vore_spawn", observer, params["selected_player"]))
+				close_ui()
 			. = TRUE
 		if("bellyspawn")
-			vore_belly_spawn(ui.user, params["selected_player"])
-			close_ui()
+			if(ghost_spawn("vore_belly_spawn", observer, params["selected_player"]))
+				close_ui()
 			. = TRUE
 		if("mouse_spawn")
-			become_mouse(ui.user)
+			ghost_spawn("become_mouse", observer)
 			. = TRUE
 		if("drone_spawn")
-			become_drone(ui.user, params["fabricator"])
+			ghost_spawn("become_drone", observer, params["fabricator"])
 			. = TRUE
 		if("vr_spawn")
-			join_vr(ui.user, params["landmark"])
+			ghost_spawn("join_vr", observer, params["landmark"])
 			. = TRUE
 		if("corgi_spawn")
-			join_corgi(ui.user)
+			ghost_spawn("join_corgi", observer)
 			. = TRUE
 		if("lost_drone_spawn")
-			join_lost(ui.user)
+			ghost_spawn("join_lost", observer)
 			. = TRUE
 		if("maintpred_spawn")
-			join_maintpred(ui.user)
+			ghost_spawn("join_maintpred", observer)
 			. = TRUE
 		if("gravekeeper_spawn")
-			join_grave(ui.user)
+			ghost_spawn("join_grave", observer)
 			. = TRUE
 		if("morph_spawn")
-			join_morpth(ui.user)
+			ghost_spawn("join_morpth", observer)
 			. = TRUE
 
 /datum/tgui_module/ghost_spawn_menu/proc/compile_pod_data()

--- a/code/datums/ghost_spawn_helper.dm
+++ b/code/datums/ghost_spawn_helper.dm
@@ -1,0 +1,70 @@
+/**
+ * Helper function to call the appropriate ghost spawn function
+ * This centralizes all ghost spawn actions, and fixes non-admins not being able to use the ghost spawn menu.
+ */
+/proc/ghost_spawn(function_name, mob/observer/dead/user, additional_args = null)
+	if(!istype(user))
+		return FALSE
+
+	switch(function_name)
+		if("jump_to_pod")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.jump_to_pod(user, additional_args)
+			return TRUE
+
+		if("become_mouse")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.become_mouse(user)
+			return TRUE
+
+		if("become_drone")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.become_drone(user, additional_args)
+			return TRUE
+
+		if("join_vr")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_vr(user, additional_args)
+			return TRUE
+
+		if("join_corgi")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_corgi(user)
+			return TRUE
+
+		if("join_lost")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_lost(user)
+			return TRUE
+
+		if("join_maintpred")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_maintpred(user)
+			return TRUE
+
+		if("join_grave")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_grave(user)
+			return TRUE
+
+		if("join_morpth")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.join_morpth(user)
+			return TRUE
+
+		if("soulcatcher_spawn")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.soulcatcher_spawn(user, additional_args)
+			return TRUE
+
+		if("soulcatcher_vore_spawn")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.soulcatcher_vore_spawn(user, additional_args)
+			return TRUE
+
+		if("vore_belly_spawn")
+			var/datum/tgui_module/ghost_spawn_menu/menu = new()
+			menu.vore_belly_spawn(user, additional_args)
+			return TRUE
+
+	return FALSE


### PR DESCRIPTION
## About The Pull Request

# Fixing compile issues at present, please ignore this for a moment - 

Fixes an issue where players can't use the ghost spawn issue based on this issue.
This is accomplished by adding a cleaner way to reference the ghost spawn functionality through a new helper.
The ghost spawn menu file itself wasn't changed too much, as I think it's layed out very cleanly.

### Additional testing would be appreciated.

## Changelog

:cl: Zizzi
fix: Fixed ghost spawn menu not working for players.
/:cl:
