### PR TITLE
Chargeblade should not destroy when dropped

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -407,7 +407,6 @@
 	active_armourpen = 25
 	projectile_parry_chance = 40
 	colorable = TRUE
-	item_flags = DROPDEL | NOSTRIP
 
 	hitcost = 75
 


### PR DESCRIPTION
## About The Pull Request
This item was accidentally flagged the same as the energy sword made by rigs/implants. However it functions on its own and can even be printed form science.

## Changelog
Removes dropdel and nostrip from chargeblade.

:cl: Will
fix: Charge blade no longer deletes itself on drop
/:cl:
