### PR TITLE
Make the dud implants in the loadout free

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -17,7 +17,7 @@
 	display_name = "implant, generic, primary"
 	description = "An implant with no obvious purpose."
 	path = /obj/item/implant
-	cost = 1
+	cost = 0
 
 /datum/gear/utility/implant/generic/second
 	display_name = "implant, generic, secondary"


### PR DESCRIPTION

## About The Pull Request
In the loadout, you can have some useless implants that do nothing but take space. There's also some tracking implant that costs no money you can stick in your neck, if you fancy that.

Personally, I like the idea of having some useless implanted cybernetics in my characters, so this PR reduces the price to zero, so I don't have to spend 3 whole points on things that only a doctor will see. Maybe. 
## Changelog
:cl:
balance: Made the dud implants free in the loadout
/:cl:
