### PR TITLE
Adds missing area flags to abandoned outpost underdark POI

### DIFF
--- a/maps/tether/submaps/underdark_pois/abandonded_outpost.dmm
+++ b/maps/tether/submaps/underdark_pois/abandonded_outpost.dmm
@@ -5,9 +5,6 @@
 "ab" = (
 /turf/simulated/wall,
 /area/mine/explored/underdark)
-"ac" = (
-/turf/template_noop,
-/area/space)
 "ad" = (
 /turf/simulated/mineral/floor/ignore_cavegen/virgo3b,
 /area/mine/explored/underdark)
@@ -399,7 +396,7 @@ ad
 ad
 aj
 ad
-ac
+aa
 "}
 (2,1,1) = {"
 aa
@@ -425,7 +422,7 @@ aj
 ad
 ad
 ad
-ac
+aa
 "}
 (3,1,1) = {"
 aa
@@ -451,7 +448,7 @@ ab
 ab
 ab
 ad
-ac
+aa
 "}
 (4,1,1) = {"
 aa
@@ -477,7 +474,7 @@ bp
 ae
 ab
 ad
-ac
+aa
 "}
 (5,1,1) = {"
 aj
@@ -503,7 +500,7 @@ ae
 ae
 ab
 ad
-ac
+aa
 "}
 (6,1,1) = {"
 aj
@@ -529,7 +526,7 @@ bi
 ae
 ab
 ad
-ac
+aa
 "}
 (7,1,1) = {"
 ad
@@ -555,7 +552,7 @@ br
 ae
 ab
 ad
-ac
+aa
 "}
 (8,1,1) = {"
 ad
@@ -581,7 +578,7 @@ bj
 bj
 ab
 ad
-ac
+aa
 "}
 (9,1,1) = {"
 aA
@@ -607,7 +604,7 @@ bj
 bj
 ab
 bc
-ac
+aa
 "}
 (10,1,1) = {"
 ad
@@ -633,7 +630,7 @@ bj
 bD
 ab
 ad
-ac
+aa
 "}
 (11,1,1) = {"
 aA
@@ -659,7 +656,7 @@ ae
 bC
 ab
 ad
-ac
+aa
 "}
 (12,1,1) = {"
 aB
@@ -685,7 +682,7 @@ ae
 aJ
 ab
 ad
-ac
+aa
 "}
 (13,1,1) = {"
 aA
@@ -711,7 +708,7 @@ ae
 aK
 ab
 ad
-ac
+aa
 "}
 (14,1,1) = {"
 aA
@@ -737,7 +734,7 @@ ae
 aL
 ab
 bc
-ac
+aa
 "}
 (15,1,1) = {"
 aA
@@ -763,7 +760,7 @@ ae
 bC
 ab
 ad
-ac
+aa
 "}
 (16,1,1) = {"
 ad
@@ -789,7 +786,7 @@ ae
 bC
 ab
 ad
-ac
+aa
 "}
 (17,1,1) = {"
 aA
@@ -815,7 +812,7 @@ ae
 ae
 ab
 ad
-ac
+aa
 "}
 (18,1,1) = {"
 bu
@@ -841,7 +838,7 @@ ae
 ae
 ab
 ad
-ac
+aa
 "}
 (19,1,1) = {"
 ad
@@ -867,7 +864,7 @@ ae
 bk
 ab
 ad
-ac
+aa
 "}
 (20,1,1) = {"
 aj
@@ -893,7 +890,7 @@ ae
 ae
 ab
 ad
-ac
+aa
 "}
 (21,1,1) = {"
 aj
@@ -919,7 +916,7 @@ ae
 ae
 ab
 ad
-ac
+aa
 "}
 (22,1,1) = {"
 aa
@@ -945,7 +942,7 @@ bq
 ae
 ab
 ad
-ac
+aa
 "}
 (23,1,1) = {"
 aa
@@ -971,7 +968,7 @@ ab
 ab
 ab
 ad
-ac
+aa
 "}
 (24,1,1) = {"
 aa
@@ -997,7 +994,7 @@ ad
 aj
 ad
 ad
-ac
+aa
 "}
 (25,1,1) = {"
 aa
@@ -1023,5 +1020,5 @@ ad
 ad
 ad
 ad
-ac
+aa
 "}


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/VOREStation/VOREStation/issues/18085.
A row of cells at the bottom of this POI had no areas, causing players walking in/out through the bottom to eat shit when daring to venture around the south side. Whoops!
<img width="400" height="315" alt="StrongDMM_2025-08-29_18-14-25" src="https://github.com/user-attachments/assets/4d62588a-2665-4647-91ef-cd197736e0e4" />


## Changelog
:cl:
maptweak: Fixed an Underdark POI having no gravity on a specific row of tiles.
/:cl:
