### PR TITLE
Alien wood crate

### DIFF
--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -29,6 +29,13 @@
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Wooden planks crate"
 
+/datum/supply_pack/materials/alienwood50
+	name = "50 alien wood planks"
+	contains = list(/obj/fiftyspawner/sifwood)
+	cost = 10
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Alien wood planks crate"
+
 /datum/supply_pack/materials/hardwood50
 	name = "50 hardwood planks"
 	contains = list(/obj/fiftyspawner/hardwood)


### PR DESCRIPTION
## About The Pull Request

Allows ordering crates of alien wood from cargo. This isn't really necessary on tether since you can just go out and get it the old fashioned way, but if you want it on SD you have to pray/ahelp or hope you get enough by maintdiving.

## Changelog

:cl:
qol: you can now order crates of alien wood from cargo
/:cl: