### PR TITLE
Beartraps for mappers

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -23,6 +23,13 @@
 	var/camo_net = FALSE
 	var/stun_length = 0.25 SECONDS
 
+/obj/item/beartrap/start_active
+	deployed = TRUE
+
+/obj/item/beartrap/Initialize(mapload)
+	. = ..()
+	update_icon()
+
 /obj/item/beartrap/proc/can_use(mob/user)
 	return (user.IsAdvancedToolUser() && !issilicon(user) && !user.stat && !user.restrained())
 


### PR DESCRIPTION
## About The Pull Request
Allows beartraps to be placed in an activated state by mappers. Hello from Outpost~

## Changelog
Adds some init code to beartraps and a subtype that starts deployed

:cl: Will
code: Allows mappers to place deployed mechanical traps properly
/:cl: