### PR TITLE
Neck grab pain fix

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -145,15 +145,15 @@
 
 	if(state >= GRAB_NECK)
 		affecting.Stun(3)
-		if(isliving(affecting))
-			var/mob/living/L = affecting
-			L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
 		//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
 		affecting.stuttering = max(affecting.stuttering, 5) //It will hamper your voice, being choked and all.
 		affecting.Weaken(5)	//Should keep you down unless you get help.
 		affecting.losebreath = max(affecting.losebreath + 2, 3)
+		if(isliving(affecting))
+			var/mob/living/L = affecting
+			L.adjustOxyLoss(1)
 
 	adjust_position()
 


### PR DESCRIPTION
## About The Pull Request
### What it does
Removes the occasional pain gasps from neck grabbing (red grab, but not kill grab). The gasping sounds while choking someone (kill grab) are unaffected.

### More details
Our pain code means that any amount of damage, no matter how small, has a nonzero chance of making you gasp/yell/scream in pain. Previously, neck grabbing (distinct from choking) did 1 oxy damage per tick; an inconsequential amount, since neck grabbing didn't actually make you unable to breathe so you'd just instantly heal it. However, it could cause you to make automatic pain emotes.

This is annoying for many scenes; while a neck grab would realistically be uncomfortable, plenty of people use neck grabs for things other than literally grabbing someone by the neck, like holding them in a very firm hug or pinning them to immobility. Further, in scenes where someone _is_ actually intended to be in pain, I feel like it's better to let the victim act that out through emotes and /me messages rather than the game occasionally forcing them to. At a glance, "yeah a neck grab should be painful" makes sense. But in practice, anyone who does rough unwilling scenes with any sort of frequency can tell you that it's a headache.

That small amount of oxy damage has instead been moved to when you are actively choking someone (a 'kill grab'), so balance-wise the damage remains completely unchanged if you're actually trying to kill someone, or roleplaying out strangling someone. The only balance difference this would make if someone being neck-grabbed also happened to be suffocating from an unrelated cause, in which case they'll now suffocate _slightly_ slower.

## Changelog
:cl:
qol: removed neck grab pain gasps
/:cl: