### PR TITLE
Lets mobs eat again

### DIFF
--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -332,6 +332,10 @@
 	preferred_target = null
 
 /datum/ai_holder/proc/vore_check(mob/living/L)
+	if(isanimal(holder))
+		var/mob/living/simple_mob/M = holder
+		if(!M.voremob_loaded)	//init vore if it's not already
+			M.init_vore(TRUE)
 	if(!holder.vore_selected)	//We probably don't have a belly so don't even try
 		return FALSE
 	if(!isliving(L))	//We only want mob/living

--- a/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
@@ -273,7 +273,7 @@
 	can_flee = TRUE
 	flee_when_dying = FALSE
 
-/datum/ai_holder/simple_mob/vore/find_target(list/possible_targets, has_targets_list)
+/datum/ai_holder/simple_mob/vore/ddraig/find_target(list/possible_targets, has_targets_list)
 	if(!vore_hostile)
 		return ..()
 	if(!isanimal(holder))	//Only simplemobs have the vars we need
@@ -290,7 +290,7 @@
 	for(var/mob/living/possible_target in possible_targets)
 		if(!can_attack(possible_target))
 			continue
-		if(isanimal(target) && !check_attacker(target)) //Do not target simple mobs who didn't attack you (disengage with TF'd mobs)
+		if(isanimal(possible_target) && !check_attacker(possible_target)) //Do not target simple mobs who didn't attack you (disengage with TF'd mobs)
 			continue
 		. |= possible_target
 		if(!isliving(possible_target))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixed vore hostile mobs (those that eat people unprompted) not being able to target players with mob vore enabled.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed vore hostile mobs (those that eat people unprompted) not being able to target players with mob vore enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
