### PR TITLE
fixes water movement not being applied properly

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -209,7 +209,7 @@
 		var/turf_move_cost = T.movement_cost
 		if(istype(T, /turf/simulated/floor/water))
 			if(species.water_movement)
-				turf_move_cost = 0
+				turf_move_cost = CLAMP(turf_move_cost + species.water_movement, HUMAN_LOWEST_SLOWDOWN, 15)
 			if(istype(shoes, /obj/item/clothing/shoes))
 				var/obj/item/clothing/shoes/feet = shoes
 				if(istype(feet) && feet.water_speed)


### PR DESCRIPTION
## About The Pull Request
big patchy somehow broke this, but now it's fixy again.

NOTE TO DOWNSTREAMS (mainly chomp):
https://github.com/CHOMPStation2/CHOMPStation2/pull/8195 You removed the clamp back in this PR to make speeds the same n' stuff for aquatics. There's probably a better way to do that, as of right now the Bad Swimmer trait acts as a positive as long as you can stand the tiny oxy loss damage. Recommending you take a look at having a conditional like "if species.aquatic" or something for your balance pass if you want to merge this.

Or don't, I'm a bird, not a cop.
## Changelog
:cl:
fix: Fixed water movement not being applied by readding the clamp to human_movement.dm. 
/:cl:
