### PR TITLE
seismic charge explosion fixed

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -13,8 +13,8 @@
 	var/atom/target = null
 	var/open_panel = 0
 	var/image_overlay = null
-	var/blast_dev = -1
-	var/blast_heavy = -1
+	var/blast_dev = 3
+	var/blast_heavy = 1
 	var/blast_light = 2
 	var/blast_flash = 3
 
@@ -106,7 +106,7 @@
 	if(open_panel)
 		if(istype(I, /obj/item/stock_parts/micro_laser))
 			var/obj/item/stock_parts/SP = I
-			var/new_blast_power = max(1, round(SP.rating / 2) + 1)
+			var/new_blast_power = max(1, round(SP.rating * 2) + 1)
 			if(new_blast_power > blast_heavy)
 				to_chat(user, span_notice("You install \the [I] into \the [src]."))
 				user.drop_from_inventory(I)


### PR DESCRIPTION
## About The Pull Request
Recursive explosions treat devastation scaling differently from the original distance radius that explosions were. This tweaks them to be similar to how they were before. Could do with further tweaks, i'm not super familiar with the item and just tried to get something close.

## Changelog
Modifies plastique explosive to actually explode with the new recursive explosions

:cl:
fix: Seismic charges and plastique explosive blast distance fixed for new explosion subsystem
/:cl:

