### PR TITLE
Fix requests console icons

### DIFF
--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -122,7 +122,7 @@
 				continue
 			if(Console.newmessagepriority < priority)
 				Console.newmessagepriority = priority
-				Console.icon_state = "req_comp[priority]"
+				Console.update_icon()
 			switch(priority)
 				if(2)
 					if(!Console.silent)


### PR DESCRIPTION
## About The Pull Request

Fixes the icons for requests consoles turning weird after receiving new messages, because the proc to send the message was force-setting the icon. Now it just triggers update_icon on the console instead, which sets the icons (and other details) correctly.

## Changelog
:cl:
fix: fixed request consoles turning invisible after receiving messages
/:cl: