### PR TITLE
Component safety

### DIFF
--- a/code/datums/components/species/shadekin/shadekin.dm
+++ b/code/datums/components/species/shadekin/shadekin.dm
@@ -92,7 +92,7 @@
 
 /datum/component/shadekin/Initialize()
 	//normal component bs
-	if(!isliving(parent))
+	if(!isliving(parent) || issilicon(parent))
 		return COMPONENT_INCOMPATIBLE
 	owner = parent
 	if(ishuman(owner))

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -53,7 +53,7 @@
 	if(href_list[VV_HK_TAG])
 		usr.client.tag_datum(target)
 	if(href_list[VV_HK_ADDCOMPONENT])
-		if(!check_rights(NONE))
+		if(!check_rights(R_DEBUG))
 			return
 		var/list/names = list()
 		var/list/componentsubtypes = sortList(subtypesof(/datum/component), GLOBAL_PROC_REF(cmp_typepaths_asc))
@@ -95,7 +95,7 @@
 		log_admin("[key_name(usr)] has added [result] [datumname] to [key_name(target)].")
 		message_admins(span_notice("[key_name_admin(usr)] has added [result] [datumname] to [key_name_admin(target)]."))
 	if(href_list[VV_HK_REMOVECOMPONENT] || href_list[VV_HK_MASS_REMOVECOMPONENT])
-		if(!check_rights(NONE))
+		if(!check_rights(R_DEBUG))
 			return
 		var/mass_remove = href_list[VV_HK_MASS_REMOVECOMPONENT]
 		var/list/components = target._datum_components.Copy()


### PR DESCRIPTION

## About The Pull Request
Adds R_DEBUG requirement to component add/remove
Prevents Silicons from becoming shadekin
## Changelog
:cl: Diana
admin: R_DEBUG is now required to apply/remove components/elements.
code: component/shadekin now fails when applied to silicons
/:cl:
