### PR TITLE
Door after_attack behavior fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -663,6 +663,8 @@ About the new airlock wires panel:
 	if(istype(C, /obj/item/taperoll))
 		return
 
+	if(istype(I,/obj/item/forensics))
+		return // Forensics item handling needs to block interaction, and block making fingerprints too
 	add_fingerprint(user)
 
 	if(!reinforcing && C.has_tool_quality(TOOL_WELDER) && !(operating > 0) && density && (health >= maxhealth || user.a_intent != I_HELP))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -663,7 +663,7 @@ About the new airlock wires panel:
 	if(istype(C, /obj/item/taperoll))
 		return
 
-	if(istype(I,/obj/item/forensics))
+	if(istype(C,/obj/item/forensics))
 		return // Forensics item handling needs to block interaction, and block making fingerprints too
 	add_fingerprint(user)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -663,8 +663,6 @@ About the new airlock wires panel:
 	if(istype(C, /obj/item/taperoll))
 		return
 
-	if(istype(C,/obj/item/forensics))
-		return // Forensics item handling needs to block interaction, and block making fingerprints too
 	add_fingerprint(user)
 
 	if(!reinforcing && C.has_tool_quality(TOOL_WELDER) && !(operating > 0) && density && (health >= maxhealth || user.a_intent != I_HELP))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -249,6 +249,8 @@
 	..()
 
 /obj/machinery/door/attackby(obj/item/I, mob/user)
+	if(istype(I,/obj/item/forensics))
+		return // Forensics item handling needs to block interaction, and block making fingerprints too
 	add_fingerprint(user)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == MAT_PLASTEEL)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -241,7 +241,7 @@
 	. = ..()
 	if(.)
 		return
-	return try_to_activate_door(user)
+	try_to_activate_door(user)
 
 /obj/machinery/door/attack_tk(mob/user)
 	if(requiresID() && !allowed(null))
@@ -249,8 +249,6 @@
 	..()
 
 /obj/machinery/door/attackby(obj/item/I, mob/user)
-	if(istype(I,/obj/item/forensics))
-		return // Forensics item handling needs to block interaction, and block making fingerprints too
 	add_fingerprint(user)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == MAT_PLASTEEL)
@@ -346,7 +344,7 @@
 				take_damage(W.force)
 		return
 
-	return try_to_activate_door(user)
+	try_to_activate_door(user)
 
 /obj/machinery/door/proc/try_to_activate_door(mob/user)
 	add_fingerprint(user)


### PR DESCRIPTION
## About The Pull Request
Forensics items relied on old door behaviors. This fixes that to make it possible to collect evidence again. 

## Changelog
Corrects door's attack_by return so after_attack() behaves correctly for items like forensics swabs and samplekits.

:cl: Will
fix: Forensics items work on doors and airlocks again
/:cl:
