### PR TITLE
Toggle for bloopers (multiple say sounds)

### DIFF
--- a/code/modules/client/preferences/types/game/sound.dm
+++ b/code/modules/client/preferences/types/game/sound.dm
@@ -63,6 +63,12 @@
 	default_value = TRUE
 	savefile_identifier = PREFERENCE_PLAYER
 
+/datum/preference/toggle/bloop_sounds
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "BLOOP_SOUNDS"
+	default_value = TRUE
+	savefile_identifier = PREFERENCE_PLAYER
+
 /datum/preference/toggle/emote_sounds
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "EMOTE_SOUNDS"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -444,7 +444,7 @@ var/list/channel_to_radio_key = list()
 #define BLOOPER_MAX_BLOOPERS 24
 #define BLOOPER_MAX_TIME (1.5 SECONDS)
 
-/mob/living/proc/blooper(extrarange = 0, volume, sound_preference = /datum/preference/toggle/say_sounds)
+/mob/living/proc/blooper(extrarange = 0, volume, sound_preference = /datum/preference/toggle/bloop_sounds)
 	playsound(\
 		src,\
 		pick(voice_sounds_list),\
@@ -458,13 +458,14 @@ var/list/channel_to_radio_key = list()
 		preference = sound_preference,
 	)
 
-/mob/living/proc/blooploop(message, extrarange = 0, volume, sound_preference = /datum/preference/toggle/say_sounds)
+/mob/living/proc/blooploop(message, extrarange = 0, volume, sound_preference = /datum/preference/toggle/say_sounds, bloop_preference = /datum/preference/toggle/bloop_sounds)
 	var/bloopers = min(round((LAZYLEN(message) / BLOOPER_SPEED)) + 1, BLOOPER_MAX_BLOOPERS)
 	var/total_delay
+	playsound(src, pick(voice_sounds_list), 75, TRUE, extrarange = extrarange, falloff = 1 , is_global = TRUE, frequency = voice_freq > 0 ? voice_freq : null, ignore_walls = FALSE, preference = /datum/preference/toggle/say_sounds)
 	for(var/i in 1 to bloopers)
 		if(total_delay > BLOOPER_MAX_TIME)
 			break
-		addtimer(CALLBACK(src, PROC_REF(blooper), extrarange, volume, sound_preference), total_delay)
+		addtimer(CALLBACK(src, PROC_REF(blooper), extrarange, volume, bloop_preference), total_delay)
 		total_delay += rand(\
 			DS2TICKS(BLOOPER_SPEED / BLOOPER_SPEED_BASELINE), \
 			DS2TICKS(BLOOPER_SPEED / BLOOPER_SPEED_BASELINE) + DS2TICKS(BLOOPER_SPEED / BLOOPER_SPEED_BASELINE)) TICKS

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -461,7 +461,7 @@ var/list/channel_to_radio_key = list()
 /mob/living/proc/blooploop(message, extrarange = 0, volume, sound_preference = /datum/preference/toggle/say_sounds, bloop_preference = /datum/preference/toggle/bloop_sounds)
 	var/bloopers = min(round((LAZYLEN(message) / BLOOPER_SPEED)) + 1, BLOOPER_MAX_BLOOPERS)
 	var/total_delay
-	playsound(src, pick(voice_sounds_list), 75, TRUE, extrarange = extrarange, falloff = 1 , is_global = TRUE, frequency = voice_freq > 0 ? voice_freq : null, ignore_walls = FALSE, preference = /datum/preference/toggle/say_sounds)
+	playsound(src, pick(voice_sounds_list), 75, TRUE, extrarange = extrarange, falloff = 1 , is_global = TRUE, frequency = voice_freq > 0 ? voice_freq : null, ignore_walls = FALSE, preference = sound_preference)
 	for(var/i in 1 to bloopers)
 		if(total_delay > BLOOPER_MAX_TIME)
 			break

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
@@ -61,6 +61,14 @@ export const SAY_SOUNDS: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const BLOOP_SOUNDS: FeatureToggle = {
+  name: 'Multiple Say Sounds',
+  category: 'SOUNDS',
+  description:
+    'Enable hearing a say sound play multiple times for longer messages.',
+  component: CheckboxInput,
+};
+
 export const EMOTE_SOUNDS: FeatureToggle = {
   name: 'Me Sounds',
   category: 'SOUNDS',


### PR DESCRIPTION

## About The Pull Request

Added a preference for "Multiple Say Sounds", which is enabled by default. If you have it enabled it plays multiple say sounds for long sentences as normal. If disabled it will play only one say sound, if say sounds are enabled. It does mean there's an extra bloop at the beginning now, but it doesn't change the effect much in my testing.

A few people prefer the single say sound, myself included, and find the multiple bloopings to be a bit overwhelming, especially when there's a lot of people around. We'd prefer this option to disabling say sounds completely.

## Changelog
:cl:
qol: Added a preference for "Multiple Say Sounds", which is enabled by default. If you have it enabled it plays multiple say sounds for long sentences as normal. If disabled it will play only one say sound, if say sounds are enabled. It does mean there's an extra bloop at the beginning now, but it doesn't change the effect much in my testing.
/:cl:
