### PR TITLE
Adds the loincloth to the loadout options

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -216,6 +216,14 @@
 	..()
 	gear_tweaks += gear_tweak_free_color_choice
 
+/datum/gear/uniform/loincloth
+	display_name = "loincloth"
+	path = /obj/item/clothing/under/skirt/loincloth
+
+/datum/gear/uniform/loincloth/New()
+	..()
+	gear_tweaks += gear_tweak_free_color_choice
+
 /datum/gear/uniform/reddress
 	display_name = "red dress with belt"
 	path = /obj/item/clothing/under/dress/darkred


### PR DESCRIPTION
## About The Pull Request
It's in the vendors, but not in the loadout. This fixes that.
## Changelog
:cl: kot
fix: fixed the loincloth not being present in the loadout options
/:cl:
