### PR TITLE
borgs don't dance

### DIFF
--- a/code/datums/components/animations/dizzy.dm
+++ b/code/datums/components/animations/dizzy.dm
@@ -83,3 +83,10 @@ below 100 is not dizzy
 	if(!DC)
 		return 0
 	return max(DC.dizziness,0)
+
+// Disabled on borgs
+/mob/living/silicon/make_dizzy(var/amount)
+	return
+
+/mob/living/silicon/get_dizzy()
+	return 0

--- a/code/datums/components/animations/jittery.dm
+++ b/code/datums/components/animations/jittery.dm
@@ -84,3 +84,10 @@ below 100 is not jittery
 	if(!JC)
 		return 0
 	return max(JC.jitteriness,0)
+
+// Disabled on borgs
+/mob/living/silicon/make_jittery(var/amount)
+	return
+
+/mob/living/silicon/get_jittery()
+	return 0


### PR DESCRIPTION
## About The Pull Request
Fixes borg jittering

## Changelog
Adds overrides to jitter procs that don't do anything when a silicon gets jittered cause they have no life signal to resolve it.

:cl: Will
fix: Borgs don't jitter
/:cl: