### PR TITLE
Fracking list runtime fix

### DIFF
--- a/code/modules/reagents/machinery/pump.dm
+++ b/code/modules/reagents/machinery/pump.dm
@@ -224,10 +224,10 @@
 		R.add_reagent(M.mineral.reagent, rand(0,volume / 8))
 	// Pump deep reagents from deepdrill boreholes
 	for(var/metal in GLOB.deepore_fracking_reagents)
-		if(!M.resources[metal])
+		if(!LAZYACCESS(M.resources,metal))
 			continue
 		var/list/ore_list = GLOB.deepore_fracking_reagents[metal]
-		if(!ore_list || !ore_list.len)
+		if(!LAZYLEN(ore_list))
 			continue
 		var/reagent_id = pick(ore_list)
 		if(reagent_id && prob(60))


### PR DESCRIPTION
## About The Pull Request
Fixes a runtime caused by trying to frack in a location without any deep resources

## Changelog
Used lazyaccess and lazylen to safety check resource lists in a more secure way.

:cl: Will
fix: Fracking in a location without deep resources no longer causes a runtime
/:cl:
