### PR TITLE
Tape recorder clicks when it stops

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -188,7 +188,9 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		to_chat(M, span_notice("Recording stopped."))
-
+	else if(isturf(loc)) // If not hidden away in a bag
+		playsound(src, 'sound/machines/click.ogg', 50, 1)
+		visible_message("\The [src] clicks as it stops recording.","click")
 
 /obj/item/taperecorder/verb/stop()
 	set name = "Stop"


### PR DESCRIPTION
## About The Pull Request
Makes the tape recorder show an indication it's stopped recording. As long as it's in clear view. This doesn't affect recorders hidden in bags.

## Changelog
Makes tape records on turfs make a click when they stop recording.

:cl: Will
add: If not hidden inside a container, tape recorders will make a click sound when they stop recording
/:cl: