### PR TITLE
Cortical borers should not touch anything while within a host

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer.dm
@@ -216,6 +216,12 @@
 /mob/living/simple_mob/animal/borer/cannot_use_vents()
 	return
 
+/mob/living/simple_mob/animal/borer/UnarmedAttack(var/atom/A, var/proximity)
+	if(ismob(loc))
+		to_chat(src, span_warning("You cannot interact with that from inside a host!"))
+		return
+	. = ..()
+
 // This is awful but its literally say code.
 /mob/living/simple_mob/animal/borer/say(var/message, var/datum/language/speaking = null, var/whispering = 0)
 	message = sanitize(message)


### PR DESCRIPTION
## About The Pull Request
Borers already don't have hands, and cannot interact with most objects. This disables the "borer prodded X" message in inside a host, which can accidentally reveal a borer is inside someone if they click anything adjacent to their host.

## Changelog
Cortical borers inside a host can no longer prod anything nearby their host.

:cl: Will
fix: Cortical borers cannot prod things adjacent to their host, while inside of their host.
/:cl:
