### PR TITLE
missing grenade icon

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -33,7 +33,7 @@
 /obj/item/grenade/explosive/frag
 	name = "fragmentation grenade"
 	desc = "A military fragmentation grenade, designed to explode in a deadly shower of fragments."
-	icon_state = "frag"
+	icon_state = "frggrenade"
 	loadable = null
 
 	fragment_types = list(/obj/item/projectile/bullet/pellet/fragment)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

## Changelog
Fragmentation grenades had the iconstate "frag", this appears to have been removed from the icon file or renamed to "frggrenade" at some point and never updated.

:cl:
fix: missing fragmentation grenade iconstate
/:cl:
