### PR TITLE
Increases cost of virus immunity

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -535,7 +535,7 @@
 /datum/trait/positive/virus_immune
 	name = "Virus Immune"
 	desc = "You are immune to viruses."
-	cost = 1
+	cost = 3
 
 	can_take = ORGANICS
 	var_changes = list("virus_immune" = TRUE)


### PR DESCRIPTION

## About The Pull Request
Virus immunity goes from 1 -> 3 points

An **IMMUNITY** trait should not be 1 point. Resistance, sure. 
But outright immunity is absurd.
## Changelog
:cl: Diana
balance: Makes Virus Immunity trait 3 points
/:cl:
