### PR TITLE
Fix circuit cloning creating invisible clothing

### DIFF
--- a/code/modules/integrated_electronics/core/circuit_serialization.dm
+++ b/code/modules/integrated_electronics/core/circuit_serialization.dm
@@ -299,6 +299,9 @@
 		var/restored_path = src.restore_assembly_prefix(assembly_data["t"])
 		var/original_path = text2path(restored_path)
 		if(original_path && ispath(original_path, /obj/item/electronic_assembly))
+			// Reject clothing assemblies
+			if(ispath(original_path, /obj/item/electronic_assembly/clothing))
+				return null
 			assembly = new original_path()
 
 	// Default to medium assembly

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -349,6 +349,12 @@
 		to_chat(user, span_warning("Invalid circuit format!"))
 		return
 
+		var/restored_path = src.restore_assembly_prefix(assembly_data["t"])
+		var/assembly_path = text2path(restored_path)
+		if(assembly_path && ispath(assembly_path, /obj/item/electronic_assembly/clothing))
+			to_chat(user, span_warning("Cannot import wearable electronic assemblies!"))
+			return
+
 	// Check if we have enough metal to build all components
 	var/total_cost = 0
 	var/total_complexity = 0


### PR DESCRIPTION
## About The Pull Request

This just adds a check when cloning circuitry to see if you are trying to clone circuitry clothing.
Circuitry clothing cannot currently be cloned, because it's a clothing item with a circuit housing hidden inside, not an actual circuit assembly.
Handling for this can be added in future, but this fix will tell the user that this feature does not work, and will prevent failed clothing printing, which causes invisible circuitry assemblies to be created on the map.

## Changelog

:cl: Zizzi
fix: fixed circuit cloning printing invisible clothes
/:cl:
