### PR TITLE
fix atmos consoles

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(atoms)
 	dependencies = list(
 		/datum/controller/subsystem/garbage,
 		/datum/controller/subsystem/mapping,
+		/datum/controller/subsystem/alarm,
 		/datum/controller/subsystem/planets,
 		/datum/controller/subsystem/transcore,
 		/datum/controller/subsystem/chemistry,


### PR DESCRIPTION

## About The Pull Request
Atmos consoles init during init ATOM, the subsystem dependencies need to exist.
## Changelog
:cl:
fix: atmos consoles not working
/:cl:
