### PR TITLE
Surgery table pulling fix

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -81,6 +81,8 @@
 	if(C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src
+	if(C.pulledby)
+		C.pulledby.stop_pulling()
 	C.resting = 1
 	C.loc = src.loc
 	for(var/obj/O in src)


### PR DESCRIPTION
## About The Pull Request
Normally, buckling a mob to an object will disable pulling them. Surgery tables are weird. This makes the behavior somewhat consistent.

## Changelog
Pulled mobs are released when they are dragged onto a surgery table (as if buckled to it)

:cl: Will
fix: Mobs dragged onto a operating table will be released from pulling, as if they were buckled.
/:cl: