### PR TITLE
prevent connecting a hose to the same object

### DIFF
--- a/code/datums/components/reagent_hose/item.dm
+++ b/code/datums/components/reagent_hose/item.dm
@@ -34,6 +34,7 @@
 	if(!proximity)
 		return
 	if(in_use)
+		to_chat(user, span_danger("You must choose which connector this hose will connect to before you can attach the hose to something else."))
 		return
 
 	var/datum/component/hose_connector/REMB = remembered?.resolve()


### PR DESCRIPTION
## About The Pull Request
While handled by normal operation, i didn't think multiple UIs could be opened by spamming the hose on a machine. This makes it so that the hose will not be able to do anything until the list menu is closed.

## Changelog
Prevent hoses from opening multiple connection menus by setting in_use

:cl:
fix: Reagent hoses can only connect to one connector at a time
/:cl:
