### PR TITLE
Fixes Stock Part Benchmark Experiment Exploit

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -298,7 +298,6 @@
 	desc = "Used in the construction of computers and other devices with a interactive console."
 	icon_state = "screen"
 	origin_tech = list(TECH_MATERIAL = 1)
-	rating = 5 // these are actually Really Important for some things??
 	matter = list(MAT_GLASS = 200)
 
 /obj/item/stock_parts/capacitor


### PR DESCRIPTION

## About The Pull Request
Fixes #18669. Console screens were rating 5, despite no machines ever seeming to check the rating of the console screen. They are now rating 1, and as such will not count for stock part benchmark experiments.
## Changelog
:cl:
fix: Exploit where console screens would count for all stock part benchmark experiments.
/:cl:
