### PR TITLE
jetpacks in zero G should hold you up if you have damaged legs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -105,6 +105,11 @@
 	if (r_hand && istype(r_hand, /obj/item/cane))
 		stance_damage -= 2
 
+	// Jetpacks in zeroG count for holding you up
+	var/obj/item/tank/jetpack/thrust = get_jetpack()
+	if (lastarea?.get_gravity() == FALSE && thrust?.stabilization_on)
+		stance_damage -= 4
+
 	// standing is poor
 	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
 		if(!(lying || resting) && !isbelly(loc))


### PR DESCRIPTION
## About The Pull Request
Had an issue where a player with lumbar impairment had to crawl along in space with a jetpack, and it just seemed really bad gameplay wise. I didn't want to have jetpacks completely negate broken legs, so I made it require zeroG to do so. If just being in zeroG should stop collapsing then I can do that instead.

## Changelog
Jetpacks worn, and active, in zeroG, count for holding you up.

:cl: Will
add: Active jetpacks worn in zeroG count as using crutchs for leg damage or lumbar impairment
/:cl:
