### PR TITLE
Disposal sorters use defines instead of magic numbers

### DIFF
--- a/code/modules/recycling/disposal_junctions.dm
+++ b/code/modules/recycling/disposal_junctions.dm
@@ -173,7 +173,7 @@
 /obj/structure/disposalpipe/sortjunction/wildcard
 	name = "wildcard sorting junction"
 	desc = "An underfloor disposal pipe which filters all wrapped and tagged items."
-	subtype = 1
+	subtype = DISPOSAL_SORT_WILDCARD
 
 /obj/structure/disposalpipe/sortjunction/wildcard/divert_check(checkTag)
 	return checkTag != ""
@@ -182,7 +182,7 @@
 /obj/structure/disposalpipe/sortjunction/untagged
 	name = "untagged sorting junction"
 	desc = "An underfloor disposal pipe which filters all untagged items."
-	subtype = 2
+	subtype = DISPOSAL_SORT_UNTAGGED
 
 /obj/structure/disposalpipe/sortjunction/untagged/divert_check(checkTag)
 	return checkTag == ""


### PR DESCRIPTION
## About The Pull Request
Inconsequential change with no player facing stuff.

## Changelog
Disposal sorter prefabs use their already existing defines instead of numbers.

:cl:
code: Disposal sorter prefabs use defines instead of numbers
/:cl:
