### PR TITLE
Fixes BS Belt and CE Belt not being able to hold combifans

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -158,7 +158,8 @@
 		/obj/item/stack/nanopaste,
 		/obj/item/geiger,
 		/obj/item/areaeditor/blueprints,	//It's a bunch of paper that could prolly be rolled up & slipped into the belt, not to mention CE only, see the RCD's thing above
-		/obj/item/wire_reader	//As above
+		/obj/item/wire_reader,	//As above
+		/obj/item/holosign_creator/combifan
 		)
 
 /obj/item/storage/belt/utility/chief/full
@@ -216,7 +217,8 @@
 		/obj/item/stack/material/steel,
 		/obj/item/stack/material/glass,
 		/obj/item/lightreplacer,
-		/obj/item/pickaxe/plasmacutter
+		/obj/item/pickaxe/plasmacutter,
+		/obj/item/holosign_creator/combifan
 	)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Normal tool belts can hold atmos combi-fans, this brings the list of heldable items for both Bluespace and Chief Engineer's belt to be closer as the normal belt

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guti
fix: fixed bluespace and chief engineer's belt not being able to hold onto atmos combi-fans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
