### PR TITLE
Impliment COMSIG_MOVABLE_CROSS and COMSIG_MOVABLE_CROSS_OVER signals

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -229,8 +229,9 @@
 #define COMSIG_MOVABLE_MOVED "movable_moved"
 ///from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSS "movable_cross"
-///when we cross over something (calling Crossed() on that atom)
-#define COMSIG_CROSSED_MOVABLE "crossed_movable"
+	#define COMPONENT_BLOCK_CROSS (1<<0)
+///from base of atom/movable/Move(): (/atom/movable)
+#define COMSIG_MOVABLE_CROSS_OVER "movable_cross_am"
 ///from base of atom/movable/Bump(): (/atom)
 #define COMSIG_MOVABLE_BUMP "movable_bump"
 ///from base of atom/movable/throw_impact(): (/atom/hit_atom, /datum/thrownthing/throwingdatum)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -265,6 +265,10 @@
 // Make sure you know what you're doing if you call this, this is intended to only be called by byond directly.
 // You probably want CanPass()
 /atom/movable/Cross(atom/movable/AM)
+	if(SEND_SIGNAL(src, COMSIG_MOVABLE_CROSS, AM) & COMPONENT_BLOCK_CROSS)
+		return FALSE
+	if(SEND_SIGNAL(AM, COMSIG_MOVABLE_CROSS_OVER, src) & COMPONENT_BLOCK_CROSS)
+		return FALSE
 	return CanPass(AM, loc)
 
 /atom/movable/CanPass(atom/movable/mover, turf/target)


### PR DESCRIPTION
## About The Pull Request
I need these downstream, neither chomp or virgo has them used or signaled. So nothing already uses them. No player facing changes. Updates crossing signals to TG versions, along with allowing components to deny crossing something.

## Changelog
Implements COMSIG_MOVABLE_CROSS in atom/movable/Cross()
Implements COMSIG_MOVABLE_CROSS_OVER in atom/movable/Cross()
Implements COMPONENT_BLOCK_CROSS flag for crossed signals to deny CanPass()

:cl:
code: Crossing atom signals now implemented
/:cl:
