### PR TITLE
Fix circuitry number inputs constraint

### DIFF
--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -159,7 +159,7 @@ list[](
 				to_chat(user, span_notice("You input [new_data] into the pin."))
 				return new_data
 		if("number")
-			new_data = tgui_input_number(user, "Now type in a number.","[src] number writing", isnum(default) ? default : null, MAX_NAME_LEN)
+			new_data = tgui_input_number(user, "Now type in a number.","[src] number writing", isnum(default) ? default : 0, INFINITY, -INFINITY, 0, FALSE)
 			if(isnum(new_data) && holder.check_interactivity(user) )
 				to_chat(user, span_notice("You input [new_data] into the pin."))
 				return new_data


### PR DESCRIPTION
## About The Pull Request

Fixes number inputs on circuitry being constrained to 52, introduced by a recent PR

## Changelog

:cl: Zizzi
fix: Fixed circuitry pins being constrained to numbers no larger than 52..
/:cl:
