### PR TITLE
Photosynthesis and photodegredation should not affect phased shadekin

### DIFF
--- a/code/datums/components/traits/burninlight.dm
+++ b/code/datums/components/traits/burninlight.dm
@@ -23,6 +23,8 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.is_incorporeal())
+		return
 	if(!isturf(owner.loc))
 		return
 	if(owner.inStasisNow())

--- a/code/datums/components/traits/photosynth.dm
+++ b/code/datums/components/traits/photosynth.dm
@@ -15,6 +15,8 @@
 		return
 	if(owner.stat == DEAD)
 		return
+	if(owner.is_incorporeal())
+		return
 	if(owner.inStasisNow())
 		return
 	if(!isturf(owner.loc))


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Phased shadekin should not be affected by light directly, especially harmfully. 

## Changelog
Photosynthesis should not generate nutrition while a shadekin is phased
photodegredation should not harm shadekin in light while phase

:cl: Will
fix: photodegredation should not harm phased shadekin
fix: Photosynthesis should not generation nutrition while its shadekin are phased
/:cl:
