### PR TITLE
Missing Icon Fixes

### DIFF
--- a/code/modules/clothing/accessories/badges_vr.dm
+++ b/code/modules/clothing/accessories/badges_vr.dm
@@ -106,6 +106,7 @@
 /obj/item/storage/box/dosimeter
 	name = "dosimeter case"
 	desc = "This case can only hold the Dosimeter, a few films and a manual."
+	icon = 'icons/inventory/accessory/item.dmi'
 	icon_state = "dosimeter_case"
 	item_state_slots = list(slot_r_hand_str = "syringe_kit", slot_l_hand_str = "syringe_kit")
 	storage_slots = 5

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -217,7 +217,7 @@
 /obj/item/fbp_backup_cell
 	name = "backup battery"
 	desc = "A small one-time-use chemical battery for synthetic crew when they are low on power in emergency situations."
-	icon = 'icons/obj/power_cells.dmi'
+	icon = 'icons/obj/power_cells_old.dmi'
 	icon_state = "backup"
 	w_class = ITEMSIZE_SMALL
 	var/amount = 150


### PR DESCRIPTION
## About The Pull Request
Fixes dosimeter and backup fbp cell missing icons

## Changelog
Dosimeter case icon path fixed to item.dmi
Backup fbp cell only existed in power_cells_old.dmi

:cl: Will
fix: Dosimeter case icon fixed
fix: Fbp backup battery icon fixed
/:cl:
