### PR TITLE
Grab Drop Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -480,15 +480,13 @@
 		if(lgrab.affecting)
 			visible_message(span_danger("[user] has broken [src]'s grip on [lgrab.affecting]!"))
 			success = TRUE
-		spawn(1)
-			qdel(lgrab)
+		drop_from_inventory(lgrab)
 	if(istype(r_hand, /obj/item/grab))
 		var/obj/item/grab/rgrab = r_hand
 		if(rgrab.affecting)
 			visible_message(span_danger("[user] has broken [src]'s grip on [rgrab.affecting]!"))
 			success = TRUE
-		spawn(1)
-			qdel(rgrab)
+		drop_from_inventory(rgrab)
 	return success
 
 /*


### PR DESCRIPTION
## About The Pull Request
Shoving with disarm could result in you dropping your grab manually using incorrect code. 

## Changelog
Fixed a situation where combat grabs could be dropped as items again

:cl: Will
fix: Disarming push attacks causing combat grabs to drop as items.
/:cl: