### PR TITLE
Adds a miniature description to the paperwork dispenser

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -192,7 +192,7 @@
 //TODO: Add prewritten forms to dispense when you work out a good way to store the strings.
 /obj/item/form_printer
 	name = "paperwork printer"
-	//name = "paper dispenser"
+	desc = "A revolution for all the bureaucrats on the go!"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "doc_printer_mod_pre"
 	item_icons = list(


### PR DESCRIPTION
## About The Pull Request
Just a small description for the paperwork printer. It felt weird to have NOTHING. I'd have added some charge counters if there was anything to describe.
## Changelog
:cl:
qol: Added a description to the paperwork dispenser.
/:cl:
