### PR TITLE
refinery mixer angle fix

### DIFF
--- a/code/modules/refinery/core/industrial_reagent_mixer.dm
+++ b/code/modules/refinery/core/industrial_reagent_mixer.dm
@@ -28,26 +28,28 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
+	// Drain it!
 	if(mixer_angle == dir2angle(dir))
-		// Drain it!
 		refinery_transfer()
 		if(reagents.total_volume <= 0)
 			mixer_angle += mixer_rotation_rate
 			mixer_angle = (360 + mixer_angle) % 360
 			update_icon()
 		got_input = FALSE
-	else
-		// Check if we were filled...
-		if(mixer_angle % 90 != 0) // Not cardinal, keep going
-			got_input = TRUE
-		else if(!(locate(/obj/machinery/reagent_refinery) in get_step(src,angle2dir(mixer_angle)))) // If nothing, keep rotating
-			got_input = TRUE
+		return
 
-		if(got_input)
-			mixer_angle += mixer_rotation_rate
-			mixer_angle = (360 + mixer_angle) % 360
-			update_icon()
-			got_input = FALSE
+	// Check if we were filled...
+	if(mixer_angle % 90 != 0) // Not cardinal, keep going
+		got_input = TRUE
+	else if(!(locate(/obj/machinery/reagent_refinery) in get_step(src,angle2dir(mixer_angle)))) // If nothing, keep rotating
+		got_input = TRUE
+
+	if(!got_input)
+		return
+	mixer_angle += mixer_rotation_rate
+	mixer_angle = (360 + mixer_angle) % 360
+	update_icon()
+	got_input = FALSE
 
 /obj/machinery/reagent_refinery/mixer/update_icon()
 	cut_overlays()


### PR DESCRIPTION
## About The Pull Request
Fixes some small icon issues with the refinery mixer

## Changelog
Refinery mixer angle calculations happen before update icon, as well as the status light actually changing color.

:cl: Will
fix: Refinery mixer wouldn't show its angle correctly when rotating counter clockwise in the northwest direction. 
fix: Refinery mixer status light properly shows if it is in a locked state
/:cl:
