### PR TITLE
Slime vorefix

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
@@ -160,7 +160,9 @@
 		pacified = FALSE //We are not obedient enough to be considered pacified.
 
 	if(!client) //Only update if we don't have a client.
-		if(old_mood == "angry") //We were recently angry, so we're still upset and won't let you eat us no matter what! (Unless we had a docility potion put on us, making us harmless)
+		if(faction != initial(faction)) //We have had a loyalty potion used on us.
+			update_allowed_vore_types(TRUE)
+		else if(old_mood == "angry") //We were recently angry, so we're still upset and won't let you eat us no matter what! (Unless we had a docility potion put on us, making us harmless)
 			update_allowed_vore_types(FALSE, harmless)
 		else
 			update_allowed_vore_types(pacified, harmless)
@@ -171,13 +173,11 @@
 /mob/living/simple_mob/slime/proc/update_allowed_vore_types(allowed, harmless)
 	if(harmless) // If we're harmless, we should always be able to be eaten.
 		allowed = TRUE
-	devourable = allowed
 	can_be_drop_prey = allowed
 	stumble_vore = allowed
 	slip_vore = allowed
 	drop_vore = allowed
 	throw_vore = allowed
-	devourable = allowed
 
 /mob/living/simple_mob/slime/xenobio/proc/enrage()
 	if(harmless)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Apparently slimes were always devourable before...This fixes the previous slime PR where it made slimes inedible if they were angry.

Additionally, it makes it so loyalty potions also work on slimes and allow them to be edible, now.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Slimes are devourable again
fix: Loyalty potions make slimes able to be spont vored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
