### PR TITLE
Fixes beds and sofa in hotsprings redgate, makes Tether research outpost dorms dorm-worthy

### DIFF
--- a/maps/redgate/hotsprings.dmm
+++ b/maps/redgate/hotsprings.dmm
@@ -955,7 +955,7 @@
 	},
 /area/redgate/hotsprings/outdoors)
 "wL" = (
-/obj/structure/bed/double,
+/obj/structure/bed/double/padded,
 /obj/item/bedsheet/hopdouble,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/redgate/hotsprings/house/dorm1)
@@ -1088,7 +1088,7 @@
 	},
 /area/redgate/hotsprings/outdoors)
 "zB" = (
-/obj/structure/bed/double,
+/obj/structure/bed/double/padded,
 /obj/item/bedsheet/hopdouble,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/redgate/hotsprings/house/dorm2)
@@ -1151,7 +1151,7 @@
 /area/redgate/hotsprings/house/lovercave)
 "AM" = (
 /obj/structure/bed/chair/sofa/corner/purp{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/redgate/hotsprings/house)

--- a/maps/tether/tether-07-solars.dmm
+++ b/maps/tether/tether-07-solars.dmm
@@ -7354,10 +7354,8 @@
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom/quarters/dorm1)
 "or" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/purple{
-	pixel_y = 1
-	},
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/purpledouble,
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom/quarters/dorm2)
 "os" = (

--- a/maps/tether/tether-07-solars.dmm
+++ b/maps/tether/tether-07-solars.dmm
@@ -7175,6 +7175,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
+"ob" = (
+/obj/machinery/door/airlock/research{
+	name = "Science Outpost Personal Quarters";
+	id_tag = "sci_outpost_dormdoor1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom)
 "oc" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -7287,7 +7301,8 @@
 /area/rnd/outpost/breakroom)
 "oo" = (
 /obj/machinery/door/airlock/research{
-	name = "Science Outpost Personal Quarters"
+	name = "Science Outpost Personal Quarters";
+	id_tag = "sci_outpost_dormdoor2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7309,17 +7324,25 @@
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "oq" = (
-/obj/structure/bed/double,
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/purpledouble,
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "or" = (
-/obj/structure/bed,
+/obj/structure/bed/padded,
+/obj/item/bedsheet/purple{
+	pixel_y = 1
+	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "os" = (
-/obj/structure/window/basic/full,
-/obj/structure/window/basic{
-	dir = 4
+/obj/structure/window/reinforced/polarized/full{
+	id = "sci_outpost_dorms2";
+	name = "Tintable Window"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "sci_outpost_dorms2"
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -7343,6 +7366,11 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 25
+	},
+/obj/machinery/button/remote/airlock/release{
+	pixel_y = 24;
+	pixel_x = -14;
+	id = "sci_outpost_dormdoor1"
 	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
@@ -7372,6 +7400,22 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/button/windowtint{
+	id = "sci_outpost_dorms1";
+	layer = 3.3;
+	name = "Window Tint Control";
+	pixel_x = -6;
+	pixel_y = -23;
+	range = 10
+	},
+/obj/machinery/button/remote/airlock{
+	id = "sci_outpost_dormdoor1";
+	name = "Outpost Quarters Lock";
+	pixel_x = -13;
+	pixel_y = -23;
+	specialfunctions = 4;
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "oz" = (
@@ -7393,6 +7437,11 @@
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
+/obj/machinery/button/remote/airlock/release{
+	pixel_y = 24;
+	pixel_x = -14;
+	id = "sci_outpost_dormdoor2"
+	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "oB" = (
@@ -7410,6 +7459,19 @@
 /obj/machinery/vending/cigarette{
 	dir = 4
 	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom)
+"oE" = (
+/obj/structure/window/reinforced/polarized/full{
+	id = "sci_outpost_dorms1";
+	name = "Tintable Window"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "sci_outpost_dorms1"
+	},
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oH" = (
@@ -7489,6 +7551,22 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/button/windowtint{
+	id = "sci_outpost_dorms2";
+	layer = 3.3;
+	name = "Window Tint Control";
+	pixel_x = -6;
+	pixel_y = -23;
+	range = 10
+	},
+/obj/machinery/button/remote/airlock{
+	id = "sci_outpost_dormdoor2";
+	name = "Outpost Quarters Lock";
+	pixel_x = -13;
+	pixel_y = -23;
+	specialfunctions = 4;
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
@@ -24664,7 +24742,7 @@ hM
 hM
 ks
 ks
-oo
+ob
 ks
 oo
 ks
@@ -25231,8 +25309,8 @@ iV
 jh
 jH
 hM
-os
-os
+oE
+oE
 ks
 os
 os

--- a/maps/tether/tether-07-solars.dmm
+++ b/maps/tether/tether-07-solars.dmm
@@ -7187,8 +7187,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "oc" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -7311,8 +7314,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7321,20 +7327,39 @@
 	dir = 9
 	},
 /obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/remote/airlock{
+	id = "sci_outpost_dormdoor1";
+	name = "Outpost Quarters Lock";
+	pixel_x = -13;
+	pixel_y = -23;
+	specialfunctions = 4;
+	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	id = "sci_outpost_dorms1";
+	layer = 3.3;
+	name = "Window Tint Control";
+	pixel_x = -6;
+	pixel_y = -23;
+	range = 10
+	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "oq" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/purpledouble,
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "or" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple{
 	pixel_y = 1
 	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "os" = (
 /obj/structure/window/reinforced/polarized/full{
 	id = "sci_outpost_dorms2";
@@ -7347,17 +7372,25 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "ot" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "ou" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "ov" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
@@ -7373,7 +7406,7 @@
 	id = "sci_outpost_dormdoor1"
 	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "ow" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7390,8 +7423,24 @@
 	pixel_x = -22
 	},
 /obj/machinery/light,
+/obj/machinery/button/remote/airlock{
+	id = "sci_outpost_dormdoor2";
+	name = "Outpost Quarters Lock";
+	pixel_x = -13;
+	pixel_y = -23;
+	specialfunctions = 4;
+	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	id = "sci_outpost_dorms2";
+	layer = 3.3;
+	name = "Window Tint Control";
+	pixel_x = -6;
+	pixel_y = -23;
+	range = 10
+	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "oy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7400,24 +7449,15 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/button/windowtint{
-	id = "sci_outpost_dorms1";
-	layer = 3.3;
-	name = "Window Tint Control";
-	pixel_x = -6;
-	pixel_y = -23;
-	range = 10
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/machinery/button/remote/airlock{
-	id = "sci_outpost_dormdoor1";
-	name = "Outpost Quarters Lock";
-	pixel_x = -13;
-	pixel_y = -23;
-	specialfunctions = 4;
-	dir = 1
+/obj/structure/privacyswitch{
+	pixel_y = -22;
+	pixel_x = 6
 	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "oz" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -7425,8 +7465,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "oA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7442,8 +7490,11 @@
 	pixel_x = -14;
 	id = "sci_outpost_dormdoor2"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "oB" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donut,
@@ -7472,6 +7523,15 @@
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom/quarters/dorm1)
+"oF" = (
+/turf/simulated/wall,
+/area/rnd/outpost/breakroom/quarters/dorm2)
+"oG" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oH" = (
@@ -7515,6 +7575,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oN" = (
@@ -7552,24 +7615,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/button/windowtint{
-	id = "sci_outpost_dorms2";
-	layer = 3.3;
-	name = "Window Tint Control";
-	pixel_x = -6;
-	pixel_y = -23;
-	range = 10
-	},
-/obj/machinery/button/remote/airlock{
-	id = "sci_outpost_dormdoor2";
-	name = "Outpost Quarters Lock";
-	pixel_x = -13;
-	pixel_y = -23;
-	specialfunctions = 4;
-	dir = 1
+/obj/structure/privacyswitch{
+	pixel_y = -22;
+	pixel_x = 6
 	},
 /turf/simulated/floor/wood,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/breakroom/quarters/dorm2)
 "oR" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -7664,6 +7715,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "pd" = (
@@ -7673,8 +7727,29 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
+"pe" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom)
+"pf" = (
+/turf/simulated/wall,
+/area/rnd/outpost/breakroom/quarters/dorm1)
+"pg" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/rnd/outpost/breakroom/quarters/dorm1)
 "zg" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/mine/explored;
@@ -24458,9 +24533,9 @@ oK
 oK
 oK
 oK
-oK
+pe
 oW
-on
+oG
 oB
 oU
 ab
@@ -24740,13 +24815,13 @@ hM
 hM
 hM
 hM
-ks
-ks
+pf
+pf
 ob
-ks
+oF
 oo
-ks
-ks
+oF
+oF
 ab
 ab
 ab
@@ -24882,13 +24957,13 @@ jf
 jo
 ji
 mV
-hM
+pf
 ov
 op
-ks
+oF
 oA
 ox
-ks
+oF
 ab
 ab
 ab
@@ -25024,13 +25099,13 @@ iV
 jo
 ji
 jF
-hM
+pf
 ou
 oy
-ks
+oF
 oz
 oQ
-ks
+oF
 ab
 ab
 ab
@@ -25166,13 +25241,13 @@ iV
 jq
 jA
 jG
-hM
-ot
+pf
+pg
 oq
-ks
+oF
 ot
 or
-ks
+oF
 ab
 ab
 ab
@@ -25308,13 +25383,13 @@ iC
 iV
 jh
 jH
-hM
+pf
 oE
 oE
-ks
+oF
 os
 os
-ks
+oF
 ab
 ab
 ab

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -813,6 +813,16 @@
 	name = "\improper Research Outpost Breakroom"
 	icon_state = "research"
 
+/area/rnd/outpost/breakroom/quarters
+	name = "\improper Research Outpost Personal Quarters"
+	flags = RAD_SHIELDED | AREA_SOUNDPROOF | AREA_ALLOW_LARGE_SIZE | AREA_BLOCK_SUIT_SENSORS | AREA_BLOCK_TRACKING | AREA_FORBID_EVENTS | AREA_FORBID_SINGULO
+
+/area/rnd/outpost/breakroom/quarters/dorm1
+	name = "\improper Research Outpost Personal Quarters 1"
+
+/area/rnd/outpost/breakroom/quarters/dorm2
+	name = "\improper Research Outpost Personal Quarters 2"
+
 /area/rnd/outpost/airlock
 	name = "\improper Research Outpost Airlock"
 	icon_state = "green"


### PR DESCRIPTION
…ost dorms dorm-worthy

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Hotspring redate:
- Fixes the corner sofa in the cabin facing the wrong direction.
- Makes the beds in the cabin padded (I don't think these were meant to be prison beds?)

Tether research outpost:
- Added areas for quarters' rooms.
- Gave the quarters' rooms all the amenities of a proper dorm room (door bolts, privacy switches, tintable windows, and emergency door releases.)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryumi
maptweak: Fixed the corner couch in the hotsprings redgate. Also made the beds appropriately cozier.
maptweak: Gave the Tether science outpost's all of the amenities of a proper dorm room.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
