### PR TITLE
Fix lleill teleport

### DIFF
--- a/code/modules/mob/living/carbon/human/species/lleill/lleill_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/lleill_abilities.dm
@@ -204,6 +204,9 @@
 		else
 			var/obj/structure/glamour_ring/R = tgui_input_list(src, "Where do you wish to teleport?", "Teleport", src.teleporters)
 
+			if(!R)
+				return
+
 			var/datum/effect/effect/system/spark_spread/spk
 			spk = new(src)
 


### PR DESCRIPTION

## About The Pull Request

Fixes lleill sparking and losing energy when choosing no option when trying teleport to a ring.

## Changelog
:cl:
fix: Fixes lleill sparking and losing energy when choosing no option when trying teleport to a ring.
/:cl:
