### PR TITLE
Upports this timer

### DIFF
--- a/code/modules/mining/resonator.dm
+++ b/code/modules/mining/resonator.dm
@@ -119,9 +119,7 @@
 	transform = matrix()*0.75
 	animate(src, transform = matrix()*1.5, time = timetoburst)
 	// Queue the actual bursting
-	spawn(timetoburst)
-		if(!QDELETED(src))
-			burst(creator)
+	addtimer(CALLBACK(src, PROC_REF(burst), creator), timetoburst)
 
 /obj/effect/resonance/proc/burst(var/creator = null)
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request
Upports a burst timer for the resonator.
Downstream fixed this but then didn't tick the correct file so their changes were never live for over 2 years.
## Changelog
