### PR TITLE
Recharger fixes & QoL

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 					continue
 				shot_to_charge.shots_left++
 				icon_state = icon_state_charging
-				update_use_power(USE_POWER_ACTIVE * shots_charged)
+				update_use_power(USE_POWER_ACTIVE)
 				return //only heal one at a time.
 		//If the chambered battery AND the magazine are all full, we are done.
 		icon_state = icon_state_charged
@@ -222,7 +222,7 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 					continue
 				shot_to_charge.shots_left++
 				icon_state = icon_state_charging
-				update_use_power(USE_POWER_ACTIVE * shots_charged)
+				update_use_power(USE_POWER_ACTIVE)
 				return
 		icon_state = icon_state_charged
 		update_use_power(USE_POWER_IDLE)


### PR DESCRIPTION

## About The Pull Request
Converts recharger lists from an individual-item list into a global list (saves memory)
Makes the recharger able to charge magnetic guns (seemingly missed. Wall charger could charge it but NOT the normal charger, even though normal charger is meant to be able to charge everything the wall charger can)
Makes the recharger able to charge cell_loaded guns and cell_mag (QoL)
Makes it so battery exempt devices have their own global list instead of being typechecked.
## Changelog
:cl: Diana
code: Rechargers are now less memory intensive
qol: Cell loaded guns (ml3m, nsfw) can be charged in rechargers now
qol: cell magazines can be charged in rechargers now
/:cl:
