### PR TITLE
A few mapping glamour objects

### DIFF
--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -278,6 +278,9 @@
 /obj/structure/simple_door/cult/Initialize(mapload,var/material_name)
 	. = ..(mapload, material_name || MAT_CULT)
 
+/obj/structure/simple_door/glamour/Initialize(mapload,var/material_name)
+	. = ..(mapload, material_name || MAT_GLAMOUR)
+
 /obj/structure/simple_door/cult/TryToSwitchState(atom/user)
 	if(isliving(user))
 		var/mob/living/L = user

--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -247,3 +247,11 @@
 	material = get_material_by_name("holowood")
 	. = ..()
 */
+
+/obj/structure/table/bench/glamour
+	icon_state = "plain_preview"
+	color = "#fffce6"
+
+/obj/structure/table/bench/glamour/Initialize(mapload)
+	material = get_material_by_name(MAT_GLAMOUR)
+	. = ..()

--- a/code/modules/tables/rack_vr.dm
+++ b/code/modules/tables/rack_vr.dm
@@ -46,3 +46,17 @@
 /obj/structure/table/rack/shelf/wood/Initialize(mapload)
 	material = get_material_by_name(MAT_WOOD)
 	. = ..()
+
+/obj/structure/table/rack/glamour
+	color = "#fffbe6"
+
+/obj/structure/table/rack/glamour/Initialize(mapload)
+	material = get_material_by_name(MAT_GLAMOUR)
+	. = ..()
+
+/obj/structure/table/rack/shelf/glamour
+	color = "#fffbe6"
+
+/obj/structure/table/rack/shelf/glamour/Initialize(mapload)
+	material = get_material_by_name(MAT_GLAMOUR)
+	. = ..()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a preset for glamour doors, tables and racks, for mapping purposes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a preset for glamour doors, tables and racks, for mapping purposes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
