### PR TITLE
Deep mining scanner shows fracking reagents

### DIFF
--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -30,6 +30,7 @@
 		"anomalous matter" = 0
 		)
 
+	var/list/reagents_found = list()
 	var/turf/Turf = get_turf(target)
 
 	for(var/turf/simulated/T in range(range, Turf))
@@ -49,9 +50,13 @@
 				if(ORE_PHORON, ORE_PLATINUM, ORE_MHYDROGEN)						ore_type = "exotic matter"
 				if(ORE_VERDANTIUM, ORE_VOPAL)									ore_type = "anomalous matter"
 
-			if(ore_type) metals[ore_type] += T.resources[metal]
+			if(ore_type)
+				metals[ore_type] += T.resources[metal]
+			if(islist(GLOB.deepore_fracking_reagents[metal]))
+				for(var/reg_id in GLOB.deepore_fracking_reagents[metal])
+					reagents_found[reg_id] += 1
 
-	var/message = "[icon2html(src, user.client)] " + span_notice("The scanner beeps and displays a readout.")
+	var/message = "[icon2html(src, user.client)] " + span_infoplain("The scanner beeps and displays a readout:")
 
 	for(var/ore_type in metals)
 		var/result = "no sign"
@@ -66,6 +71,24 @@
 			result = metals[ore_type]
 
 		message += "<br>" + span_notice("- [result] of [ore_type].")
+
+	if(reagents_found.len)
+		message += "<br>" + span_infoplain("Sediment sample contains: ")
+		for(var/reg_id in reagents_found)
+			var/amnt = reagents_found[reg_id]
+			var/minimum = 25
+			if(amnt > minimum || exact)
+				var/datum/reagent/R = SSchemistry.chemical_reagents[reg_id]
+				var/ds = ""
+				if(amnt <= minimum && exact)
+					ds = "miniscule "
+				else if(amnt <= 40)
+					ds = "low "
+				else if(amnt >= 120 && exact)
+					ds = "massive "
+				else if(amnt >= 80)
+					ds = "high "
+				message += "<br>" + span_notice("- [ds][R.name]")
 
 	to_chat(user, message)
 


### PR DESCRIPTION
## About The Pull Request
Refinery feedback requested a way to show fracking reagents in an area. I wanted to keep information slightly limited as it is a bit overwhelming if given all at once, and can give away deep ores very easily. The advanced scanner shows them all however. Shows general estimations of reagents you will get if you start fluid pumping a mining borehole.

## Changelog
Adds somewhat vague reagent information to deep mining scanner to assist with refinery game play,

:cl: Will
add: Deep mining scanner will show some or all fluid pump fracking results depending on if advanced type or not
/:cl:
