### PR TITLE
Ventcrawling hides body lights

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -267,7 +267,7 @@
 			set_light(distance, distance * 4, l_color = "#660066")
 			return TRUE
 
-	else if(glow_toggle)
+	else if(glow_toggle && !is_ventcrawling) // Hide the light in vents
 		set_light(glow_range, glow_intensity, glow_color)
 
 	else


### PR DESCRIPTION
## About The Pull Request
If a mob glows, ventcrawling will show the glow, and reveal its position to other players.

## Changelog
Hides body lights when a mob is ventcrawling

:cl: Will
fix: Mobs that glow will hide their light while ventcrawling
/:cl: