### PR TITLE
Adds "start disabled" option to Reflexive Biting + Personal Bubble

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1560,10 +1560,12 @@
 	desc = "You will reflexively bite hands that attempt to pat your head or boop your nose, this can be toggled off."
 	cost = 0
 	custom_only = FALSE
+	has_preferences = list("biting_toggle" = list(TRAIT_PREF_TYPE_BOOLEAN, "Enabled on spawn", TRAIT_NO_VAREDIT_TARGET, FALSE))
 
-/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H, var/list/trait_prefs)
 	..()
-	H.touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
+	if(trait_prefs && trait_prefs["biting_toggle"])
+		H.touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
 	add_verb(H, /mob/living/proc/toggle_patting_defence)
 
 /datum/trait/neutral/personal_space

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1560,9 +1560,9 @@
 	desc = "You will reflexively bite hands that attempt to pat your head or boop your nose, this can be toggled off."
 	cost = 0
 	custom_only = FALSE
-	has_preferences = list("biting_toggle" = list(TRAIT_PREF_TYPE_BOOLEAN, "Enabled on spawn", TRAIT_NO_VAREDIT_TARGET, FALSE))
+	has_preferences = list("biting_toggle" = list(TRAIT_PREF_TYPE_BOOLEAN, "Enabled on spawn", TRAIT_NO_VAREDIT_TARGET, TRUE))
 
-/datum/trait/neutral/patting_defence/apply(var/datum/species/S,var/mob/living/carbon/human/H, var/list/trait_prefs)
+/datum/trait/neutral/patting_defence/apply(var/datum/species/S, var/mob/living/carbon/human/H, var/list/trait_prefs)
 	..()
 	if(trait_prefs && trait_prefs["biting_toggle"])
 		H.touch_reaction_flags |= SPECIES_TRAIT_PATTING_DEFENCE
@@ -1573,10 +1573,12 @@
 	desc = "You are adept at avoiding unwanted physical contact and dodge it with ease. You will reflexively dodge any attempt to hug, pat, boop, lick, sniff you or even shake your hand, this can be toggled off."
 	cost = 0
 	custom_only = FALSE
+	has_preferences = list("bubble_toggle" = list(TRAIT_PREF_TYPE_BOOLEAN, "Enabled on spawn", TRAIT_NO_VAREDIT_TARGET, TRUE))
 
-/datum/trait/neutral/personal_space/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+/datum/trait/neutral/personal_space/apply(var/datum/species/S, var/mob/living/carbon/human/H, var/list/trait_prefs)
 	..()
-	H.touch_reaction_flags |= SPECIES_TRAIT_PERSONAL_BUBBLE
+	if(trait_prefs && trait_prefs["bubble_toggle"])
+		H.touch_reaction_flags |= SPECIES_TRAIT_PERSONAL_BUBBLE
 	add_verb(H, /mob/living/proc/toggle_personal_space)
 
 /* // Commented out in lieu of finding a better solution.


### PR DESCRIPTION

## About The Pull Request

Adds to the Reflexive Biting and Personal Bubble traits an extra option to let you start with it disabled on spawn - for people who don't wanna default to chomping hands but want the option to be there in case it's desired.
<img width="226" height="60" alt="image" src="https://github.com/user-attachments/assets/6e73b523-1250-4146-a13e-39534aaa9d58" />


## Changelog
:cl: Ryumi
qol: Added an option to the Reflexive Biting and Personal Bubble traits that lets you choose to start with them enabled or disabled.
/:cl:
