### PR TITLE
Using up a stack in a bag no longer leaves a lingering icon on the hud

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -269,6 +269,10 @@
 	if(!uses_charge)
 		amount -= used
 		if (amount <= 0)
+			// Tell container that we used up a stack
+			if(istype( loc, /obj/item/storage))
+				var/obj/item/storage/holder = loc
+				holder.remove_from_storage( src, null)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		update_icon()
 		return 1


### PR DESCRIPTION
## About The Pull Request
In some cases you can use up a stack while it is in a bag's hotbar, resulting in it lingering on the hud until byond forcibly dels it.

## Changelog
Fixed several situations where a sheet would linger on your hud due to a hard reference

:cl: Will
fix: Sheets used in bags will no longer leave a lingering icon locked up on the hud
/:cl:
