### PR TITLE
ai holo faces where clicked

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -63,6 +63,10 @@
 		CtrlClickOn(A)
 		return
 
+	if(holo && istype(holo.masters[src],/obj/effect/overlay/aiholo))
+		var/curdur = get_dir(get_turf(holo.masters[src]), get_turf(A))
+		holo.masters[src].set_dir(curdur)
+
 	if(aiCamera.in_camera_mode)
 		aiCamera.camera_mode_off()
 		aiCamera.captureimage(A, usr)


### PR DESCRIPTION
## About The Pull Request
Adds a basic function of literally every player controllable mob to the AI hologram.

## Changelog
Clicking a location while projecting a hologram as an AI, makes the hologram turn to face the clicked location.

:cl: Will
fix: AI holograms will rotate to face toward where you click like most mobs do.
/:cl: