### PR TITLE
Makes pain simulation more "realistic"

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -3,7 +3,7 @@
 
 // proc to find out in how much pain the mob is at the moment
 /mob/living/carbon/proc/updateshock()
-	if (!can_feel_pain())
+	if (!can_feel_pain() && !synth_cosmetic_pain)
 		src.traumatic_shock = 0
 		return 0
 


### PR DESCRIPTION

## About The Pull Request
Makes pain simulation actually simulate the effects of traumatic shock. This means synthetics that have pain simulation on will be able to be stunned, batoned, etc. 
This will also mean that if a xenochimera has an fbp and pain simulation, they will be able to go feral from pain
## Changelog
:cl:
fix: Pain simulation now simulates traumatic shock
/:cl:
