### PR TITLE
Gets rid of hasvar usage

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -604,11 +604,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			cant_pass = 1
 	return cant_pass
 
+/* //If you uncomment and use this I will assimilate you. -C.L.
 //Takes: Anything that could possibly have variables and a varname to check.
 //Returns: 1 if found, 0 if not.
 /proc/hasvar(var/datum/A, var/varname)
 	if(A.vars.Find(lowertext(varname))) return 1
 	else return 0
+*/
 
 //Returns: all the areas in the world
 /proc/return_areas()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -240,25 +240,32 @@ var/list/slot_equipment_priority = list( \
 
 //Outdated but still in use apparently. This should at least be a human proc.
 /mob/proc/get_equipped_items()
-	var/list/items = new/list()
-
-	if(hasvar(src,"back")) if(src:back) items += src:back
-	if(hasvar(src,"belt")) if(src:belt) items += src:belt
-	if(hasvar(src,"l_ear")) if(src:l_ear) items += src:l_ear
-	if(hasvar(src,"r_ear")) if(src:r_ear) items += src:r_ear
-	if(hasvar(src,"glasses")) if(src:glasses) items += src:glasses
-	if(hasvar(src,"gloves")) if(src:gloves) items += src:gloves
-	if(hasvar(src,"head")) if(src:head) items += src:head
-	if(hasvar(src,"shoes")) if(src:shoes) items += src:shoes
-	if(hasvar(src,"wear_id")) if(src:wear_id) items += src:wear_id
-	if(hasvar(src,"wear_mask")) if(src:wear_mask) items += src:wear_mask
-	if(hasvar(src,"wear_suit")) if(src:wear_suit) items += src:wear_suit
-	if(hasvar(src,"w_uniform")) if(src:w_uniform) items += src:w_uniform
-
-	if(hasvar(src,"l_hand")) if(src:l_hand) items += src:l_hand
-	if(hasvar(src,"r_hand")) if(src:r_hand) items += src:r_hand
+	var/list/items = list()
 
 	return items
+
+/mob/living/get_equipped_items()
+	var/list/items = ..()
+	if(back) items += back
+	if(l_hand) items += l_hand
+	if(r_hand) items += r_hand
+	if(wear_mask) items += wear_mask
+	return .
+
+/mob/living/carbon/human/get_equipped_items()
+	var/list/items = ..()
+
+	if(belt) items += belt
+	if(l_ear) items += l_ear
+	if(r_ear) items += r_ear
+	if(glasses) items += glasses
+	if(gloves) items += gloves
+	if(head) items += head
+	if(shoes) items += shoes
+	if(wear_id) items += wear_id
+	if(wear_suit) items += wear_suit
+	if(w_uniform) items += w_uniform
+	return .
 
 /mob/proc/delete_inventory()
 	for(var/entry in get_equipped_items())

--- a/code/modules/reagents/reactions/instant/instant.dm
+++ b/code/modules/reagents/reactions/instant/instant.dm
@@ -784,16 +784,18 @@
 	for(var/mob/living/carbon/M in viewers(world.view, location))
 		switch(get_dist(M, location))
 			if(0 to 3)
-				if(hasvar(M, "glasses"))
-					if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
+				if(ishuman(M))
+					var/mob/living/carbon/human/target = M
+					if(istype(target.glasses, /obj/item/clothing/glasses/sunglasses))
 						continue
 
 				M.flash_eyes()
 				M.Weaken(15)
 
 			if(4 to 5)
-				if(hasvar(M, "glasses"))
-					if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
+				if(ishuman(M))
+					var/mob/living/carbon/human/target = M
+					if(istype(target.glasses, /obj/item/clothing/glasses/sunglasses))
 						continue
 
 				M.flash_eyes()

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -123,7 +123,7 @@
 			else
 				to_chat(user, span_notice("Unable to repair while [src] is off."))
 
-	else if(hasvar(W,"force") && hasvar(W,"damtype"))
+	else if(W.force && W.damtype)
 		user.setClickCooldown(user.get_attack_speed(W))
 		switch(W.damtype)
 			if("fire")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Gets rid of usage of hasvar

This shit is UBER expensive for NO reason.

Typecasting is bad. Don't do it.

Draft while I also move damtype from /obj to /obj/item

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
refactor: Inventory code no longer uses hasvar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
