### PR TITLE
Cleans circuit empty newlines from assembly examine text

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -210,7 +210,10 @@
 	. = ..()
 	if(Adjacent(user))
 		for(var/obj/item/integrated_circuit/IC in contents)
-			. += IC.external_examine(user)
+			// Make sure there's actually examine text to prevent empty lines being printed for EVERY component!
+			var/examine_text = IC.external_examine(user)
+			if (length(examine_text))
+				. += examine_text
 		if(opened)
 			tgui_interact(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Before, whenever you examined a circuit assembly, it would print a new line for every single component in the assembly - EVEN if the component in question had nothing to show. This results in component-heavy builds spamming tons of empty newlines when they have nothing to show. Whoops!
This (hopefully) fixes that.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed circuit assemblies printing empty lines on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
