### PR TITLE
Change character setup default to odd scaling

### DIFF
--- a/code/modules/client/preference_setup/general/09_size.dm
+++ b/code/modules/client/preference_setup/general/09_size.dm
@@ -10,7 +10,7 @@
 	var/weight_gain = 100	// Weight gain rate.
 	var/weight_loss = 50	// Weight loss rate.
 	var/fuzzy = 0			// Preference toggle for sharp/fuzzy icon. Default sharp.
-	var/offset_override = FALSE
+	var/offset_override = TRUE
 	var/voice_freq = 42500
 	var/voice_sound = "beep-boop"
 	var/custom_speech_bubble = "default"


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin, should keep people from encountering weird slants n stuff when scaling. For reference, this was the default before https://github.com/VOREStation/VOREStation/pull/15519 was merged way back when.

I tested this to see if it messed up saves and it doesn't appear to overwrite anything that was set to even or odd scaling (and new characters will default to odd). Full list below:
- Characters remain on Odd scaling if set to Odd before update
- Characters remain on Even scaling if set to Even before update
- New characters will default to Odd scaling upon creation or slot reset
- Characters spawn with set scaling offset
- Offset still swaps properly when verb is used in game

Also fixes https://github.com/VOREStation/VOREStation/issues/16944 by making it so people have to manually switch to even scaling to jank themselves up.
## Changelog
:cl:
config: changed default sprite scale offset to odd scaling since that was the default for the longest time.
/:cl:
