### PR TITLE
Slipfix

### DIFF
--- a/code/datums/components/turfslip.dm
+++ b/code/datums/components/turfslip.dm
@@ -45,7 +45,7 @@
 	SIGNAL_HANDLER
 
 	// Can the mob slip?
-	if(QDELETED(owner) || isbelly(owner.loc))
+	if(QDELETED(owner) || !isturf(owner.loc))
 		qdel(src)
 		return
 


### PR DESCRIPTION
If we're not on a turf (slipped into something like a machine) stop slipping.
## About The Pull Request
If we're not on a turf (slipped into something like a machine) stop slipping.
## Changelog
:cl Diana:
fix: Slipping will properly stop if you slip into an object.
/:cl:
