### PR TITLE
Cell-Loaded Revolver Update

### DIFF
--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
@@ -24,11 +24,11 @@
 // The Magazine //
 /obj/item/ammo_magazine/cell_mag/combat
 	name = "microbattery magazine"
-	desc = "A microbattery holder for the \'NSFW\'"
+	desc = "A microbattery holder for the \'NSFW\'."
 	icon_state = "nsfw_mag"
 	max_ammo = 4
 	x_offset = 4
-	description_info = "This magazine holds NSFW microbatteries to power the NSFW handgun. Up to three can be loaded at once, and each provides four shots of their respective energy type. Loading multiple of the same type will provide additional shots of that type. The batteries can be recharged in a normal recharger."
+	description_info = "This magazine holds NSFW microbatteries to power the NSFW handgun. Up to four can be loaded at once, and each provides four shots of their respective energy type. Loading multiple of the same type will provide additional shots of that type. The batteries can be recharged in a normal recharger."
 	ammo_type = /obj/item/ammo_casing/microbattery/combat
 
 /obj/item/ammo_magazine/cell_mag/combat/prototype

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
@@ -35,7 +35,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/e_shot_stun
 
 /obj/item/projectile/bullet/pellet/e_shot_stun
-	icon_state = "spell"
+	icon_state = "spark"
 	damage = 2
 	agony = 20
 	pellets = 6			//number of pellets


### PR DESCRIPTION
:cl:
fix: Cell-Loaded Revolver's 'Scatterstun' mode now has projectile icons.
spellcheck: Fixed some errors in the Revolver's description.
/:cl: