### PR TITLE
Makes poker chips half scale

### DIFF
--- a/code/modules/economy/casinocash.dm
+++ b/code/modules/economy/casinocash.dm
@@ -51,6 +51,8 @@
 	var/access = list()
 	access = ACCESS_CRATE_CASH
 	var/worth = 0
+	icon_scale_x = 0.5
+	icon_scale_y = 0.5
 
 /obj/item/spacecasinocash/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/spacecasinocash))
@@ -215,6 +217,8 @@
 	gender = PLURAL
 	icon = 'icons/obj/casino.dmi'
 	icon_state = "spacecasinocash1"
+	icon_scale_x = 0.5
+	icon_scale_y = 0.5
 	opacity = 0
 	density = 0
 	anchored = 0.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Does as it says on the tin. They're more appropriately sized and less visually obtrusive this way.
<img width="183" height="141" alt="dreamseeker_2025-09-22_02-58-11" src="https://github.com/user-attachments/assets/a9ffe2ae-86a0-4cf3-a3eb-ffacfafabace" />


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
image: Halved the size of playing chips' icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
