### PR TITLE
Landmine fixes

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -102,7 +102,7 @@
 
 	if(istype(M, /mob/living/))
 		var/mob/living/mob = M
-		if(!(L.hovering || L.flying || L.is_incorporeal() || L.mob_size <= MOB_TINY))
+		if(!(mob.hovering || mob.flying || mob.is_incorporeal() || mob.mob_size <= MOB_TINY))
 			explode(M)
 
 /obj/effect/mine/attackby(obj/item/W as obj, mob/living/user as mob)


### PR DESCRIPTION
## About The Pull Request
Fixes some landmine code

## Changelog
Proper checks for flying, hovering, incorporeal, and tiny mobs not setting off landmines
Vehicles set off landmines
Shadekin no longer set off landmines while phased
Mice and other small mobs won't set off landmines

:cl: Will
fix: Flying and hovering properly checked when avoiding landmines
fix: Phased shadekin no longer set off landmines
fix: Vehicles set off landmines
balance: Tiny mobs like mice no longer set off landmines
/:cl:

