### PR TITLE
Disable Telekinesis Research

### DIFF
--- a/code/modules/research/tg/designs/tool_designs.dm
+++ b/code/modules/research/tg/designs/tool_designs.dm
@@ -875,6 +875,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
+/* Decided that we were not keen on this being able to be printed freely as we immediately saw undesirable behaviour
 /datum/design_techweb/telekinetic_gloves
 	name = "Kinesis Assistance Module"
 	id = "tk_gloves"
@@ -886,6 +887,7 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+*/
 
 /datum/design_techweb/mail_scanner
 	name = "Mail Scanner"

--- a/code/modules/research/tg/techwebs/nodes/research_nodes.dm
+++ b/code/modules/research/tg/techwebs/nodes/research_nodes.dm
@@ -104,6 +104,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(CHANNEL_SCIENCE)
 
+/* Decided that we were not keen on this being able to be printed freely as we immediately saw undesirable behaviour
 /datum/techweb_node/telekinetics
 	id = TECHWEB_NODE_TELEKINETIC_RESEARCH
 	display_name = "Applied Telekinetics Research"
@@ -114,3 +115,4 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 	announce_channels = list(CHANNEL_SCIENCE)
+*/


### PR DESCRIPTION

## About The Pull Request

Disabled the telekinesis node in techwebs for the time being. We quite quickly saw undesirable behaviour from otherwise well behaved players when they got ahold of these. We believe they encourage memey behaviour and don't bring anything else of much value. In addition to that, they bring problems with access to buttons, especially when combined with gravitons. This causes issues with dorms amongst other areas. We don't want them removed from the game however, gimmicky silly things like this are perfect rare rewards from events, etc.

## Changelog
:cl:
del: Disabled the telekinesis node in techwebs for the time being.
/:cl:
