### PR TITLE
Icon fix and skrell fix

### DIFF
--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 	if (transparent && !istype(src,/obj/item/organ/external/head) && can_apply_transparency && should_apply_transparency) //VORESTATION EDIT: transparent instead of nonsolid
 		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well
 
-	dir = EAST
+	dir = SOUTH
 	icon = mob_icon
 	return mob_icon
 

--- a/code/modules/organs/subtypes/skrell.dm
+++ b/code/modules/organs/subtypes/skrell.dm
@@ -15,7 +15,7 @@
 	icon_state = "brain_skrell"
 
 /obj/item/organ/internal/stomach/skrell
-	icon_state = "skrell_stomach"
+	icon_state = "skrell_intestine" //Skrell have no stomach sprite so this is the best we can do
 
 /obj/item/organ/internal/kidneys/skrell
 	icon_state = "skrell_kidney"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a bug where left arms were invisible (When get_icon was called on an external organ, it'd set it's state to East, causing left arms to render as invisible)

Makes skrell stomachs use a placeholder spritee (skrell intestine) until a sprite is made.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
fix: Organ printer now shows left arms
fix: Unattaching your left arm will now show a proper sprite
fix: Skrell stomachs no longer require you to download Counter Strike: Source
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
