### PR TITLE
Explorer belt can hold binoculars

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -645,6 +645,7 @@
 		/obj/item/cataloguer,
 		/obj/item/radio,
 		/obj/item/mapping_unit,
+		/obj/item/binoculars,
 		/obj/item/kinetic_crusher,
 		/obj/item/analyzer,
 		/obj/item/storage/sample_container


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes explorer belt able to hold binoculars
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
qol: Explorer belt can now hold binoculars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
