### PR TITLE
Upports craftable operating tables

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -72,3 +72,14 @@
 	var/obj/item/material/twohanded/spear/S = result
 	S.set_material(M.material.name)
 	qdel(M)
+
+/datum/crafting_recipe/surgerytable
+	name = "surgery table"
+	result = /obj/machinery/optable
+	reqs = list(
+		list(/obj/item/stack/material/silver = 12),
+		list(/obj/item/stack/rods = 10),
+		list(/obj/item/stack/material/leather = 1)
+	)
+	time = 240
+	category = CAT_MISC


### PR DESCRIPTION

## About The Pull Request

Upports craftable operating tables from https://github.com/CHOMPStation2/CHOMPStation2/pull/7128 .

## Changelog
:cl:
add: Added operating tables to the crafting menu. You'll need 12 silver, 10 metal rods, and one leather!
/:cl:
