### PR TITLE
Scalpels use a var instead of a typecheck for clamping

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -108,6 +108,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	drop_sound = 'sound/items/drop/knife.ogg'
+	var/clamp_chance = 0 // chance that the scalpel will perform cautery on its own
 
 /*
  * Researchable Scalpels
@@ -118,6 +119,7 @@
 	icon_state = "scalpel_laser1"
 	damtype = "fire"
 	hitsound = 'sound/weapons/blade1.ogg'
+	clamp_chance = 75
 
 /obj/item/surgical/scalpel/laser2
 	name = "laser scalpel"
@@ -126,6 +128,7 @@
 	damtype = "fire"
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 12.0
+	clamp_chance = 85
 
 /obj/item/surgical/scalpel/laser3
 	name = "laser scalpel"
@@ -134,12 +137,14 @@
 	damtype = "fire"
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 15.0
+	clamp_chance = 95
 
 /obj/item/surgical/scalpel/manager
 	name = "incision management system"
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
 	icon_state = "scalpel_manager"
 	force = 7.5
+	clamp_chance = 100
 
 /obj/item/surgical/scalpel/ripper
 	name = "jagged scalpel"

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -108,13 +108,10 @@
 	affected.open = 1
 
 	affected.createwound(CUT, 1)
-	var/clamp_chance = 0 //I hate this. Make all laser scalpels a /laser subtype and give them a clamp_chance var???
-	if(istype(tool,/obj/item/surgical/scalpel/laser1))
-		clamp_chance = 75
-	if(istype(tool,/obj/item/surgical/scalpel/laser2))
-		clamp_chance = 85
-	if(istype(tool,/obj/item/surgical/scalpel/laser3))
-		clamp_chance = 95
+	var/clamp_chance = 0
+	if(istype(tool,/obj/item/surgical/scalpel))
+		var/obj/item/surgical/scalpel/T = tool
+		clamp_chance = T.clamp_chance
 	if(clamp_chance)
 		affected.organ_clamp()
 		user.visible_message(span_notice("[user] has made a bloodless incision on [target]'s [affected.name] with \the [tool]."), \


### PR DESCRIPTION
## About The Pull Request
Grants an old comment's wish by moving clamping chance to a var with overrides instead of using typechecks.

## Changelog
Scalpel uses a clamp_chance var instead of typechecking the scalpel's type.

:cl: Will
code: Scalpel uses a clamp_chance var instead of typechecking during surgery
/:cl: