### PR TITLE
General Command Selector

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -20,6 +20,30 @@
 
 //Command/Specific
 
+/datum/gear/uniform/general_command_selector
+	display_name = "Command - Department Head's Uniforms"
+	description = "Select from a range of outfits available to all Department Heads, and Talon Captains."
+	allowed_roles = list(JOB_SITE_MANAGER,JOB_TALON_CAPTAIN,JOB_HEAD_OF_PERSONNEL,JOB_HEAD_OF_SECURITY,JOB_QUARTERMASTER,JOB_RESEARCH_DIRECTOR,JOB_CHIEF_MEDICAL_OFFICER,JOB_CHIEF_ENGINEER)
+	show_roles = FALSE
+	path = /obj/item/clothing/under/rank/neo_gorka/command
+	sort_category = "Uniforms"
+	cost = 1
+
+/datum/gear/uniform/general_command_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"neocorporate uniform"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"TG&C utility suit"=/obj/item/clothing/under/rank/neo_commandutil,
+		"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_gorka/command,
+		"TG&C black command gorka"=/obj/item/clothing/under/rank/neo_gorka/black_command
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
 /datum/gear/uniform/site_manager_selector
 	display_name = "Command - " + JOB_SITE_MANAGER + "'s Uniforms"
 	description = "Select from a range of outfits available to all " + JOB_SITE_MANAGER + "s, and Talon Captains."


### PR DESCRIPTION
## About The Pull Request
Adds a general uniform selector for command uniforms available to all department heads. Duplicates in per-role selectors are untouched to avoid messing with loadouts.

## Changelog

:cl:
add: Added a general command uniform selector for all department heads.
/:cl: