### PR TITLE
Fixes mangled quotation mark parsing in pod storage UI

### DIFF
--- a/code/modules/food/kitchen/smartfridge/smartfridge.dm
+++ b/code/modules/food/kitchen/smartfridge/smartfridge.dm
@@ -205,7 +205,7 @@
 		var/datum/stored_item/I = item_records[i]
 		var/count = I.get_amount()
 		if(count > 0)
-			items.Add(list(list("name" = html_encode(capitalize(I.item_name)), "index" = i, "amount" = count)))
+			items.Add(list(list("name" = capitalize(I.item_name), "index" = i, "amount" = count)))
 
 	.["contents"] = items
 	.["name"] = name


### PR DESCRIPTION

## About The Pull Request

Removes HTML encoding from listed item names in the pod storage UI, letting us actually see quotation marks!
Before:
<img width="201" height="234" alt="2025-08-31_04-36-36" src="https://github.com/user-attachments/assets/f79ba28d-8e0d-4cd6-9f92-4ce57e75685e" />



After:
<img width="227" height="263" alt="image" src="https://github.com/user-attachments/assets/ca22782d-a232-4fd9-be20-2202080f6604" />


## Changelog
:cl:Ryumi
fix: Fixed the pod storage UI not correctly displaying quotation marks in listed item names.
/:cl:
