### PR TITLE
Maglev track tweaks

### DIFF
--- a/maps/common/common_things.dm
+++ b/maps/common/common_things.dm
@@ -101,7 +101,9 @@
 
 // Walking on maglev tracks will shock you! Horray!
 /turf/simulated/floor/maglev/Entered(var/atom/movable/AM, var/atom/old_loc)
-	if(isliving(AM) && !(AM.is_incorporeal()) && prob(50))
+	if(locate(/obj/structure/catwalk) in src) // safe to walk over as a bridge!
+		return
+	if(isliving(AM) && prob(50))
 		track_zap(AM)
 
 /turf/simulated/floor/maglev/attack_hand(var/mob/user)
@@ -109,7 +111,8 @@
 		track_zap(user)
 
 /turf/simulated/floor/maglev/proc/track_zap(var/mob/living/user)
-	if (!istype(user)) return
+	if(!istype(user) || user.is_incorporeal())
+		return
 	if (electrocute_mob(user, shock_area, src))
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, src)

--- a/maps/common/common_things.dm
+++ b/maps/common/common_things.dm
@@ -101,10 +101,11 @@
 
 // Walking on maglev tracks will shock you! Horray!
 /turf/simulated/floor/maglev/Entered(var/atom/movable/AM, var/atom/old_loc)
+	if(!isliving(AM) || prob(50))
+		return
 	if(locate(/obj/structure/catwalk) in src) // safe to walk over as a bridge!
 		return
-	if(isliving(AM) && prob(50))
-		track_zap(AM)
+	track_zap(AM)
 
 /turf/simulated/floor/maglev/attack_hand(var/mob/user)
 	if(prob(75))


### PR DESCRIPTION
## About The Pull Request
Allows catwalks mapped over maglev tracks to act as a bridge over them. Also stops phased shadekin that touch tracks with a click from getting zapped.

## Changelog
Catwalks protect from maglev zaps
Shadekin cannot touch maglev tracks while phased

:cl: Will
add: Catwalks mapped over maglev tracks will act as a bridge
fix: Phased shadekin can no longer touch maglev tracks and get shocked
/:cl: