### PR TITLE
slug slime does not stack forever

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/slug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/slug.dm
@@ -96,6 +96,8 @@
 		return
 	if(istype(get_turf(src), /turf/simulated/floor/water)) //Important to stop my_slime from filling with null entries in water.
 		return
+	if(locate(/obj/effect/slug_glue) in get_turf(src)) // Don't stack slime forever
+		return
 	var/obj/effect/slug_glue/G = new /obj/effect/slug_glue/(get_turf(src))
 	G.my_slug = src
 	my_slime += G


### PR DESCRIPTION
## About The Pull Request
The slugslime proc has no safety for splooting the same turf

## Changelog
Prevents slugs from applying slime to an already slime covered turf

:cl: Will
fix: Slugs can no longer apply slime to a turf already covered in their slime
/:cl:
