### PR TITLE
Drinky Tweaks

### DIFF
--- a/code/modules/food/drinkingglass/drinkingglass.dm
+++ b/code/modules/food/drinkingglass/drinkingglass.dm
@@ -23,6 +23,7 @@
 
 	amount_per_transfer_from_this = 5
 	max_transfer_amount = 30
+	min_transfer_amount = 1
 	flags = OPENCONTAINER
 
 	matter = list(MAT_GLASS = 60)

--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -113,7 +113,7 @@
 					food_inserted_micros -= F
 
 	if(!reagents.total_volume && changed)
-		M.visible_message(span_notice("[M] finishes drinking \the [src]."),span_notice("You finish drinking \the [src]."))
+		M.visible_message(span_notice("[M] finishes drinking from \the [src]."),span_notice("You finish drinking from \the [src]."))
 		if(trash)
 			user.drop_from_inventory(src)	//so icons update :[
 			if(ispath(trash,/obj/item))
@@ -184,12 +184,16 @@
 /obj/item/reagent_containers/food/drinks/self_feed_message(var/mob/user)
 	if(amount_per_transfer_from_this == volume)	//I wanted to use a switch, but switch statements can't use vars and the maximum volume of containers varies
 		to_chat(user, span_notice("You knock back the entire [src] in one go!"))
+	else if(amount_per_transfer_from_this == 1)
+		to_chat(user, span_notice("You take a dainty little sip from \the [src]."))
 	else if(amount_per_transfer_from_this <= 4)	//below the standard 5
 		to_chat(user, span_notice("You take a modest sip from \the [src]."))
 	else if(amount_per_transfer_from_this <= 10)	//the standard five to a bit more
 		to_chat(user, span_notice("You swallow a gulp from \the [src]."))
 	else if(amount_per_transfer_from_this <= 30)
 		to_chat(user, span_notice("You take a long drag from \the [src]."))
+	else if(amount_per_transfer_from_this <= 60)
+		to_chat(user, span_notice("You chug from \the [src]!"))
 	else	//default message as a fallback
 		to_chat(user, span_notice("You swallow a gulp from \the [src]."))
 

--- a/code/modules/food/food/drinks/drinkingglass.dm
+++ b/code/modules/food/food/drinks/drinkingglass.dm
@@ -5,6 +5,8 @@
 	desc = "Your standard drinking glass."
 	icon_state = "glass_empty"
 	amount_per_transfer_from_this = 5
+	max_transfer_amount = 30
+	min_transfer_amount = 1
 	volume = 30
 	unacidable = TRUE //glass
 	center_of_mass_x = 16

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -11,6 +11,7 @@
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
+	min_transfer_amount = 1
 	max_transfer_amount = 60
 	volume = 60
 	w_class = ITEMSIZE_SMALL


### PR DESCRIPTION
## About The Pull Request

Restores the ability to go as low as 1u sippies for most glasses, either for precision chemistry or micros drinking from shotglasses. Also makes a minor grammar tweak to the "finish drinking" text, and adds a couple more drink level messages.

## Changelog
:cl:
qol: you can now sippy as low as 1u at a time from most glasses
spellcheck: added a 'from' to the drinking text because the name and icon update *before* the message goes through
/:cl: