### PR TITLE
Hose connectors force pumping do not make noise if disconnected

### DIFF
--- a/code/datums/components/reagent_hose/connector.dm
+++ b/code/datums/components/reagent_hose/connector.dm
@@ -75,6 +75,8 @@
 
 /datum/component/hose_connector/proc/force_pump()
 	SIGNAL_HANDLER
+	if(!my_hose)
+		return
 	process()
 	if(prob(5))
 		carrier.visible_message(span_infoplain(span_bold("\The [carrier]") + " gurgles as it pumps fluid."))


### PR DESCRIPTION
## About The Pull Request
Stops connectors from gurgling if they have no hose to pump fluid with.

## Changelog
Gurgle

:cl:
fix: Hose connectors that force pump no longer pump if no hose is connected
/:cl:
