### PR TITLE
Vore death privacy pref

### DIFF
--- a/code/__defines/vore_prefs.dm
+++ b/code/__defines/vore_prefs.dm
@@ -15,6 +15,7 @@
 	target.digest_pain = source.digest_pain;											\
 	target.noisy_full = source.noisy_full;												\
 	target.eating_privacy_global = source.eating_privacy_global;						\
+	target.vore_death_privacy = source.vore_death_privacy;								\
 																						\
 	target.can_be_drop_prey = source.can_be_drop_prey;									\
 	target.can_be_drop_pred = source.can_be_drop_pred;									\

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -88,9 +88,10 @@
 		var/area/A = get_area(src)
 		if(!(A?.flag_check(AREA_BLOCK_SUIT_SENSORS)) && isbelly(loc))
 			// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // We don't use SSgame_master yet.
-			for(var/mob/observer/dead/O in GLOB.mob_list)
-				if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))
-					to_chat(O, span_deadsay(span_bold("[src]") + " has died in " + span_bold("[get_area(src)]")  + ". [ghost_follow_link(src, O)] "))
+			if(isbelly(loc) && !vore_death_privacy)
+				for(var/mob/observer/dead/O in GLOB.mob_list)
+					if(O.client?.prefs?.read_preference(/datum/preference/toggle/show_dsay))
+						to_chat(O, span_deadsay(span_bold("[src]") + " has died in " + span_bold("[get_area(src)]")  + ". [ghost_follow_link(src, O)] "))
 
 	if(!gibbed && !isbelly(loc))
 		playsound(src, pick(get_species_sound(get_gendered_sound(src))["death"]), src.species.death_volume, 1, 20, volume_channel = VOLUME_CHANNEL_DEATH_SOUNDS)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -115,3 +115,5 @@
 	var/ooc_notes_favs = null
 	var/ooc_notes_maybes = null
 	var/ooc_notes_style = FALSE
+
+	var/immunities = null // Various immunities that can be applied to mobs.

--- a/code/modules/vore/eating/mob_vr.dm
+++ b/code/modules/vore/eating/mob_vr.dm
@@ -26,6 +26,7 @@
 	var/show_vore_fx = TRUE				// Show belly fullscreens
 	var/selective_preference = DM_DEFAULT	// Preference for selective bellymode
 	var/eating_privacy_global = FALSE 	// Makes eating attempt/success messages only reach for subtle range if true, overwritten by belly-specific var
+	var/vore_death_privacy = FALSE		// Chooses whether to announce prey death when digested to ghosts.
 	var/allow_mimicry = TRUE 	// Allows mimicking their character
 	var/allow_mind_transfer = FALSE			//Allows ones mind to be taken over or swapped
 	var/nutrition_message_visible = TRUE

--- a/code/modules/vore/eating/panel_databackend/vorepanel_pref_data.dm
+++ b/code/modules/vore/eating/panel_databackend/vorepanel_pref_data.dm
@@ -42,6 +42,7 @@
 		"consume_liquid_belly" = owner.consume_liquid_belly,
 		"digest_pain" = owner.digest_pain,
 		"eating_privacy_global" = owner.eating_privacy_global,
+		"vore_death_privacy" = owner.vore_death_privacy,
 		"allow_mimicry" = owner.allow_mimicry,
 		//Soulcatcher
 		"soulcatcher_allow_capture" = owner.soulcatcher_pref_flags & SOULCATCHER_ALLOW_CAPTURE,

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -47,6 +47,7 @@
 	var/permit_healbelly = TRUE
 	var/noisy = FALSE
 	var/eating_privacy_global = FALSE //Makes eating attempt/success messages only reach for subtle range if true, overwritten by belly-specific var
+	var/vore_death_privacy = FALSE //Makes it so that vore deaths don't get advertised to ghosts
 	var/allow_mimicry = TRUE
 
 	// These are 'modifier' prefs, do nothing on their own but pair with drop_prey/drop_pred settings.
@@ -216,6 +217,7 @@
 	weight_message_visible = json_from_file["weight_message_visible"]
 	weight_messages = json_from_file["weight_messages"]
 	eating_privacy_global = json_from_file["eating_privacy_global"]
+	vore_death_privacy = json_from_file["vore_death_privacy"]
 	allow_mimicry = json_from_file["allow_mimicry"]
 	vore_sprite_color = json_from_file["vore_sprite_color"]
 	allow_mind_transfer = json_from_file["allow_mind_transfer"]

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -407,6 +407,12 @@
 				host.eating_privacy_global = host.eating_privacy_global
 			unsaved_changes = TRUE
 			return TRUE
+		if("toggle_death_privacy")
+			host.vore_death_privacy = !host.vore_death_privacy
+			if(host.client.prefs_vr)
+				host.vore_death_privacy = host.vore_death_privacy
+			unsaved_changes = TRUE
+			return TRUE
 		if("toggle_mimicry")
 			host.allow_mimicry = !host.allow_mimicry
 			if(host.client.prefs_vr)

--- a/tgui/packages/tgui/interfaces/VorePanel/VorePanelMainTabs/VoreUserPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VorePanelMainTabs/VoreUserPreferences.tsx
@@ -44,6 +44,7 @@ export const VoreUserPreferences = (props: {
     allow_spontaneous_tf,
     allow_mind_transfer,
     eating_privacy_global,
+    vore_death_privacy,
     allow_mimicry,
     strip_mechanics_active,
     autotransferable,
@@ -491,6 +492,19 @@ export const VoreUserPreferences = (props: {
       content: {
         enabled: 'Global Vore Privacy: Subtle',
         disabled: 'Global Vore Privacy: Loud',
+      },
+    },
+    vore_death_privacy: {
+      action: 'toggle_death_privacy',
+      test: vore_death_privacy,
+      tooltip: {
+        main: 'Sets whether your vore deaths are announced to ghosts',
+        enable: ' Click here to prevent announcing vore deaths',
+        disable: ' Click here to allow announcing vore deaths',
+      },
+      content: {
+        enabled: 'Vore Death Privacy: Unannonced',
+        disabled: 'Vore Death Privacy: Announced',
       },
     },
     allow_mimicry: {

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferencesTabs/VoreUserPreferencesMechanical.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferencesTabs/VoreUserPreferencesMechanical.tsx
@@ -93,23 +93,29 @@ export const VoreUserPreferencesMechanical = (props: {
         </Stack.Item>
         <Stack.Item basis="32%">
           <VoreUserPreferenceItem
-            spec={preferences.spontaneous_tf}
+            spec={preferences.vore_death_privacy}
             tooltipPosition="right"
           />
         </Stack.Item>
         <Stack.Item basis="32%" grow>
           <VoreUserPreferenceItem
-            spec={preferences.mind_transfer}
+            spec={preferences.spontaneous_tf}
             tooltipPosition="top"
           />
         </Stack.Item>
         <Stack.Item basis="32%">
           <VoreUserPreferenceItem
-            spec={preferences.allow_mimicry}
+            spec={preferences.mind_transfer}
             tooltipPosition="left"
           />
         </Stack.Item>
-        <Stack.Item basis="34%">
+        <Stack.Item basis="32%">
+          <VoreUserPreferenceItem
+            spec={preferences.allow_mimicry}
+            tooltipPosition="right"
+          />
+        </Stack.Item>
+        <Stack.Item basis="34%" grow>
           <VoreUserPreferenceItem
             spec={preferences.toggle_consume_liquid_belly}
             tooltipPosition="top"

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -126,6 +126,7 @@ export type bellyOptionData = {
   selective_preference: string;
   save_digest_mode: BooleanLike;
   eating_privacy_local: string;
+  vore_death_privacy: string;
   vorespawn_blacklist: BooleanLike;
   vorespawn_whitelist: string[];
   vorespawn_absorbed: number;
@@ -328,6 +329,7 @@ export type prefData = {
   food_vore: BooleanLike;
   digest_pain: BooleanLike;
   eating_privacy_global: BooleanLike;
+  vore_death_privacy: BooleanLike;
   allow_mimicry: BooleanLike;
   soulcatcher_allow_capture: BooleanLike;
   soulcatcher_allow_transfer: BooleanLike;
@@ -432,6 +434,7 @@ export type localPrefs = {
   mind_transfer: preferenceData;
   strippref: preferenceData;
   eating_privacy_global: preferenceData;
+  vore_death_privacy: preferenceData;
   allow_mimicry: preferenceData;
   autotransferable: preferenceData;
   liquid_receive: preferenceData;


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a vore death privacy pref, which prevents "X has died at Y [jump]" from popping up to ghosts when you die in a belly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Added a vore death privacy pref, which prevents "X has died at Y [jump]" from popping up to ghosts when you die in a belly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
