### PR TITLE
Addiction Withdrawal Shown On Body Scanners

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -192,6 +192,13 @@
 			else
 				// Using another species as base, doctors should know this to avoid some meds
 				occupantData["species"] = "[H.custom_species] \[Similar biology to [H.species.name]\]"
+
+		var/has_withdrawl = FALSE
+		for(var/addic in H.get_all_addictions())
+			if(H.get_addiction_to_reagent(addic) > 0 && H.get_addiction_to_reagent(addic) < 80)
+				has_withdrawl = TRUE
+				break
+
 		occupantData["stat"] = H.stat
 		occupantData["health"] = H.health
 		occupantData["maxHealth"] = H.getMaxHealth()
@@ -212,6 +219,8 @@
 		occupantData["bodyTempF"] = (((H.bodytemperature-T0C) * 1.8) + 32)
 
 		occupantData["hasBorer"] = H.has_brain_worms()
+		occupantData["hasWithdrawl"] = has_withdrawl
+
 		occupantData["colourblind"] = null
 		for(var/datum/modifier/M in H.modifiers)
 			if(!isnull(M.wire_colors_replace))
@@ -397,6 +406,7 @@
 
 	dat = span_blue(span_bold("Occupant Statistics:")) + "<br>" //Blah obvious
 	if(istype(occupant)) //is there REALLY someone in there?
+		var/has_withdrawl = ""
 		if(ishuman(occupant))
 			var/mob/living/carbon/human/H = occupant
 			var/speciestext = H.species.name
@@ -408,6 +418,11 @@
 				else
 					speciestext = "[H.custom_species] \[Similar biology to [H.species.name]\]"
 					dat += span_blue("Sapient Species: [speciestext]") + "<BR>"
+			for(var/addic in H.get_all_addictions())
+				if(H.get_addiction_to_reagent(addic) > 0 && H.get_addiction_to_reagent(addic) < 80)
+					var/datum/reagent/R = SSchemistry.chemical_reagents[addic]
+					has_withdrawl = R.name
+					break
 		var/t1
 		switch(occupant.stat) // obvious, see what their status is
 			if(0)
@@ -601,6 +616,8 @@
 			dat += span_red("Cataracts detected.") + "<BR>"
 		if(occupant.disabilities & NEARSIGHTED)
 			dat += span_red("Retinal misalignment detected.") + "<BR>"
+		if(has_withdrawl != "")
+			dat += span_red("Experiencing withdrawal symptoms!") + "<BR>[has_withdrawl]"
 		if(HUSK in occupant.mutations) // VOREstation edit
 			dat += span_red("Anatomical structure lost, resuscitation not possible!") + "<BR>"
 	else

--- a/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainAbnormalities.tsx
+++ b/tgui/packages/tgui/interfaces/BodyScanner/BodyScannerMainAbnormalities.tsx
@@ -13,7 +13,8 @@ export const BodyScannerMainAbnormalities = (props: { occupant: occupant }) => {
     occupant.nearsighted ||
     occupant.brokenspine ||
     occupant.hasVirus ||
-    occupant.husked;
+    occupant.husked ||
+    occupant.hasWithdrawl;
 
   hasAbnormalities =
     hasAbnormalities ||

--- a/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
@@ -52,7 +52,7 @@ export const abnormalities: (string | ((occupant: occupant) => string))[][] = [
   [
     'hasWithdrawl',
     'bad',
-    (occupant) => 'Chemical dependancy has begun withdrawal! Inaprovaline can reduce symptoms.',
+    (occupant) => 'Experiencing withdrawal! Inaprovaline can reduce symptoms.',
   ],
 ];
 

--- a/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/constants.ts
@@ -49,6 +49,11 @@ export const abnormalities: (string | ((occupant: occupant) => string))[][] = [
     'bad',
     (occupant) => 'Anatomical structure lost, resuscitation not possible!',
   ],
+  [
+    'hasWithdrawl',
+    'bad',
+    (occupant) => 'Chemical dependancy has begun withdrawal! Inaprovaline can reduce symptoms.',
+  ],
 ];
 
 export const damages: string[][] = [

--- a/tgui/packages/tgui/interfaces/BodyScanner/types.ts
+++ b/tgui/packages/tgui/interfaces/BodyScanner/types.ts
@@ -38,6 +38,7 @@ export type occupant = {
   objectPrey: number;
   weight: number;
   husked: BooleanLike;
+  hasWithdrawl: BooleanLike;
 };
 
 type reagent = { name: string; amount: number; overdose: BooleanLike };


### PR DESCRIPTION
## About The Pull Request
Something missed from one of the original addiction PRs. Withdrawal state is shown on medical's body scanner.

## Changelog
Shows withdrawal on body scanner and a hint that inappropriate helps symptoms.

:cl: Will
qol: Medical body scanner now shows if a subject is experiencing withdrawal symptoms.
/:cl: