### PR TITLE
Crates Handle Directional Lights Better

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -245,6 +245,8 @@
 /datum/component/overlay_lighting/proc/set_holder(atom/movable/new_holder)
 	if(new_holder == current_holder)
 		return
+	if(istype(new_holder,/obj/structure/closet))
+		new_holder = null // Forbid crates from holding lights
 	if(current_holder)
 		if(current_holder != parent && current_holder != parent_attached_to)
 			UnregisterSignal(current_holder, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED, COMSIG_LIGHT_EATER_QUEUE))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -58,7 +58,7 @@
 	for(var/obj/O in get_turf(src))
 		if(itemcount >= storage_capacity)
 			break
-		if(O.density || O.anchored || istype(O,/obj/structure/closet))
+		if(O.density || O.anchored || istype(O,/obj/structure/closet) || istype(O,/obj/effect/abstract))
 			continue
 		if(istype(O, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
 			var/obj/structure/bed/B = O


### PR DESCRIPTION
## About The Pull Request
Crates could collect the abstract light cone objects made by flashlights and various helmets. As well, putting lightcone emitting objects in crates and closing them caused the light to be left behind. This corrects that behavior, but just for crates due to concerns about breaking other objects if done more broadly.

## Changelog
Crates do not pick up abstract effects
Light overlay component will not accept crates as light holders. Nothing in the game does this other then light emitting objects stored in crates, and if you gave a crate a directional light overlay(for some reason) it would be the parent and not the holder anyway as crates cannot be inside most objects. 

This shouldn't lead to any breaking behavior, and resolves crates being able to consume photons.

:cl: Will
fix: Crates will no longer make flashlight beams vanish when closed over them
fix: Crates closed on flashlights and other directional light sources no longer leave the light floating in place where it was closed
/:cl: