### PR TITLE
Various sofa-like chair icon fixes

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -163,6 +163,7 @@
 /obj/structure/bed/chair/comfy/rounded
 	name = "rounded chair"
 	desc = "It's a rounded chair. It looks comfy."
+	icon = 'icons/obj/furniture_vr.dmi'
 	icon_state = "roundedchair"
 	base_icon = "roundedchair"
 
@@ -342,6 +343,7 @@
 /obj/structure/bed/chair/sofa/pew
 	name = "pew bench"
 	desc = "If they want you to go to church, why do they make these so uncomfortable?"
+	icon = 'icons/obj/sofas.dmi'
 	base_icon = "pewmiddle"
 	icon_state = "pewmiddle"
 	applies_material_colour = FALSE
@@ -358,6 +360,7 @@
 /obj/structure/bed/chair/sofa/bench
 	name = "metal bench"
 	desc = "Almost as comfortable as waiting at a bus station for hours on end."
+	icon = 'icons/obj/sofas.dmi'
 	base_icon = "benchmiddle"
 	icon_state = "benchmiddle"
 	applies_material_colour = FALSE
@@ -394,6 +397,7 @@
 // Corporate sofa - one color fits all
 /obj/structure/bed/chair/sofa/corp
 	name = "black leather sofa"
+	icon = 'icons/obj/sofas.dmi'
 	desc = "How corporate!"
 	base_icon = "corp_sofamiddle"
 	icon_state = "corp_sofamiddle"


### PR DESCRIPTION
## About The Pull Request
Various couches inheret the _vr override for sofas. However those files lack some of the more specialized chairs like church pews, metal benches, and corporate couches. 

## Changelog
Makes some chairs with invisible icons use an icon file with the icon_states.

:cl:
fix: missing icons fixed for church pews, metal benches, corporate sofas, and rounded chairs
/:cl: