### PR TITLE
Adds circuit kit + Vendomat in Stellar Delight science maintenance

### DIFF
--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -4081,6 +4081,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
+"hO" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/steel,
+/obj/item/storage/bag/circuits/basic,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/starboardaft)
 "hP" = (
 /obj/structure/morgue{
 	dir = 2
@@ -6038,6 +6050,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/vending/assist{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardaft)
 "lU" = (
@@ -37438,7 +37453,7 @@ Dv
 Uv
 Dv
 lT
-Dv
+hO
 il
 OR
 CY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Does exactly as described.
<img width="873" height="872" alt="image" src="https://github.com/user-attachments/assets/7e58d7a6-1873-4cbf-9ea8-6a2533c832aa" />
You know how the Tether has a publicly accessible maintenance room in Research that lets people get a circuitry kit? This is to be something like that.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
maptweak: (Stellar Delight) Added a circuit kit and Vendomat to the maintenance tunnel behind Science.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
