### PR TITLE
random styles shouldn't roll dev forbidden names

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -45,6 +45,8 @@
 			continue
 		if(gender == FEMALE && S.gender == MALE)
 			continue
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 		if( !(species in S.species_allowed))
 			continue
 		valid_hairstyles[hairstyle] = GLOB.hair_styles_list[hairstyle]
@@ -63,6 +65,8 @@
 		if(gender == MALE && S.gender == FEMALE)
 			continue
 		if(gender == FEMALE && S.gender == MALE)
+			continue
+		if(S.name == DEVELOPER_WARNING_NAME)
 			continue
 		if( !(species in S.species_allowed))
 			continue


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Randomized styles could roll forbidden parents.

## Changelog
Prevents randomize style buttons from using forbidden styles.

:cl:
fix: Dev disabled styles removed from randomized rolls.
/:cl: