### PR TITLE
allow precision item placement on casino table

### DIFF
--- a/code/modules/casino/casino.dm
+++ b/code/modules/casino/casino.dm
@@ -23,9 +23,12 @@
 	AddElement(/datum/element/climbable)
 
 /obj/structure/casino_table/attackby(obj/item/W, mob/user)
-	if(item_place)
-		user.drop_item(src.loc)
-	return
+	if(!item_place)
+		return
+	if(user.unEquip(W, 0, loc) && user.client?.prefs?.read_preference(/datum/preference/toggle/precision_placement))
+		auto_align(W, click_parameters) // Precisely place item like this is a normal table
+		return
+	user.drop_item(loc)
 
 /obj/structure/casino_table/roulette_table
 	name = "roulette"

--- a/code/modules/casino/casino.dm
+++ b/code/modules/casino/casino.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	AddElement(/datum/element/climbable)
 
-/obj/structure/casino_table/attackby(obj/item/W, mob/user)
+/obj/structure/casino_table/attackby(obj/item/W, mob/user, hit_modifier, click_parameters)
 	if(!item_place)
 		return
 	if(user.unEquip(W, 0, loc) && user.client?.prefs?.read_preference(/datum/preference/toggle/precision_placement))


### PR DESCRIPTION
## About The Pull Request
Nothing special, makes the casino table structure use the same precision placement code that tables do to increase IMMERSION.

## Changelog
Allows precision item placement on casino tables.

:cl: Will
qol: Items can now be placed on casino tables with click precision, like normal tables.
/:cl:
