### PR TITLE
Allows survival watch users to set its GPS tag name

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -278,6 +278,15 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	popup.set_content(dat.Join(null))
 	popup.open()
 
+/obj/item/gps/proc/set_tag_prompt(mob/user)
+	var/a = tgui_input_text(user, "Please enter desired tag.", name, gps_tag, 10)
+	a = uppertext(copytext(a, 1, 11))
+	if(in_range(src, user))
+		gps_tag = a
+		name = "global positioning system ([gps_tag])"
+		to_chat(user, "You set your GPS's tag to '[gps_tag]'.")
+		. = TRUE
+
 /obj/item/gps/Topic(var/href, var/list/href_list)
 	if(..())
 		return TRUE
@@ -327,13 +336,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 				. = TRUE
 
 	if(href_list["tag"])
-		var/a = tgui_input_text(usr, "Please enter desired tag.", name, gps_tag, 10)
-		a = uppertext(copytext(a, 1, 11))
-		if(in_range(src, usr))
-			gps_tag = a
-			name = "global positioning system ([gps_tag])"
-			to_chat(usr, "You set your GPS's tag to '[gps_tag]'.")
-			. = TRUE
+		set_tag_prompt(usr)
 
 	if(href_list["range"])
 		local_mode = !local_mode

--- a/code/modules/clothing/accessories/watches.dm
+++ b/code/modules/clothing/accessories/watches.dm
@@ -71,3 +71,7 @@
 	if(Adjacent(user))
 		gps.tracking = !gps.tracking
 		to_chat(user,span_notice("You turn the micro beacon [gps.tracking ? "on" : "off"]."))
+
+/obj/item/clothing/accessory/watch/survival/attack_self(mob/user)
+	. = ..()
+	gps.set_tag_prompt(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

See title. Using the GPS watch inhand allows you to set the name of its tag now! This will no doubt make it more useful as a GPS now that people actually know who the watch belongs to. However it still cannot do anything else a normal GPS can do.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Survival watch users can now set the tag of the watch's inbuilt GPS by using it in-hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
