### PR TITLE
Boneless Trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -853,7 +853,7 @@
 
 /datum/trait/negative/boneless/major
 	name = "Boneless, Major"
-	desc = "You have no bones! Though your limbs are also much, much easier to gib in exchange. (Seriously this can result in one shot deaths and similar)"
+	desc = "You have no bones! Your limbs are also much, much easier to gib in exchange. (Seriously this can result in one shot deaths and similar)"
 	cost = -6 //For reference, getting hit in the head with a welder 3 times kills you. Head has 37.5 HP. Reaching that cap = instant death
 	limb_health = 0.5
 

--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -828,3 +828,47 @@
 	addiction = REAGENT_ID_ASUSTENANCE
 	custom_only = FALSE
 	hidden = TRUE //Disabled on Virgo
+
+/*
+ * So, I know what you're thinking.
+ * "Why is this a negative trait? It sounds like a positive one!"
+ * In theory, yes. Being unable to have your limbs break DOES sound like a good thing!
+ * However, that is where limb code comes into play.
+ * Normally, with highly damaged limbs, you have a RNG(X)% chance for it to be sliced off if it takes a lot of damage and the damage from the blow is over a certain threshold.
+ * Additionally, limbs have a 'maximum damage' it can reach in which it can't reach anymore. Your arm, for example, is 80 damage maximum. Head 75.
+ * Trying to hit it more won't do any more damage, just constantly roll chances (if the hitting blow is strong enough) to cut it off/gib it.
+ * With this trait, however, as soon as you reach that maximum damage, your limb IMMEDIATELY gibs. No RNG chance rolls. 'attack must be X strong to hit it off'. Nothing.
+ * Additionally, normal limbloss code has one-shot protection and prevents bullets from gibbing limbs. This makes you forfeit that protection.
+ */
+/datum/trait/negative/boneless
+	name = "Boneless"
+	desc = "You have no bones! Though your limbs will gib once reaching their maximum limit in exchange."
+	cost = -3
+	custom_only = TRUE
+	can_take = ORGANICS
+	is_genetrait = FALSE //genetically removes your bones? nah.
+	hidden = FALSE
+	///How much our limbs max_damage is multiplied by.
+	var/limb_health = 1
+
+/datum/trait/negative/boneless/major
+	name = "Boneless, Major"
+	desc = "You have no bones! Though your limbs are also much, much easier to gib in exchange. (Seriously this can result in one shot deaths and similar)"
+	cost = -6 //For reference, getting hit in the head with a welder 3 times kills you. Head has 37.5 HP. Reaching that cap = instant death
+	limb_health = 0.5
+
+/datum/trait/negative/boneless/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	for(var/obj/item/organ/external/ex_organ in H.organs)
+		ex_organ.cannot_break = TRUE
+		ex_organ.dislocated = -1
+		ex_organ.nonsolid = TRUE //ESSENTIAL for boneless. Otherwise it acts like a normal limb.
+		ex_organ.spread_dam = TRUE
+		ex_organ.max_damage = floor(ex_organ.max_damage * limb_health)
+
+		if(istype(ex_organ, /obj/item/organ/external/head))
+			ex_organ.encased = FALSE //you can just reach in and grab it
+			ex_organ.cannot_gib = FALSE
+
+		else if(istype(ex_organ, /obj/item/organ/external/chest))
+			ex_organ.encased = FALSE

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1035,9 +1035,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 					I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 
 			for(var/obj/item/I in src)
-				if(I.w_class <= ITEMSIZE_SMALL)
-					qdel(I)
-					continue
 				I.forceMove(droploc)
 				I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Boneless trait for people that lack bones (Synx), wouldn't logically have bones (plant-people), goopy people that aren't quite prometheans but are still gooey, or otherwise!

Adds two variants: Boneless and Boneless Major

Boneless: Gives -3 trait points. Limb health remains untouched.
Boneless, Major: Gives -6 trait points. Limb health is reduced by half.

Copy-pasting my coder comment here to explain why this is a _very_ harsh negative, even though it sounds like an upside on the surface:

So, I know what you're thinking.
Why is this a negative trait? It sounds like a positive one!"
In theory, yes. Being unable to have your limbs break DOES sound like a good thing!
However, that is where limb code comes into play.
Normally, with highly damaged limbs, you have a RNG(X)% chance for it to be sliced off if it takes a lot of damage and the damage from the blow is over a certain threshold.
Additionally, limbs have a 'maximum damage' it can reach in which it can't reach anymore. Your arm, for example, is 80 damage maximum. Head 75.
Trying to hit it more won't do any more damage, just constantly roll chances (if the hitting blow is strong enough) to cut it off/gib it.
With this trait, however, as soon as you reach that maximum damage, your limb IMMEDIATELY gibs. No RNG chance rolls. 'attack must be X strong to hit it off'. Nothing.
Additionally, normal limbloss code has one-shot protection and prevents bullets from gibbing limbs. This makes you forfeit that protection.


For example, with the major version, you can hit someone in the head 3 times with a lit welder and they will die. Twice if they have burn weakness. Likewise, having a brain (with no head) makes surgery to bring someone back alive harder.


<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Diana
add: Adds boneless trait
fix: Brains no longer qdel() if the head is gibbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
