### PR TITLE
TGS DMAPI update workflow fix

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -49,14 +49,22 @@ jobs:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           APP_ID: ${{ secrets.APP_ID }}
 
+      # Create PR if changes were made
+      - name: Check for changes
+        run: |
+          git fetch origin
+          if git diff --quiet origin/master...tgs-dmapi-update; then
+            echo "No changes to PR. Skipping creation."
+            exit 0
+          fi
       - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
         if: ${{ success() }}
-        with:
-          source_branch: "tgs-dmapi-update"
-          destination_branch: "master"
-          pr_title: "Automatic TGS DMAPI Update"
-          pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any changes that may be breaking or unimplemented in your codebase by checking what changes are in the definitions file: code/__DEFINES/tgs.dm before merging.\n\n${{ steps.dmapi-update.outputs.release-notes }}"
-          pr_label: "Tools"
-          pr_allow_empty: false
-          github_token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base master \
+            --head tgs-dmapi-update \
+            --title "Automatic TGS DMAPI Update"
+            --body "This pull request updates the TGS DMAPI to the latest version. Please note any changes that may be breaking or unimplemented in your codebase by checking what changes are in the definitions file: code/__DEFINES/tgs.dm before merging.\n\n${{ steps.dmapi-update.outputs.release-notes }}"
+            --label "Tools"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The old github action is deprecated by the authors and they recommend using the gh cli to create the PR instead.