### PR TITLE
Fix material stacks runtime when stacked entirely into another stack

### DIFF
--- a/code/modules/materials/sheets/_sheets.dm
+++ b/code/modules/materials/sheets/_sheets.dm
@@ -84,8 +84,8 @@
 	if(!istype(M) || material.name != M.material.name)
 		return 0
 	var/transfer = ..(S,tamount,1)
-	if(src) update_strings()
-	if(M) M.update_strings()
+	if(!QDELETED(src)) update_strings()
+	if(!QDELETED(M)) M.update_strings()
 	return transfer
 
 /obj/item/stack/material/attack_self(var/mob/user)


### PR DESCRIPTION
## About The Pull Request
Stacking one stack entirely into another results in a runtime. This happens now because the material datum reference is now cleaned on Destroy() but the old code still expected it to be present.

## Changelog
Fixes stacking materials by checking if the stack was qdeleted before updating string data. Previously it only checked if the reference vars used were null. Which will not protect it from qdeleted stacks with nulled material vars.

:cl: Will
fix: Runtime when combining one stack entirely into another
/:cl:
