### PR TITLE
Negative trait point changes.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -244,7 +244,7 @@
 /datum/trait/negative/less_blood
 	name = "Low Blood Volume"
 	desc = "You have 33.3% less blood volume compared to most species, making you more prone to blood loss issues."
-	cost = -3
+	cost = -2
 	var_changes = list("blood_volume" = 375)
 	excludes = list(/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
@@ -252,7 +252,7 @@
 /datum/trait/negative/less_blood_extreme
 	name = "Low Blood Volume, Extreme"
 	desc = "You have 60% less blood volume compared to most species, making you much more prone to blood loss issues."
-	cost = -5
+	cost = -3
 	var_changes = list("blood_volume" = 224)
 	excludes = list(/datum/trait/negative/less_blood)
 	can_take = ORGANICS
@@ -601,21 +601,21 @@
 /datum/trait/negative/reduced_biocompat_minor
 	name = "Reduced Biocompatibility, Minor"
 	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 80% as effective on you!"
-	cost = -2
+	cost = -1
 	var_changes = list("chem_strength_heal" = 0.8)
 	can_take = ORGANICS
 
 /datum/trait/negative/reduced_biocompat
 	name = "Reduced Biocompatibility"
 	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 60% as effective on you!"
-	cost = -4
+	cost = -2
 	var_changes = list("chem_strength_heal" = 0.6)
 	can_take = ORGANICS
 
 /datum/trait/negative/reduced_biocompat_extreme
 	name = "Reduced Biocompatibility, Major"
 	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 30% as effective on you!"
-	cost = -8
+	cost = -4
 	var_changes = list("chem_strength_heal" = 0.3)
 	can_take = ORGANICS
 

--- a/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
@@ -202,7 +202,7 @@
 	name = "Ambulant Blood"
 	desc = "Your blood reacts to hostile stimulation such as burning when seperated from your body, as if it was its own creature. You WILL be mistaken for a changeling, you may want to document this in your medical records."
 	var_changes = list("ambulant_blood" = TRUE)
-	cost = -1
+	cost = 0
 
 	is_genetrait = TRUE
 	hidden = FALSE


### PR DESCRIPTION

## About The Pull Request

Changed some of the negative traits point values, primarily as they give so many points relative to the small cost of positive traits: 
Low Blood Volume from 3 to 2 and the extreme version from 5 to 3. These are serious, but they're reasonably in-line with other serious weakness traits. They also have the upside of you being easier to treat for bloodloss too once in medbay, by very quickly refilling you when hooked up to a bloodbag.
Reduced biocompatibility 2->1, 4->2, 8->4. These are really not that much of an issue, if you are in medbay getting treated, it just means they need to stick you with a couple extra syringes and rarely actually causes a problem other than taking a couple more minutes. 4 points is still a lot. 
Ambulant Blood 1 to 0, this has no effect at all here where changelings are never a risk. Really I would say this is a neutral trait here, but we can keep it as negative for downstream compatibility.

## Changelog
:cl:
balance: Low Blood Volume from 3 to 2 and the extreme version from 5 to 3.
balance: Reduced biocompatibility 2->1, 4->2, 8->4.
balance: Ambulant Blood 1 to 0, this has no effect at all here where changelings are never a risk.
/:cl:
