### PR TITLE
Fluidpumps actually use their newly installed powercell

### DIFF
--- a/code/modules/reagents/machinery/pump.dm
+++ b/code/modules/reagents/machinery/pump.dm
@@ -168,6 +168,7 @@
 			to_chat(user, span_notice("There is a power cell already installed."))
 			return FALSE
 		user.drop_from_inventory(W, src)
+		cell = W // Link the cell to us
 		to_chat(user, span_notice("You insert the power cell."))
 
 	else


### PR DESCRIPTION
## About The Pull Request
lol

## Changelog
Makes fluidpumps with a replaced powercell, actually USE that powercell.

:cl: Will
fix: Replacing a fluidpumps powercell now actually works
/:cl: