### PR TITLE
Hotfix for borg recharger view desync

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -4,6 +4,7 @@
 	desc = "A standard recharger for all devices that use power."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "recharger0"
+	flags = REMOTEVIEW_ON_ENTER
 	anchored = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 4


### PR DESCRIPTION
## About The Pull Request
This is not a full investigation of the issue, but should resolve the problem. I don't have enough info yet to debug what causes it to rarely happen.

## Changelog
Restored remote view handling on entry to borg chargers

:cl: Will
fix: Borg charger rarely locking focus to the charger itself
/:cl:
