### PR TITLE
Backward netgun science entries

### DIFF
--- a/code/modules/research/tg/designs/weapon_designs.dm
+++ b/code/modules/research/tg/designs/weapon_designs.dm
@@ -363,7 +363,7 @@
 	// req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_MAGNET = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000)
-	build_path = /obj/item/gun/energy/netgun/shrink
+	build_path = /obj/item/gun/energy/netgun
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_RANGED
 	)
@@ -375,7 +375,7 @@
 	id = "sizenetgun"
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 4000)
-	build_path = /obj/item/gun/energy/netgun
+	build_path = /obj/item/gun/energy/netgun/shrink
 	category = list(
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_RANGED
 	)


### PR DESCRIPTION
## About The Pull Request
The netguns were backward, the normal one gave you the shrinking one, etc

## Changelog
Swapped the resulting netgun from each research entry to be the correct one.

:cl: Will
fix: Netgun and shrinking netgun science entries swapped around to give the proper item when printed
/:cl:
