### PR TITLE
Floor tile placement and backend logic

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -65,10 +65,7 @@
 
 	// Floor has flooring set
 	if(!is_plating())
-		if(istype(C, /obj/item))
-			try_deconstruct_tile(C, user)
-			return
-		else if(istype(C, /obj/item/stack/cable_coil))
+		if(istype(C, /obj/item/stack/cable_coil))
 			to_chat(user, span_warning("You must remove the [flooring.descriptor] first."))
 			return
 		else if(istype(C, /obj/item/stack/tile))
@@ -87,7 +84,9 @@
 					playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 					ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
 					return
-
+		else if(istype(C, /obj/item))
+			try_deconstruct_tile(C, user)
+			return
 
 	// Floor is plating (or no flooring)
 	else
@@ -160,43 +159,43 @@
 						do_remove_plating(C, user, base_type)
 
 /turf/simulated/floor/proc/try_deconstruct_tile(obj/item/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/stack/tile) && isliving(user)) //If we're hitting it with a tile, try to check our offhand
+		var/mob/living/deconstructor = user
+		W = deconstructor.get_inactive_hand()
+		if(!W || !istype(W, /obj/item))
+			return FALSE
 	if(W.has_tool_quality(TOOL_CROWBAR))
 		if(broken || burnt)
 			to_chat(user, span_notice("You remove the broken [flooring.descriptor]."))
-			make_plating()
+			make_plating(FALSE)
 		else if(flooring.flags & TURF_IS_FRAGILE)
 			to_chat(user, span_danger("You forcefully pry off the [flooring.descriptor], destroying them in the process."))
-			make_plating()
+			make_plating(FALSE)
 		else if(flooring.flags & TURF_REMOVE_CROWBAR)
 			to_chat(user, span_notice("You lever off the [flooring.descriptor]."))
-			make_plating(1)
+			make_plating(TRUE)
 		else
-			return 0
+			return FALSE
 		playsound(src, W.usesound, 80, 1)
-		if(isliving(user) && is_plating())
-			var/mob/living/deconstructor = user
-			var/obj/item/stack/tile/T = deconstructor.get_inactive_hand()
-			if(T)
-				attackby(T, user) // Replace the tile
-		return 1
+		return TRUE
 	else if(W.has_tool_quality(TOOL_SCREWDRIVER) && (flooring.flags & TURF_REMOVE_SCREWDRIVER))
 		if(broken || burnt)
-			return 0
+			return FALSE
 		to_chat(user, span_notice("You unscrew and remove the [flooring.descriptor]."))
-		make_plating(1)
+		make_plating(TRUE)
 		playsound(src, W.usesound, 80, 1)
-		return 1
+		return TRUE
 	else if(W.has_tool_quality(TOOL_WRENCH) && (flooring.flags & TURF_REMOVE_WRENCH))
 		to_chat(user, span_notice("You unwrench and remove the [flooring.descriptor]."))
-		make_plating(1)
+		make_plating(TRUE)
 		playsound(src, W.usesound, 80, 1)
-		return 1
+		return TRUE
 	else if(istype(W, /obj/item/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
 		to_chat(user, span_notice("You shovel off the [flooring.descriptor]."))
-		make_plating(1)
+		make_plating(TRUE)
 		playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /turf/simulated/floor/proc/try_replace_tile(obj/item/stack/tile/T as obj, mob/user as mob)
 	if(T.type == flooring.build_type)

--- a/code/modules/examine/descriptions/turfs.dm
+++ b/code/modules/examine/descriptions/turfs.dm
@@ -44,19 +44,22 @@
 			. += "Use a welder on it to repair the damage."
 		else
 			. += "Use a crowbar on it to remove it."
-			. += "If using a crowbar and holding a floor tile in your offhand, you will automatically replace the floor with that tile."
+			. += "If using a floor tile on the floor with a crowbar in your offhand, you will automatically replace the floor with that tile."
 	else if(flooring)
 		if(flooring.flags & TURF_IS_FRAGILE)
 			. += "You can use a crowbar on it to remove it, but this will destroy it!"
 		else if(flooring.flags & TURF_REMOVE_CROWBAR)
 			. += "Use a crowbar on it to remove it."
-			. += "If using a crowbar and holding a floor tile in your offhand, you will automatically replace the floor with that tile."
+			. += "If using a floor tile on the floor with a crowbar in your offhand, you will automatically replace the floor with that tile."
 		if(flooring.flags & TURF_REMOVE_SCREWDRIVER)
 			. += "Use a screwdriver on it to remove it."
+			. += "If using a floor tile on the floor with a screwdriver in your offhand, you will automatically replace the floor with that tile."
 		if(flooring.flags & TURF_REMOVE_WRENCH)
 			. += "Use a wrench on it to remove it."
+			. += "If using a floor tile on the floor with a wrench in your offhand, you will automatically replace the floor with that tile."
 		if(flooring.flags & TURF_REMOVE_SHOVEL)
 			. += "Use a shovel on it to remove it."
+			. += "If using a floor tile on the floor with a shovel in your offhand, you will automatically replace the floor with that tile."
 
 /turf/simulated/floor/outdoors/snow/get_description_interaction()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes the logic behind hitting the floor with an object. The /weapon removal caused an error where everything past the first check wouldn't ever be called.

Tweaks the crowbar-tile placement. Now, you can crowbar up tiles like normal (or use any tool to pry up the floor that's acceptable) with tile in offhand.

Now, if you click the floor with tile, it'll check your offhand to see if you can pry it up. If so, it'll pry it up and instantly swap it to the tile!
## Changelog
:cl: Diana
qol: Makes placing ti
code: Fixes some backend logic for hitting floors
/:cl:
