### PR TITLE
teshari blocking deployable barriers

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -106,7 +106,7 @@ Deployable items
 		icon_state = "barrier[locked]"
 
 /obj/machinery/deployable/barrier/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
-	if(istype(mover) && mover.checkpass(PASSTABLE))
+	if(istype(mover) && mover.checkpass(PASSTABLE) && !isliving(mover)) // Check if living so teshari can't evade security barriers by pressing W
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request
Security barriers are coded to clearly only allow projectiles to pass by them, but they use the tablepasser flag to do this. Teshari also use this flag with their agility, allowing them to run through barriers without even slowdown.

## Changelog
Check for living when doing tablepasser check on projectiles to block teshari and tablepasser gene.

:cl: Will
fix: Teshari can no longer pass through deployed security barriers
/:cl: