### PR TITLE
Gives the borg service fabricator all radial menus

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(robot_glass_options, list(
 		balloon_alert(user,"you are too far away.")
 		return
 
-	var/glass_choice = show_radial_menu(user, user, GLOB.robot_glass_options, radius = 70)
+	var/glass_choice = show_radial_menu(user, user, GLOB.robot_glass_options, radius = 40)
 
 	if(glass_choice)
 		balloon_alert(user, "container chosen: [glass_choice]")
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(robot_glass_options, list(
 		"dice pack (gaming)" = image(icon = 'icons/obj/dice.dmi', icon_state = "magicdicebag"),
 		"paper" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper"),
 		"pen" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "pen"))
-	var/choice = show_radial_menu(user, user, options, radius = 70)
+	var/choice = show_radial_menu(user, user, options, radius = 40)
 	if(choice)
 		mode = choice
 		playsound(src, 'sound/effects/pop.ogg', 50, 0)

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(robot_glass_options, list(
 	anchored = FALSE
 	matter = list(DEFAULT_WALL_MATERIAL = 25000)
 	var/stored_matter = 30
-	var/mode = "Container"
+	var/mode = "container"
 	var/glasstype_name = "metamorphic glass"
 
 	w_class = ITEMSIZE_NORMAL
@@ -58,11 +58,8 @@ GLOBAL_LIST_INIT(robot_glass_options, list(
 	if(!Adjacent(user) || !istype(user))
 		balloon_alert(user,"you are too far away.")
 		return
-	var/options = list()
-	for(var/key, value in GLOB.robot_glass_options)
-		options[key] = value
 
-	var/glass_choice = show_radial_menu(user, user, options, radius = 70)
+	var/glass_choice = show_radial_menu(user, user, GLOB.robot_glass_options, radius = 70)
 
 	if(glass_choice)
 		balloon_alert(user, "container chosen: [glass_choice]")

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -4,6 +4,20 @@ RSF
 
 */
 
+GLOBAL_LIST_INIT(robot_glass_options, list(
+		"metamorphic glass" = /obj/item/reagent_containers/food/drinks/metaglass,
+		"metamorphic pint glass" = /obj/item/reagent_containers/food/drinks/metaglass/metapint,
+		"half-pint glass" = /obj/item/reagent_containers/food/drinks/glass2/square,
+		"rocks glass" = /obj/item/reagent_containers/food/drinks/glass2/rocks,
+		"milkshake glass" = /obj/item/reagent_containers/food/drinks/glass2/shake,
+		"cocktail glass" = /obj/item/reagent_containers/food/drinks/glass2/cocktail,
+		"shot glass" = /obj/item/reagent_containers/food/drinks/glass2/shot,
+		"pint glass" = /obj/item/reagent_containers/food/drinks/glass2/pint,
+		"mug" = /obj/item/reagent_containers/food/drinks/glass2/mug,
+		"wine glass" = /obj/item/reagent_containers/food/drinks/glass2/wine,
+		"condiment bottle" = /obj/item/reagent_containers/food/condiment
+		))
+
 /obj/item/rsf
 	name = "\improper Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
@@ -16,21 +30,7 @@ RSF
 	matter = list(DEFAULT_WALL_MATERIAL = 25000)
 	var/stored_matter = 30
 	var/mode = "Container"
-	var/obj/item/reagent_containers/glasstype = /obj/item/reagent_containers/food/drinks/metaglass
-
-	var/list/container_types = list(
-		"metamorphic glass" = /obj/item/reagent_containers/food/drinks/metaglass,
-		"metamorphic pint glass" = /obj/item/reagent_containers/food/drinks/metaglass/metapint,
-		"half-pint glass" = /obj/item/reagent_containers/food/drinks/glass2/square,
-		"rocks glass" = /obj/item/reagent_containers/food/drinks/glass2/rocks,
-		"milkshake glass" = /obj/item/reagent_containers/food/drinks/glass2/shake,
-		"cocktail glass" = /obj/item/reagent_containers/food/drinks/glass2/cocktail,
-		"shot glass" = /obj/item/reagent_containers/food/drinks/glass2/shot,
-		"pint glass" = /obj/item/reagent_containers/food/drinks/glass2/pint,
-		"mug" = /obj/item/reagent_containers/food/drinks/glass2/mug,
-		"wine glass" = /obj/item/reagent_containers/food/drinks/glass2/wine,
-		"condiment bottle" = /obj/item/reagent_containers/food/condiment
-		)
+	var/glasstype_name = "metamorphic glass"
 
 	w_class = ITEMSIZE_NORMAL
 
@@ -58,16 +58,28 @@ RSF
 	if(!Adjacent(user) || !istype(user))
 		balloon_alert(user,"you are too far away.")
 		return
-	var/glass_choice = tgui_input_list(user, "Please choose which type of glass you would like to produce.", "Glass Choice", container_types)
+	var/options = list()
+	for(var/key, value in GLOB.robot_glass_options)
+		options[key] = value
+
+	var/glass_choice = show_radial_menu(user, user, options, radius = 70)
 
 	if(glass_choice)
-		glasstype = container_types[glass_choice]
-	else
-		glasstype = /obj/item/reagent_containers/food/drinks/metaglass
+		balloon_alert(user, "container chosen: [glass_choice]")
+		glasstype_name = glass_choice
 
 /obj/item/rsf/attack_self(mob/user as mob)
-	var/options = list("card deck", "card deck (big)", "casino chips (replica) x200", "cigarette", "container", "dice pack (d6)", "dice pack (gaming)", "paper", "pen")
-	var/choice = tgui_input_list(user, "Please choose what item you would like to synthesize.", "Rapid Service Fabricator", options, mode)
+	var/options = list(
+		"card deck" = image(icon = 'icons/obj/playing_cards.dmi', icon_state = "deck"),
+		"card deck (big)" = image(icon = 'icons/obj/playing_cards.dmi', icon_state = "deck"),
+		"casino chips (replica) x200" = image(icon = 'icons/obj/casino.dmi', icon_state = "spacecasinocash200"),
+		"cigarette" = image(icon = 'icons/inventory/face/item.dmi', icon_state = "cig"),
+		"container" = GLOB.robot_glass_options[glasstype_name],
+		"dice pack (d6)" = image(icon = 'icons/obj/dice.dmi', icon_state = "dicebag"),
+		"dice pack (gaming)" = image(icon = 'icons/obj/dice.dmi', icon_state = "magicdicebag"),
+		"paper" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper"),
+		"pen" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "pen"))
+	var/choice = show_radial_menu(user, user, options, radius = 70)
 	if(choice)
 		mode = choice
 		playsound(src, 'sound/effects/pop.ogg', 50, 0)
@@ -106,6 +118,7 @@ RSF
 			product = new /obj/item/clothing/mask/smokable/cigarette()
 			used_energy = 10
 		if("container")
+			var/glasstype = GLOB.robot_glass_options[glasstype_name]
 			product = new glasstype()
 			used_energy = 50
 		if("dice pack (d6)")


### PR DESCRIPTION

## About The Pull Request

The RSF now utilizes all pretty pictures...

![dreamseeker_2025-09-19_00-29-43](https://github.com/user-attachments/assets/a9997d48-f18f-4bae-930b-b006b2ee7c40)

## Changelog
:cl: Ryumi
qol: Cyborg Rapid-Service-Fabricators now use radial menus for all of its selection menus. Pretty pictures...
/:cl:
