### PR TITLE
hippo mob fixes

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
@@ -5,8 +5,8 @@
 
 	icon_state = "hippo"
 	icon_living = "hippo"
-	icon_dead = "hippo_dead"
-	icon_gib = "hippo_gib"
+	icon_dead = "hippo-dead"
+	icon_gib = "hippo-dead" // No gib sprite yet
 	icon = 'icons/mob/vore64x64.dmi'
 
 	maxHealth = 200
@@ -55,7 +55,7 @@
 	vore_active = 1
 	vore_capacity = 1
 	vore_bump_chance = 15
-	vore_bump_emote = "lazily wraps its tentacles around"
+	vore_bump_emote = "lazily wraps its mouth around"
 	vore_standing_too = 1
 	vore_ignores_undigestable = 0
 	vore_default_mode = DM_HOLD


### PR DESCRIPTION
## About The Pull Request
Fixes some assorted issues on the chunky bois.

## Changelog
Hippos use correct death icon state
Hippos use their death state for their gibbed state, as no gibbed art exists
Hippos don't pull you in with tentacles

:cl: Will
fix: Hippo death sprites fixed
fix: Hippos no longer pretend to be squids when eating you
/:cl:
