### PR TITLE
Hide illegal cosmetics from selection

### DIFF
--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -203,6 +203,9 @@
 	for(var/hairstyle in GLOB.hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hairstyle]
 
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
+
 		if(check_gender && gender != NEUTER)
 			if(gender == MALE && S.gender == FEMALE)
 				continue
@@ -228,6 +231,9 @@
 	var/list/valid_facial_hairstyles = new()
 	for(var/facialhairstyle in GLOB.facial_hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.facial_hair_styles_list[facialhairstyle]
+
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 
 		if(gender != NEUTER)
 			if(gender == MALE && S.gender == FEMALE)

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -86,6 +86,8 @@ var/list/wrapped_species_by_ref = list()
 	var/list/valid_gradstyles = GLOB.hair_gradients
 	for(var/hairstyle in GLOB.hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hairstyle]
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 		if(gender == MALE && S.gender == FEMALE)
 			continue
 		if(gender == FEMALE && S.gender == MALE)
@@ -95,6 +97,8 @@ var/list/wrapped_species_by_ref = list()
 		valid_hairstyles += hairstyle
 	for(var/facialhairstyle in GLOB.facial_hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.facial_hair_styles_list[facialhairstyle]
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 		if(gender == MALE && S.gender == FEMALE)
 			continue
 		if(gender == FEMALE && S.gender == MALE)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -278,6 +278,8 @@
 	var/list/valid_hairstyles = list()
 	for(var/hairstyle in GLOB.hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hairstyle]
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 		if(!(species in S.species_allowed) && (!custom_base || !(custom_base in S.species_allowed)))
 			continue
 		if((!S.ckeys_allowed) || (user.ckey in S.ckeys_allowed))
@@ -290,6 +292,8 @@
 	var/list/valid_facialhairstyles = list()
 	for(var/facialhairstyle in GLOB.facial_hair_styles_list)
 		var/datum/sprite_accessory/S = GLOB.facial_hair_styles_list[facialhairstyle]
+		if(S.name == DEVELOPER_WARNING_NAME)
+			continue
 		if(biological_gender == MALE && S.gender == FEMALE)
 			continue
 		if(biological_gender == FEMALE && S.gender == MALE)

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(fancy_sprite_accessory_color_channel_names, list("Primary", "Se
 	var/icon_state		// the icon_state of the accessory
 	var/preview_state	// a custom preview state for whatever reason
 
-	var/name = "ERROR - FIXME" // the preview name of the accessory
+	var/name = DEVELOPER_WARNING_NAME // the preview name of the accessory
 
 	// Determines if the accessory will be skipped or included in random hair generations
 	var/gender = NEUTER


### PR DESCRIPTION
## About The Pull Request
Adds several checks, and fixes default cosmetic name so that "TODO - FIX ME" is finally hidden from (hopefully) all character customization menus.

## Changelog
Adds multiple checks for DEV_WARNING_NAME
Sets default cosmetic name to DEV_WARNING_NAME

:cl:
fix: TODO - FIX ME, finally fixed. Cosmetic menus properly hides illegal cosmetics.
/:cl: