### PR TITLE
remove dead proc in gravgen UI

### DIFF
--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -330,7 +330,6 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	update_list()
 	update_gravity(new_state)
 	update_icon()
-	src.updateUsrDialog()
 
 	if(alert)
 		shake_everyone()


### PR DESCRIPTION
## About The Pull Request
This is blocking work on no sleep in Destroy(), it does nothing as the UI as already tgui.

## Changelog
Removed byond UI line that does nothing

:cl: Will
code: Tiny cleanup in gravgen UI code
/:cl:
