### PR TITLE
sleeper uses forcemove

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -383,7 +383,7 @@
 		if(!beaker)
 			beaker = I
 			user.drop_item()
-			I.loc = src
+			I.forceMove(src)
 			user.visible_message(span_infoplain(span_bold("\The [user]") + " adds \a [I] to \the [src]."), span_notice("You add \a [I] to \the [src]."))
 		else
 			to_chat(user, span_warning("\The [src] has a beaker already."))
@@ -482,7 +482,7 @@
 		if(M.client)
 			M.client.perspective = EYE_PERSPECTIVE
 			M.client.eye = src
-		M.loc = src
+		M.forceMove(src)
 		update_use_power(USE_POWER_ACTIVE)
 		occupant = M
 		update_icon()
@@ -495,14 +495,14 @@
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.Stasis(0)
-	occupant.loc = src.loc
+	occupant.forceMove(get_turf(src))
 	occupant = null
 	for(var/atom/movable/A in src) // In case an object was dropped inside or something
 		if(A == beaker || A == circuit)
 			continue
 		if(A in component_parts)
 			continue
-		A.loc = src.loc
+		A.forceMove(get_turf(src))
 	update_use_power(USE_POWER_IDLE)
 	update_icon()
 	toggle_filter()
@@ -510,7 +510,7 @@
 
 /obj/machinery/sleeper/proc/remove_beaker()
 	if(beaker)
-		beaker.loc = src.loc
+		beaker.forceMove(get_turf(src))
 		beaker = null
 		toggle_filter()
 


### PR DESCRIPTION
## About The Pull Request
Medical sleepers updated to use forceMove().

## Changelog
Medical sleepers use forceMove() instead of directly setting loc. Making signals and recursive listeners happier.

:cl: Will
refactor: Medical sleepers use forceMove instead of loc 
fix: locked screen after being put in a sleeper
fix: hearing radios around a sleeper once you leave it
/:cl:
