### PR TITLE
Transit Tubes Use Forcemove

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -42,7 +42,7 @@
 
 /obj/structure/transit_tube_pod/Destroy()
 	for(var/atom/movable/AM in contents)
-		AM.loc = loc
+		AM.forceMove(get_turf(src))
 
 	. = ..()
 
@@ -53,7 +53,7 @@
 	switch(severity)
 		if(1.0)
 			for(var/atom/movable/AM in contents)
-				AM.loc = loc
+				AM.forceMove(get_turf(src))
 				AM.ex_act(severity++)
 
 			qdel(src)
@@ -61,7 +61,7 @@
 		if(2.0)
 			if(prob(50))
 				for(var/atom/movable/AM in contents)
-					AM.loc = loc
+					AM.forceMove(get_turf(src))
 					AM.ex_act(severity++)
 
 				qdel(src)
@@ -96,7 +96,7 @@
 		to_chat(AM, span_warning("The tube's support pylons block your way."))
 		return ..()
 	else
-		AM.loc = src.loc
+		AM.forceMove(get_turf(src))
 		to_chat(AM, span_info("You slip under the tube."))
 
 /obj/structure/transit_tube/station/Bumped(mob/AM as mob|obj)
@@ -106,7 +106,7 @@
 				to_chat(AM, span_notice("The pod is already occupied."))
 				return
 			else if(!pod.moving && (pod.dir in directions()))
-				AM.loc = pod
+				AM.forceMove(pod)
 				return
 
 
@@ -313,7 +313,7 @@
 			last_delay = current_tube.enter_delay(src, next_dir)
 			sleep(last_delay)
 			set_dir(next_dir)
-			loc = next_loc // When moving from one tube to another, skip collision and such.
+			forceMove(next_loc) // When moving from one tube to another, skip collision and such.
 			density = current_tube.density
 
 			if(current_tube && current_tube.should_stop_pod(src, next_dir))
@@ -366,7 +366,7 @@
 	if(istype(mob, /mob) && mob.client)
 		// If the pod is not in a tube at all, you can get out at any time.
 		if(!(locate(/obj/structure/transit_tube) in loc))
-			mob.loc = loc
+			mob.forceMove(get_turf(src))
 			mob.client.Move(get_step(loc, direction), direction)
 
 			//if(moving && istype(loc, /turf/space))
@@ -379,7 +379,7 @@
 					if(!station.pod_moving)
 						if(direction == station.dir)
 							if(station.icon_state == "open")
-								mob.loc = loc
+								mob.forceMove(get_turf(src))
 								mob.client.Move(get_step(loc, direction), direction)
 
 							else


### PR DESCRIPTION
## About The Pull Request
Begone M.loc = src.loc

## Changelog
Updates transittubes to use forcemove() instead of directly setting loc, as this misses many critical signals and procs.

:cl: Will
refactor: transit tubes use forceMove() instead of directly setting loc
/:cl:
