### PR TITLE
Makes suit sensors choice menu default to current sensor setting

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1252,12 +1252,22 @@
 		to_chat(user, "This suit does not have any sensors.")
 		return 0
 
-	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
-	var/switchMode = tgui_input_list(user, "Select a sensor mode:", "Suit Sensor Mode", modes)
+	var/list/modes = list(
+		"Off" = SUIT_SENSOR_OFF,
+		"Binary sensors" = SUIT_SENSOR_BINARY,
+		"Vitals tracker" = SUIT_SENSOR_VITAL,
+		"Tracking beacon" = SUIT_SENSOR_TRACKING
+		)
+	var/default_choice
+	for(var/key, value in modes)
+		if(value == sensor_mode)
+			default_choice = key
+			break
+	var/switchMode = tgui_input_list(user, "Select a sensor mode:", "Suit Sensor Mode", modes, default_choice)
 	if(get_dist(user, src) > 1)
 		to_chat(user, "You have moved too far away.")
 		return
-	sensor_mode = modes.Find(switchMode) - 1
+	sensor_mode = modes[switchMode]
 
 	if (src.loc == user)
 		switch(sensor_mode)


### PR DESCRIPTION

## About The Pull Request

Does as it says on the tin. Now it can be a bit clearer to players setting suit sensors what they already had their suit sensors set to when going to change it!

## Changelog
:cl: Ryumi
qol: The suit sensors setting menu now defaults to whatever the outfit's suit sensors are already set to. Now you can be totally sure whether or not you set them on or off!
/:cl:
