### PR TITLE
Disposal Atom Flushed Signal

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -858,6 +858,8 @@
 #define COMSIG_ATOM_SET_LIGHT_FLAGS "atom_set_light_flags"
 ///Called right after the atom changes the value of light_flags to a different one, from base of [/atom/proc/set_light_flags]: (old_flags)
 #define COMSIG_ATOM_UPDATE_LIGHT_FLAGS "atom_update_light_flags"
+///Called right after the atom is flushed into a disposal holder and sent through the disposal network: (/obj/structure/disposalholder)
+#define COMSIG_ATOM_DISPOSAL_FLUSHED "atom_disposal_flushed"
 
 // /datum/element/light_eater
 ///from base of [/datum/element/light_eater/proc/table_buffet]: (list/light_queue, datum/light_eater)

--- a/code/modules/recycling/disposal_holder.dm
+++ b/code/modules/recycling/disposal_holder.dm
@@ -53,6 +53,7 @@
 		if(istype(AM, /mob/living/silicon/robot/drone))
 			var/mob/living/silicon/robot/drone/drone = AM
 			src.destinationTag = drone.mail_destination
+		SEND_SIGNAL(AM, COMSIG_ATOM_DISPOSAL_FLUSHED, src)
 
 // movement process, persists while holder is moving through pipes
 /obj/structure/disposalholder/proc/move()


### PR DESCRIPTION
## About The Pull Request
Adds a signal that is fired when an atom is put into a disposal holder being flushed into the disposal network. With all the disposal work done, and Reo talking about doing new disposal stuff, this seemed like a useful signal. Maybe a circuit that detects it?

## Changelog
Adds COMSIG_ATOM_DISPOSAL_FLUSHED signal. Fired from disposal_holder.init(). Called on each item added to the disposal holder itself, but not sub-contents of each item.

:cl: Will
code: Adds atom disposal flushed signal, sent from items when they are flushed into the disposal network
/:cl:
