### PR TITLE
Fixes Luck 7 map needing power (oops)

### DIFF
--- a/maps/gateway_vr/lucky_7.dm
+++ b/maps/gateway_vr/lucky_7.dm
@@ -15,6 +15,7 @@
 	icon_state = "away1"
 	ambience = AMBIENCE_CASINO
 	flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_BLOCK_INSTANT_BUILDING
+	requires_power = FALSE
 
 /area/awaymission/lucky7/casinofloor
 	name = "\improper Gateway - Casino Floor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Apparently when making https://github.com/VOREStation/VOREStation/pull/18561 I didn't notice that the event areas still needed power for some reason, so no lighting or devices work. Whoops! Let's, um, fix that real quick.


