### PR TITLE
Fixes chemicals not healing internal bleeding

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -71,7 +71,7 @@
 	M.eye_blurry = min(M.eye_blurry + wound_heal, 250)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/external/O in H.bad_external_organs)
+		for(var/obj/item/organ/external/O in H.organs)
 			for(var/datum/wound/W in O.wounds)
 				if(W.bleeding())
 					W.damage = max(W.damage - wound_heal, 0)
@@ -804,7 +804,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/wound_heal = removed * repair_strength
-		for(var/obj/item/organ/external/O in H.bad_external_organs)
+		for(var/obj/item/organ/external/O in H.organs)
 			for(var/datum/wound/W in O.wounds)
 				if(W.bleeding())
 					W.bandage() //This is the ACTUAL clotting being performed.


### PR DESCRIPTION

## About The Pull Request
These needed to check ALL organs and not just SOME organs, as internal bleeding doesn't mean an organ is 'bad', at least, not externally.

myelamine and Bicaridine now heal internal bleeds
## Changelog
:cl: Diana
fix: you will no longer have to beat the snot out of a limb you want to fix internal bleeding on with bicard or myelamine
/:cl:
