### PR TITLE
Trims groin attack to be less wordy

### DIFF
--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -74,7 +74,7 @@
 						target.set_dir(GLOB.reverse_dir[target.dir])
 					target.apply_effect(attack_damage * 0.4, WEAKEN, armour)
 			if(BP_GROIN)
-				target.visible_message(span_warning("[target] looks like [target.p_theyre()] in pain!"), span_warning("[(target.gender=="female") ? "Oh god that hurt!" : "Oh no, not your[pick("testicles", "crown jewels", "clockweights", "family jewels", "marbles", "bean bags", "teabags", "sweetmeats", "goolies")]!"]")) // I see no easy way to fix this for non-organic or neuter characters.
+				target.visible_message(span_warning("[target] looks like [target.p_theyre()] in pain!"), span_warning("Oh god that hurt!"))
 				target.apply_effects(stutter = attack_damage * 2, agony = attack_damage* 3, blocked = armour)
 			if(BP_L_LEG, BP_L_FOOT, BP_R_LEG, BP_R_FOOT)
 				if(!target.lying)


### PR DESCRIPTION

## About The Pull Request
Makes it so being attacked in the groin as a female sex but male gender character is less wordy and doesn't run off the presumption that you have "sweetmeats" between your legs
## Changelog
:cl: Diana
qol: Being attacked in the groin gives a less wordy message
/:cl:
