### PR TITLE
prevent vr bodyscanner kiosk from scanning

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -325,6 +325,8 @@
 		return "<br>" + span_warning("Unable to perform full scan. Please see a medical professional.")
 	if(!user.mind)
 		return "<br>" + span_warning("Unable to perform full scan. Please see a medical professional.")
+	if(istype(get_area(src), /area/vr))
+		return "<br>" + span_danger("Incompatible database configuration error: A Transcore Mind and Body Resource Management server could not be detected.")
 
 	var/nif = user.nif
 	if(nif)


### PR DESCRIPTION
## About The Pull Request
This shouldn't be possible.

## Changelog
Prevents VR interaction with the medical kiosk when attempting a mind/bodyscan.

:cl: Will
fix: Medical kiosk can no longer do mind and body record scans in VR
/:cl:
