### PR TITLE
reoder some subsystems not to load with ticker active

### DIFF
--- a/code/controllers/subsystems/air_traffic.dm
+++ b/code/controllers/subsystems/air_traffic.dm
@@ -6,7 +6,6 @@ SUBSYSTEM_DEF(atc)
 	priority = FIRE_PRIORITY_ATC
 	runlevels = RUNLEVEL_GAME
 	wait = 2 SECONDS
-	init_stage = INITSTAGE_LAST
 	flags = SS_BACKGROUND
 
 	VAR_PRIVATE/next_tick = 0

--- a/code/controllers/subsystems/events.dm
+++ b/code/controllers/subsystems/events.dm
@@ -1,7 +1,9 @@
 SUBSYSTEM_DEF(events)
-	name = "Events"	// VOREStation Edit - This is still the main events subsystem for us.
+	name = "Events"
 	wait = 2 SECONDS
-	init_stage = INITSTAGE_LAST
+	dependencies = list(
+		/datum/controller/subsystem/atoms
+	)
 
 	var/tmp/list/currentrun = null
 

--- a/code/controllers/subsystems/internal_wiki.dm
+++ b/code/controllers/subsystems/internal_wiki.dm
@@ -6,12 +6,10 @@
 SUBSYSTEM_DEF(internal_wiki)
 	name = "Wiki"
 	wait = 1
-	//dependencies = list(
-	//	/datum/controller/subsystem/chemistry,
-	//	/datum/controller/subsystem/plants,
-	//	/datum/controller/subsystem/supply
-	//)
-	init_stage = INITSTAGE_LAST
+	dependencies = list(
+		/datum/controller/subsystem/atoms,
+		/datum/controller/subsystem/supply
+	)
 	flags = SS_NO_FIRE
 
 	VAR_PRIVATE/list/pages = list()

--- a/code/controllers/subsystems/overmap_renamer_vr.dm
+++ b/code/controllers/subsystems/overmap_renamer_vr.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(overmap_renamer)
 	//Loaded very late in initializations. Must come before mapping and objs. Uses both as inputs.
 	init_stage = INITSTAGE_LAST
 	dependencies = list(
-		/datum/controller/subsystem/skybox
+		/datum/controller/subsystem/atoms
 	)
 	runlevels = RUNLEVEL_SETUP
 	flags = SS_NO_FIRE

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -2,8 +2,7 @@
 //Exists to handle a few global variables that change enough to justify this. Technically a parallax, but it exhibits a skybox effect.
 SUBSYSTEM_DEF(skybox)
 	name = "Space skybox"
-	init_stage = INITSTAGE_LAST
-	flags = SS_NO_FIRE
+	flags = SS_NO_FIRE | SS_NO_INIT
 	var/static/list/skybox_cache = list()
 
 	var/static/mutable_appearance/normal_space
@@ -88,9 +87,6 @@ SUBSYSTEM_DEF(skybox)
 		mapedge_cache["[dir]"] = MA
 
 	. = ..()
-
-/datum/controller/subsystem/skybox/Initialize()
-	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!initialized)

--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -15,7 +15,9 @@
 SUBSYSTEM_DEF(xenoarch)
 	name = "Xenoarch"
 	flags = SS_NO_FIRE
-	init_stage = INITSTAGE_LAST
+	dependencies = list(
+		/datum/controller/subsystem/atoms
+	)
 	var/list/artifact_spawning_turfs = list()
 	var/list/digsite_spawning_turfs = list()
 


### PR DESCRIPTION
Reorders some subsystems as ticker already fires in init stage last, so only things like chat should be there.