### PR TITLE
Fix Feline Taur Loaf Icon State Typo

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -617,9 +617,9 @@
 
 /datum/sprite_accessory/tail/taur/feline/feline_2c_wag
 	name = "Feline 3-color (Taur, Fat vwag)"
-	icon_state = "feline2_s"
-	extra_overlay = "feline2_markings"
-	extra_overlay2 = "feline2_markings_2"
+	icon_state = "fatfeline2_s"
+	extra_overlay = "fatfeline2_markings"
+	extra_overlay2 = "fatfeline2_markings_2"
 	ani_state = "fatfeline_s"
 	extra_overlay_w = "fatfeline_markings_vwag"
 	extra_overlay2_w = "fatfeline_markings_vwag2"


### PR DESCRIPTION

## About The Pull Request

Fixed a typo preventing Feline 3-color (Taur, Fat vwag) from using its loaf sprite.

## Changelog

:cl:
fix: Feline 3-color (Taur, Fat vwag) loaf sprite
/:cl:

