### PR TITLE
Fixes pod storages not initializing with their inventory sorted

### DIFF
--- a/code/modules/mining/shelter_atoms_vr.dm
+++ b/code/modules/mining/shelter_atoms_vr.dm
@@ -329,6 +329,7 @@ GLOBAL_LIST_EMPTY(unique_deployable)
 	for(var/obj/item/O in loc)
 		if(accept_check(O))
 			stock(O)
+			sortTim(item_records, GLOBAL_PROC_REF(cmp_stored_item_name))
 
 /obj/machinery/smartfridge/survival_pod/accept_check(obj/item/O)
 	return isitem(O)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/VOREStation/VOREStation/issues/18366 .
Turns out this issue was caused by them not sorting each item being put into them on initialize!

## Changelog
:cl:
fix: fixed capsule pod storages not initializing with their inventories sorted.
/:cl:
