### PR TITLE
Oil and blood with no dna can be streaked again

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -118,9 +118,9 @@
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
 					S.handle_movement(src,(H.m_intent == I_RUN ? 1 : 0), H) // handle_movement now needs to know who is moving, for inshoe steppies
-					if(S.track_blood && S.forensic_data?.has_blooddna())
+					if(S.track_blood)
 						bloodDNA = S.forensic_data.get_blooddna()
-						bloodcolor=S.blood_color
+						bloodcolor = S.blood_color
 						S.track_blood--
 			else
 				if(H.track_blood && H.feet_blood_DNA)


### PR DESCRIPTION
## About The Pull Request
Oil and blood spawned from maintenance have no dna, this prevent streaking them along the ground. However this check was only done on shoes. 

## Changelog
Fixes shoes being unable to spread bloody footsteps if the blood was mapspawned

:cl: Will
fix: Wearing shoes no longer prevents map spawned blood from spreading with footsteps
/:cl:
