### PR TITLE
Uses balloon alerts for mining messages instead of logged ones

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -517,7 +517,7 @@ var/list/mining_overlay_cache = list()
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
 					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
 					wreckfinds(P.destroy_artefacts)
-			to_chat(user, span_notice("You start [P.drill_verb][fail_message]."))
+			user.balloon_alert(user, "You start [P.drill_verb][fail_message].")
 
 			if(do_after(user, P.digspeed, target = src))
 
@@ -528,7 +528,7 @@ var/list/mining_overlay_cache = list()
 					else if(newDepth > F.excavation_required)
 						excavate_find(prob(10), F) //A 1 in 10 chance to get it out perfectly seems fine if you're not being careful.
 
-				to_chat(user, span_notice("You finish [P.drill_verb] \the [src]."))
+				user.balloon_alert(user, "You finish [P.drill_verb] \the [src].")
 
 				if(newDepth >= 200) // This means the rock is mined out fully
 					if(P.destroy_artefacts)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -517,7 +517,7 @@ var/list/mining_overlay_cache = list()
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
 					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
 					wreckfinds(P.destroy_artefacts)
-			user.balloon_alert(user, "You start [P.drill_verb][fail_message].")
+			user.balloon_alert(user, "you start [P.drill_verb][fail_message].")
 
 			if(do_after(user, P.digspeed, target = src))
 
@@ -528,7 +528,7 @@ var/list/mining_overlay_cache = list()
 					else if(newDepth > F.excavation_required)
 						excavate_find(prob(10), F) //A 1 in 10 chance to get it out perfectly seems fine if you're not being careful.
 
-				user.balloon_alert(user, "You finish [P.drill_verb] \the [src].")
+				user.balloon_alert(user, "you finish [P.drill_verb] \the [src].")
 
 				if(newDepth >= 200) // This means the rock is mined out fully
 					if(P.destroy_artefacts)


### PR DESCRIPTION

## About The Pull Request

See title.
![dreamseeker_2025-09-10_15-17-24](https://github.com/user-attachments/assets/ecf38f76-dfe0-41e2-ab30-3e6c87e8e5a3)

## Changelog
:cl: Ryumi
qol: Mining uses balloon alerts instead of spamming your chat with every little mining attempt.
/:cl:
