### PR TITLE
weakref is exclusive

### DIFF
--- a/code/__defines/var_copy.dm
+++ b/code/__defines/var_copy.dm
@@ -1,2 +1,2 @@
 /// Use this when copying vars[] to skip some built in byond ones that get really unhappy when you access them like that. Used like if(BLACKLISTED_COPY_VARS) in switch or list(BLACKLISTED_COPY_VARS)
-#define BLACKLISTED_COPY_VARS "ATOM_TOPIC_EXAMINE","type","loc","locs","vars","parent","parent_type","verbs","ckey","key","_active_timers", "_datum_components", "_listen_lookup", "_signal_procs"
+#define BLACKLISTED_COPY_VARS "ATOM_TOPIC_EXAMINE","type","loc","locs","vars","parent","parent_type","verbs","ckey","key","_active_timers", "_datum_components", "_listen_lookup", "_signal_procs", "weak_reference"


### PR DESCRIPTION
## About The Pull Request
Weak_reference shouldn't be cloned during var copies. Added it to blacklist to prevent weakref desyncing

## Changelog
Added a new exclusive to blacklisted vars

:cl:
code: weak_reference added to blacklisted copyvars
/:cl: