### PR TITLE
Cargo sale element

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -480,6 +480,8 @@
 // /obj/item signals for economy
 ///called when an item is sold by the exports subsystem
 #define COMSIG_ITEM_SOLD "item_sold"
+///called when an item's cargo sale value is scanned
+#define COMSIG_ITEM_SCAN_PROFIT "item_scan_profit"
 ///called when a wrapped up structure is opened by hand
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"
 #define COMSIG_ITEM_UNWRAPPED "item_unwrapped"

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -103,13 +103,11 @@ SUBSYSTEM_DEF(supply)
 							find_slip = FALSE
 					else
 						// For each thing in the crate, get the value and quantity
-						SEND_SIGNAL(A,COMSIG_ITEM_SOLD,EC)
-
-			// Make a log of it, but it wasn't shipped properly, and so isn't worth anything
+						SEND_SIGNAL(A,COMSIG_ITEM_SOLD,EC,TRUE)
 			else
-				EC.contents = list(
-						"error" = "Error: Product was improperly packaged. Payment rendered null under terms of agreement."
-					)
+				// Selling things that are not in crates.
+				// Usually it just makes a log that it wasn't shipped properly, and so isn't worth anything
+				SEND_SIGNAL(MA,COMSIG_ITEM_SOLD,EC,FALSE)
 
 			exported_crates += EC
 			points += EC.value

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -85,7 +85,7 @@ SUBSYSTEM_DEF(supply)
 				points += CR.points_per_crate
 				if(CR.points_per_crate)
 					base_value = CR.points_per_crate
-				var/find_slip = 1
+				var/find_slip = TRUE
 
 				for(var/atom/A in CR)
 					EC.contents[++EC.contents.len] = list(
@@ -100,57 +100,10 @@ SUBSYSTEM_DEF(supply)
 						if(!slip.is_copy && slip.stamped && slip.stamped.len) //yes, the clown stamp will work. clown is the highest authority on the station, it makes sense
 							points += points_per_slip
 							EC.contents[EC.contents.len]["value"] = points_per_slip
-							find_slip = 0
-						continue
-
-					// Sell phoron and platinum
-					if(istype(A, /obj/item/stack))
-						var/obj/item/stack/P = A
-						var/datum/material/mat = P.get_material()
-						if(mat?.supply_conversion_value)
-							EC.contents[EC.contents.len]["value"] = P.get_amount() * mat.supply_conversion_value
-						EC.contents[EC.contents.len]["quantity"] = P.get_amount()
-						EC.value += EC.contents[EC.contents.len]["value"]
-
-					//Sell spacebucks
-					if(istype(A, /obj/item/spacecash))
-						var/obj/item/spacecash/cashmoney = A
-						EC.contents[EC.contents.len]["value"] = cashmoney.worth * points_per_money
-						EC.contents[EC.contents.len]["quantity"] = cashmoney.worth
-						EC.value += EC.contents[EC.contents.len]["value"]
-
-					//Sell research samples and containers with samples in them
-					if(istype(A, /obj/item/research_sample))
-						var/obj/item/research_sample/sample = A
-						EC.contents[EC.contents.len]["value"] = sample.supply_value
-						EC.contents[EC.contents.len]["quantity"] = 1
-						EC.value += EC.contents[EC.contents.len]["value"]
-
-					if(istype(A, /obj/item/storage/sample_container))
-						var/obj/item/storage/sample_container/sample_can = A
-						var/sample_sum = 0
-						var/obj/item/research_sample/stored_sample
-						if(LAZYLEN(sample_can.contents))
-							for(stored_sample in sample_can.contents)
-								sample_sum += stored_sample.supply_value
-						EC.contents[EC.contents.len]["quantity"] = "[A.contents.len] sample(s) "
-						EC.contents[EC.contents.len]["value"] = sample_sum
-						EC.value += sample_sum
-
-					//Sell vaccine samples
-					if(istype(A, /obj/item/reagent_containers/glass/beaker/vial/vaccine))
-						var/obj/item/reagent_containers/glass/beaker/vial/vaccine/sale_bottle = A
-						if(!istype(CR, /obj/structure/closet/crate/freezer))
-							EC.contents = list(
-								"error" = "Error: Product was improperly packaged. Send conents in freezer crate to preserve contents for transport."
-							)
-						else if(sale_bottle.reagents.reagent_list.len != 1 || sale_bottle.reagents.get_reagent_amount(REAGENT_ID_VACCINE) < sale_bottle.volume)
-							EC.contents = list(
-								"error" = "Error: Tainted product in batch. Was opened, contaminated, or was full. Payment rendered null under terms of agreement."
-							)
-						else
-							EC.contents[EC.contents.len]["value"] = 5
-							EC.value += EC.contents[EC.contents.len]["value"]
+							find_slip = FALSE
+					else
+						// For each thing in the crate, get the value and quantity
+						SEND_SIGNAL(A,COMSIG_ITEM_SOLD,EC)
 
 			// Make a log of it, but it wasn't shipped properly, and so isn't worth anything
 			else

--- a/code/datums/elements/sellable.dm
+++ b/code/datums/elements/sellable.dm
@@ -32,7 +32,7 @@
 		return
 
 	EC.contents[EC.contents.len]["value"] = calculate_sell_value(source)
-	EC.contents[EC.contents.len]["quantity"] = calculate_sell_quantity(obj/source)
+	EC.contents[EC.contents.len]["quantity"] = calculate_sell_quantity(source)
 	EC.value += EC.contents[EC.contents.len]["value"]
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/elements/sellable.dm
+++ b/code/datums/elements/sellable.dm
@@ -1,0 +1,94 @@
+/datum/element/sellable
+
+/datum/element/sellable/Attach(datum/target)
+	. = ..()
+	if(!isobj(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_SOLD, PROC_REF(sell))
+	return
+
+/datum/element/sellable/Detach(datum/source)
+	UnregisterSignal(source, COMSIG_ITEM_SOLD)
+	return ..()
+
+// Override this for sub elements that need to do complex calculations when sold
+/datum/element/sellable/proc/sell_error(obj/source)
+	return null // returns a string explaining why the item couldn't be sold. Otherwise null to allow it to be sold.
+
+/datum/element/sellable/proc/calculate_sell_value(obj/source)
+	return 2
+
+/datum/element/sellable/proc/calculate_sell_quantity(obj/source)
+	return 1
+// End overrides
+
+/datum/element/sellable/proc/sell(obj/source, var/datum/exported_crate/EC)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	SIGNAL_HANDLER
+
+	var/sell_error = sell_error(source)
+	if(sell_error)
+		EC.contents = list("error" = sell_error)
+		return
+
+	EC.contents[EC.contents.len]["value"] = calculate_sell_value(source)
+	EC.contents[EC.contents.len]["quantity"] = calculate_sell_quantity(obj/source)
+	EC.value += EC.contents[EC.contents.len]["value"]
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+// Subtypes
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Material stacks
+/datum/element/sellable/material_stack/calculate_sell_value(obj/source)
+	var/obj/item/stack/P = source
+	var/datum/material/mat = P.get_material()
+	return P.get_amount() * mat.supply_conversion_value
+
+/datum/element/sellable/material_stack/calculate_sell_quantity(obj/source)
+	var/obj/item/stack/P = source
+	return P.get_amount()
+
+
+// Money
+/datum/element/sellable/spacecash/calculate_sell_value(obj/source)
+	var/obj/item/spacecash/cashmoney = source
+	return cashmoney.worth * SSsupply.points_per_money
+
+/datum/element/sellable/spacecash/calculate_sell_quantity(obj/source)
+	var/obj/item/spacecash/cashmoney = source
+	return cashmoney.worth
+
+
+// Research samples
+/datum/element/sellable/research_sample/calculate_sell_value(obj/source)
+	var/obj/item/research_sample/sample = source
+	return sample.supply_value
+
+
+// Research containers
+/datum/element/sellable/sample_container/calculate_sell_value(obj/source)
+	var/obj/item/storage/sample_container/sample_can = source
+	var/sample_sum = 0
+	var/obj/item/research_sample/stored_sample
+	if(LAZYLEN(sample_can.contents))
+		for(stored_sample in sample_can.contents)
+			sample_sum += stored_sample.supply_value
+	return sample_sum
+
+/datum/element/sellable/sample_container/calculate_sell_quantity(obj/source)
+	var/obj/item/storage/sample_container/sample_can = source
+	return "[sample_can.contents.len] sample(s) "
+
+
+// Vaccine samples
+/datum/element/sellable/vaccine/sell_error(obj/source)
+	if(!istype(source.loc, /obj/structure/closet/crate/freezer))
+		return "Error: Product was improperly packaged. Vaccines must be sold in a freezer crate to preserve for transport. Payment rendered null under terms of agreement."
+	var/obj/item/reagent_containers/glass/beaker/vial/vaccine/sale_bottle = source
+	if(sale_bottle.reagents.reagent_list.len != 1 || sale_bottle.reagents.get_reagent_amount(REAGENT_ID_VACCINE) < sale_bottle.volume)
+		return "Error: Tainted product in vaccine batch. Was opened, contaminated, or wasn't filled to full. Payment rendered null under terms of agreement."
+	return null
+
+/datum/element/sellable/vaccine/calculate_sell_value(obj/source)
+	return 5

--- a/code/datums/elements/sellable.dm
+++ b/code/datums/elements/sellable.dm
@@ -1,14 +1,20 @@
 /datum/element/sellable
+	var/sale_info = "This can be sold on the cargo shuttle if packed in a crate."
+	var/needs_crate = TRUE
 
 /datum/element/sellable/Attach(datum/target)
 	. = ..()
 	if(!isobj(target))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ITEM_SOLD, PROC_REF(sell))
+	RegisterSignal(target, COMSIG_ITEM_SCAN_PROFIT, PROC_REF(calculate_sell_value))
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	return
 
 /datum/element/sellable/Detach(datum/source)
 	UnregisterSignal(source, COMSIG_ITEM_SOLD)
+	UnregisterSignal(source, COMSIG_ITEM_SCAN_PROFIT)
+	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
 	return ..()
 
 // Override this for sub elements that need to do complex calculations when sold
@@ -22,18 +28,28 @@
 	return 1
 // End overrides
 
-/datum/element/sellable/proc/sell(obj/source, var/datum/exported_crate/EC)
-	SHOULD_NOT_OVERRIDE(TRUE)
+/datum/element/sellable/proc/sell(obj/source, var/datum/exported_crate/EC, var/in_crate)
 	SIGNAL_HANDLER
+
+	if(needs_crate && !in_crate)
+		EC.contents = list("error" = "Error: Product was improperly packaged. Payment rendered null under terms of agreement.")
+		return FALSE
 
 	var/sell_error = sell_error(source)
 	if(sell_error)
 		EC.contents = list("error" = sell_error)
-		return
+		return FALSE
 
 	EC.contents[EC.contents.len]["value"] = calculate_sell_value(source)
 	EC.contents[EC.contents.len]["quantity"] = calculate_sell_quantity(source)
 	EC.value += EC.contents[EC.contents.len]["value"]
+	return TRUE
+
+/datum/element/sellable/proc/on_examine(datum/source, mob/user, list/examine_texts)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	SIGNAL_HANDLER
+	if(sale_info)
+		examine_texts += span_notice(sale_info)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // Subtypes
@@ -82,6 +98,9 @@
 
 
 // Vaccine samples
+/datum/element/sellable/vaccine
+	sale_info = "This can be sold on the cargo shuttle if packed in a freezer crate."
+
 /datum/element/sellable/vaccine/sell_error(obj/source)
 	if(!istype(source.loc, /obj/structure/closet/crate/freezer))
 		return "Error: Product was improperly packaged. Vaccines must be sold in a freezer crate to preserve for transport. Payment rendered null under terms of agreement."

--- a/code/game/machinery/pandemic.dm
+++ b/code/game/machinery/pandemic.dm
@@ -19,6 +19,10 @@
 	possible_transfer_amounts = (list(5, 10, 15))
 	volume = 15
 
+/obj/item/reagent_containers/glass/beaker/vial/vaccine/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sellable/vaccine)
+
 /obj/machinery/computer/pandemic/Initialize(mapload)
 	. = ..()
 	update_icon()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -45,6 +45,7 @@
 				starting_amount = 1
 		set_amount(starting_amount, TRUE)
 	update_icon()
+	AddElement(/datum/element/sellable/material_stack)
 
 /obj/item/stack/Destroy()
 	if(uses_charge)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -19,6 +19,10 @@
 	drop_sound = 'sound/items/drop/paper.ogg'
 	pickup_sound = 'sound/items/pickup/paper.ogg'
 
+/obj/item/spacecash/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sellable/spacecash)
+
 /obj/item/spacecash/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/spacecash))
 		if(istype(W, /obj/item/spacecash/ewallet)) return 0

--- a/code/modules/samples/samples.dm
+++ b/code/modules/samples/samples.dm
@@ -69,6 +69,7 @@
 		rand_tech = pick(valid_techs)	//assign techs last
 		LAZYSET(new_tech, rand_tech, tech_value)
 	origin_tech = new_tech
+	AddElement(/datum/element/sellable/research_sample)
 
 /obj/item/research_sample/attack_hand(mob/user)
 	. = ..()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -662,6 +662,7 @@
 #include "code\datums\elements\footstep.dm"
 #include "code\datums\elements\footstep_override.dm"
 #include "code\datums\elements\light_blocking.dm"
+#include "code\datums\elements\sellable.dm"
 #include "code\datums\elements\slosh.dm"
 #include "code\datums\elements\turf_transparency.dm"
 #include "code\datums\elements\lootable\_lootable.dm"


### PR DESCRIPTION
## About The Pull Request
Items sold with the cargo shuttle are a bit of a typechecking nightmare. This turns the code used to sell items from cargo into an element. Making each sellable item much easier to maintain, because the code is separated from the base object. So you could apply a cargo sale element to anything, and give it any custom code you want to calculate its sale value and quantity. Without ever needing to modify the subsystem that sells it.

No player facing changes, except a notice in the description if an item can be sold on the cargo shuttle, and if it needs a crate to do so.

## Changelog
Moves cargo sale items to an element.
Adds support for objects sold from cargo that do not require a crate, but none currently exist.
Adds a signal to ask an object for its cargo sale value if it has a cargo-sellable element.

:cl:
add: Items that can be sold by cargo now state it at the end of their description
code: Moved cargo item selling code to an element
/:cl: