### PR TITLE
Lets borg use reagent hoses

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -1086,7 +1086,8 @@ GLOBAL_LIST_INIT(area_or_turf_fail_types, typecacheof(list(
 	/obj/item/circuitboard, \
 	/obj/item/smes_coil, \
 	/obj/item/fuel_assembly, \
-	/obj/item/stack/tile/floor
+	/obj/item/stack/tile/floor, \
+	/obj/item/stack/hose
 
 #define OMNI_GRIPPER \
 	/obj/item


### PR DESCRIPTION

## About The Pull Request
Lets borgs use reagent hoses. So they can both hook them up to machines and people for liquid vore
## Changelog
:cl: Diana
qol: Borgs can now pick up reagent hoses
/:cl:
