### PR TITLE
Mass Part Installation For Frames From Storage Boxes/Bags

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -130,6 +130,16 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/circuitboard
 	)
+	// Because you deal with so many parts, and the borg needs this anyway...
+	use_to_pickup = TRUE
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = TRUE
+
+/obj/item/storage/pouch/eng_parts/borg
+	name = "parts storage unit"
+	desc = "Can only hold machinery components."
+	max_storage_space = INVENTORY_POUCH_SPACE*5 // Borgs need some love here, so very expanded space
 
 /obj/item/storage/pouch/medical
 	name = "storage pouch (medical)"

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -369,6 +369,7 @@
 	src.modules += new /obj/item/rcd/electric/mounted/borg(src)
 	src.modules += new /obj/item/pickaxe/plasmacutter/borg(src)
 	src.modules += new /obj/item/dogborg/stasis_clamp(src)
+	src.modules += new /obj/item/storage/pouch/eng_parts/borg(src)
 
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(40000)
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -116,6 +116,13 @@
 	if(!(target in view(user)))
 		return ..()
 
+	if(istype(target, /obj/structure/frame))
+		var/obj/structure/frame/F = target
+		if(F.mass_install_parts(user,src))
+			play_rped_sound()
+			user.Beam(F, icon_state = "rped_upgrade", time = 0.5 SECONDS)
+		return
+
 	if(!istype(target, /obj/machinery))
 		return
 


### PR DESCRIPTION
## About The Pull Request
Installing large numbers of stock parts on multiple frames is very slow, tedious, and incredibly painful on borgs due to needing to swap gripper around for it. This PR makes it so storage containers can be dumped into machines to install all parts at once. This still requires the machine to be constructed, boarded, secured, and wired however. It does not instantly construct the machine either. It just removes the tedium of manually parting machines.

Also borg qol with a special pouch just for parts instead of one by one part gripping.

## Changelog
Made frames accept bags as input, and scans their inventory for parts to install.
RPED is already a bag, bluespace one can install parts remotely, but still not finish the machine.
Parts pouch can now pickup all stockparts on a turf, and drop all at once
Borgs given a very big special parts pouch to give them some qol with this pr

:cl: Will
add: Frames now accept parts stored in boxes or bags and load them all at once
add: RPED can now install parts in a frame, bluespace RPED can do so at range
add: Engineering borgs given an expanded parts pouch
qol: Engineering parts pouch can now pick up all stock parts on a turf, and drop them all at once, can be used to mass install parts in machines like any other bag
/:cl:
