### PR TITLE
Fixes looc log category

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -19,6 +19,9 @@
 /// log messages sent in OOC
 /datum/config_entry/flag/log_ooc
 
+/// log messages sent in LOOC
+/datum/config_entry/flag/log_looc
+
 /// log login/logout
 /datum/config_entry/flag/log_access
 

--- a/code/modules/logging/categories/log_category_game.dm
+++ b/code/modules/logging/categories/log_category_game.dm
@@ -32,6 +32,11 @@
 	config_flag = /datum/config_entry/flag/log_ooc
 	master_category = /datum/log_category/game
 
+/datum/log_category/game_looc
+	category = LOG_CATEGORY_GAME_LOOC
+	config_flag = /datum/config_entry/flag/log_looc
+	master_category = /datum/log_category/game
+
 /datum/log_category/game_prayer
 	category = LOG_CATEGORY_GAME_PRAYER
 	config_flag = /datum/config_entry/flag/log_prayer

--- a/config/example/logging.txt
+++ b/config/example/logging.txt
@@ -26,6 +26,9 @@ LOG_EVENTCHAT
 ## log OOC channel
 LOG_OOC
 
+## log LOOC channel
+LOG_LOOC
+
 ## log prayers
 LOG_PRAYER
 


### PR DESCRIPTION

## About The Pull Request

LOOC messages have been using the fallback category after deployment as the category (for some reason) was still missing. This fixes the issue so they are properly in their own category now.

## Changelog
:cl:
fix: LOOC messages are now properly logging in the right category instead of falling back to the default one.
/:cl:
