### PR TITLE
Soggy Shadekin Fixes

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -97,6 +97,8 @@
 /turf/simulated/floor/water/Entered(atom/movable/AM, atom/oldloc)
 	if(isliving(AM))
 		var/mob/living/L = AM
+		if(L.is_incorporeal())
+			return
 		L.update_water()
 		if(L.check_submerged() <= 0)
 			return
@@ -108,6 +110,8 @@
 /turf/simulated/floor/water/Exited(atom/movable/AM, atom/newloc)
 	if(isliving(AM))
 		var/mob/living/L = AM
+		if(L.is_incorporeal())
+			return
 		L.update_water()
 		if(L.check_submerged() <= 0)
 			return
@@ -155,7 +159,7 @@
 /mob/living/proc/check_submerged()
 	if(buckled)
 		return 0
-	if(hovering || flying)
+	if(hovering || flying || is_incorporeal())
 		if(flying)
 			adjust_nutrition(-0.5)
 		return 0

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -271,7 +271,7 @@
 
 	// Turf related slowdown
 	var/turf/T = get_turf(src)
-	if(T && T.movement_cost && (!hovering || !flying)) // Flying mobs ignore turf-based slowdown. Aquatic mobs ignore water slowdown, and can gain bonus speed in it.
+	if(T && T.movement_cost && (!hovering || !flying || is_incorporeal())) // Flying mobs ignore turf-based slowdown. Aquatic mobs ignore water slowdown, and can gain bonus speed in it.
 		if(istype(T,/turf/simulated/floor/water) && aquatic_movement)
 			. -= aquatic_movement - 1
 		else


### PR DESCRIPTION
## About The Pull Request
Shadekin trigger water entry, turf movement calculations, and can be hurt by reagents on a water turf while phased. This has been resolved.

## Changelog
Shadekin ignore water, turf movement calculations, and water reagent interactions while phased.

:cl: Will
fix: Shadekin no longer interact with water turfs while phased
fix: Shadekin no longer calculate turf slowdown while phased
/:cl:
