### PR TITLE
Makes rigsuits instead use balloon alerts when deploying parts

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -739,7 +739,7 @@
 				holder = use_obj.loc
 				if(istype(holder))
 					if(use_obj && check_slot == use_obj)
-						to_chat(H, span_boldnotice("Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly."))
+						balloon_alert(H, "your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.")
 						playsound(src, 'sound/machines/rig/rigservo.ogg', 10, FALSE)
 						use_obj.canremove = TRUE
 						holder.drop_from_inventory(use_obj)
@@ -758,7 +758,7 @@
 					to_chat(H, span_danger("You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way."))
 					return
 			else
-				to_chat(H, span_notice("Your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly."))
+				balloon_alert(H, "your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly.")
 				playsound(src, 'sound/machines/rig/rigservo.ogg', 10, FALSE)
 
 	if(piece == "helmet" && helmet?.light_system == STATIC_LIGHT)


### PR DESCRIPTION
## About The Pull Request

Makes suit deploy/retract notifications use balloon alerts instead of chat logs, as they get very spammy for rigsuit users and aren't necessary to keep in our chat logs. However, error messages are kept logged as they are important things for a player to read to understand the issue.

![dreamseeker_2025-10-09_01-03-11](https://github.com/user-attachments/assets/ff1330ae-4503-411d-a307-e74b6aa14818)

## Changelog
:cl: Ryumi
qol: Rigsuits now use balloon alerts instead of logged messages when parts of them are deployed and retracted. No more log spam for rigsuit users!
/:cl:
