### PR TITLE
Fixes three piping issues in the Stellar Delight

### DIFF
--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -1424,6 +1424,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "cJ" = (
@@ -3113,6 +3117,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "fT" = (
@@ -3856,6 +3863,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "hu" = (
@@ -5124,12 +5134,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "jR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -5145,6 +5155,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/vines,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "jU" = (
@@ -6469,6 +6482,9 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "mJ" = (
@@ -7240,6 +7256,9 @@
 "os" = (
 /obj/structure/sign/department/miner_dock{
 	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
@@ -8770,6 +8789,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "rH" = (
@@ -9254,6 +9276,7 @@
 	name = "Shuttle Bay";
 	stripe_color = "#5a19a8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck1/exploration)
 "sD" = (
@@ -11740,6 +11763,7 @@
 /area/stellardelight/deck1/starboard)
 "yj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "yk" = (
@@ -14029,7 +14053,10 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/stellardelight/deck1/dorms/dorm3)
 "Dd" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /obj/effect/floor_decal/milspec/color/emerald/half{
 	dir = 6
 	},
@@ -17575,6 +17602,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "KY" = (
@@ -19013,6 +19043,9 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/milspec/color/emerald/half,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "Ob" = (
@@ -19091,6 +19124,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
@@ -21279,6 +21315,9 @@
 /obj/structure/sign/directions/shuttle_bay{
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "SP" = (
@@ -21618,6 +21657,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"Tu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/stellardelight/deck1/aft)
 "Tv" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -22028,6 +22073,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals3{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
@@ -23738,6 +23786,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "XG" = (
@@ -23886,6 +23937,9 @@
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
@@ -34062,7 +34116,7 @@ RT
 CG
 CG
 yO
-hg
+Tu
 dl
 sR
 pV
@@ -34204,7 +34258,7 @@ pA
 hv
 CG
 ZB
-hg
+Tu
 dl
 ZC
 YQ
@@ -34346,7 +34400,7 @@ ir
 ip
 CG
 cA
-hg
+Tu
 dl
 Nm
 on
@@ -34914,7 +34968,7 @@ MM
 QO
 ta
 Ie
-hg
+Tu
 gQ
 Ps
 Ps
@@ -35056,7 +35110,7 @@ VA
 qD
 qD
 sM
-hg
+Tu
 gQ
 xD
 pw
@@ -35198,7 +35252,7 @@ Df
 zn
 qD
 lt
-hg
+Tu
 gQ
 dO
 sZ
@@ -35340,7 +35394,7 @@ tv
 Ol
 qD
 YN
-hg
+Tu
 gQ
 cQ
 gQ
@@ -35482,7 +35536,7 @@ yu
 EM
 qD
 bR
-hg
+Tu
 gQ
 WP
 Ps

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -4310,6 +4310,12 @@
 /obj/random/snack,
 /turf/simulated/floor,
 /area/maintenance/security_port)
+"ij" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/stellardelight/deck1/aft)
 "ik" = (
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -21657,12 +21663,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
-"Tu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/stellardelight/deck1/aft)
 "Tv" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -34116,7 +34116,7 @@ RT
 CG
 CG
 yO
-Tu
+ij
 dl
 sR
 pV
@@ -34258,7 +34258,7 @@ pA
 hv
 CG
 ZB
-Tu
+ij
 dl
 ZC
 YQ
@@ -34400,7 +34400,7 @@ ir
 ip
 CG
 cA
-Tu
+ij
 dl
 Nm
 on
@@ -34968,7 +34968,7 @@ MM
 QO
 ta
 Ie
-Tu
+ij
 gQ
 Ps
 Ps
@@ -35110,7 +35110,7 @@ VA
 qD
 qD
 sM
-Tu
+ij
 gQ
 xD
 pw
@@ -35252,7 +35252,7 @@ Df
 zn
 qD
 lt
-Tu
+ij
 gQ
 dO
 sZ
@@ -35394,7 +35394,7 @@ tv
 Ol
 qD
 YN
-Tu
+ij
 gQ
 cQ
 gQ
@@ -35536,7 +35536,7 @@ yu
 EM
 qD
 bR
-Tu
+ij
 gQ
 WP
 Ps

--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -904,6 +904,7 @@
 	dir = 4
 	},
 /mob/living/simple_mob/animal/passive/opossum/poppy,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/eris/dark/gray_platform,
 /area/engineering/workshop)
 "bN" = (


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/VOREStation/VOREStation/issues/17480 .
<img width="696" height="720" alt="StrongDMM_2025-08-29_18-31-05" src="https://github.com/user-attachments/assets/fd339087-c69b-48e5-b4c7-b7213d1b8952" />
This room was missing a scrubber pipe in this spot!

Also fixes https://github.com/VOREStation/VOREStation/issues/16932 :
<img width="1095" height="616" alt="StrongDMM_2025-08-29_18-50-15" src="https://github.com/user-attachments/assets/987337f9-3f4a-4355-b8ef-79de46e6f26d" />
A new line of disposals pipes moves these bins' contents into Research's disposals.

<img width="610" height="678" alt="StrongDMM_2025-08-29_18-53-52" src="https://github.com/user-attachments/assets/9027fd59-77bc-47a8-bcb1-b329fd0999d3" />
Also, this air supply pipe is now a manifold so it actually connects to the outlet pump!


## Changelog
:cl:
maptweak: (Stellar Delight) Fixed a missing scrubber pipe in the Engineering Workshop.
maptweak: (Stellar Delight) Fixed a misshapen air distro pipe in exploration.
maptweak: (Stellar Delight) Fixed exploration disposals' pipes spitting items out into each other.
/:cl:
