### PR TITLE
fix minor belly typo

### DIFF
--- a/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/OptionTab/BellyOptionsLeft.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/OptionTab/BellyOptionsLeft.tsx
@@ -124,7 +124,7 @@ export const BellyOptionsLeft = (props: {
             stepPixel={0.1}
             digits={2}
             unit="%"
-            tooltip="The multiplier for nutrition you'll fain from prey."
+            tooltip="The multiplier for nutrition you'll gain from prey."
           />
         </LabeledList.Item>
         <LabeledList.Item label="Required Examine Size">


### PR DESCRIPTION

## About The Pull Request

fain -> gain

thanks Molly for noticing this one, just did a quick edit to fixy.
## Changelog
:cl:
spellcheck: fain -> gain in the belly tooltips for nutrition
/:cl:
