### PR TITLE
Lanyards in SecVendors

### DIFF
--- a/code/modules/economy/vending_machines.dm
+++ b/code/modules/economy/vending_machines.dm
@@ -1335,7 +1335,8 @@
 		/obj/item/clothing/accessory/holster/hip = 2,
 		/obj/item/clothing/accessory/holster/hip/black = 2,
 		/obj/item/clothing/accessory/holster/leg = 2,
-		/obj/item/clothing/accessory/holster/leg/black = 2
+		/obj/item/clothing/accessory/holster/leg/black = 2,
+		/obj/item/clothing/accessory/holster/waist/lanyard = 2
 	)
 	req_log_access = access_hop
 	has_logs = 1


### PR DESCRIPTION
## About The Pull Request

Quick edit to add a pair of baton lanyards to sec wardrobe vendors, since I never did that when I originally added them and you can get every other kind of sec-applicable holster from those machines.

## Changelog

:cl:
add: Baton lanyards can now be acquired from sec wardrobe vendors
/:cl: