### PR TITLE
Santabag is a bag and no longer turns invisible

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -93,15 +93,6 @@
 		return FALSE
 	return ..()
 
-/obj/item/storage/backpack/santabag
-	name = "\improper Santa's gift bag"
-	desc = "Space Santa uses this to deliver toys to all the nice children in space in Christmas! Wow, it's pretty big!"
-	icon_state = "giftbag0"
-	item_state_slots = list(slot_r_hand_str = "giftbag", slot_l_hand_str = "giftbag")
-	w_class = ITEMSIZE_LARGE
-	max_w_class = ITEMSIZE_NORMAL
-	max_storage_space = ITEMSIZE_COST_NORMAL * 100 // can store a ton of shit!
-
 /obj/item/storage/backpack/cultpack
 	name = "trophy rack"
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -516,3 +516,27 @@
 	max_w_class = ITEMSIZE_NORMAL
 	w_class = ITEMSIZE_SMALL
 	can_hold = list(/obj/item/forensics/swab,/obj/item/sample/print,/obj/item/sample/fibers,/obj/item/evidencebag)
+
+// -----------------------------
+//          Santa bag
+// -----------------------------
+/obj/item/storage/bag/santabag
+	name = "\improper Santa's gift bag"
+	desc = "Space Santa uses this to deliver toys to all the nice children in space in Christmas! Wow, it's pretty big!"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "giftbag0"
+	item_state_slots = list(slot_r_hand_str = "giftbag", slot_l_hand_str = "giftbag")
+
+	w_class = ITEMSIZE_LARGE
+	max_w_class = ITEMSIZE_NORMAL
+	max_storage_space = ITEMSIZE_COST_NORMAL * 100 // can store a ton of shit!
+	can_hold = list() // any
+	cant_hold = list(/obj/item/disk/nuclear)
+
+/obj/item/storage/bag/santabag/update_icon()
+	if(contents.len < 10)
+		icon_state = "giftbag0"
+	else if(contents.len < 25)
+		icon_state = "giftbag1"
+	else
+		icon_state = "giftbag2"


### PR DESCRIPTION
## About The Pull Request
Repaths santabag to take advantage of some of it's code

## Changelog
Repaths santabag from /obj/item/storage/backpack/santabag to /obj/item/storage/bag/santabag to take advantage of the storage icon update behavior. It was also broken before this, and would vanish on icon changes.

:cl: Will
fix: Santabag is now actually a bag
/:cl:
