### PR TITLE
Saves your PDA message if you get a messinging server error

### DIFF
--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -183,8 +183,8 @@
 		U.log_message("(PDA: [src.name] | [U.real_name]) sent \"[t]\" to [P.name]", LOG_PDA)
 		to_chat(U, "[icon2html(pda,U.client)] <b>Sent message to [P.owner] ([P.ownjob]), </b>\"[t]\"")
 	else
-		to_chat(U, span_notice("ERROR: Messaging server is not responding."))
-		to_chat(U, span_notice("However, your message has been saved: ") + t)
+		to_chat(U, span_notice("ERROR: Messaging server is not responding.\n\n\
+			However, your message has been saved: ") + t)
 
 /datum/data/pda/app/messenger/proc/available_pdas()
 	var/list/names = list()


### PR DESCRIPTION

## About The Pull Request

See changelog.

## Changelog
:cl: Ryumi
qol: When using a PDA, if you receive a messinging server error when trying to send a PDA message to someone, your message will now be saved. Now you won't have to retype everything because the servers got quirky!
/:cl:
