### PR TITLE
Fixes pointblank shots not increasing agony damage

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -631,6 +631,7 @@
 				damage_mult = 2.5
 			else if(grabstate >= GRAB_AGGRESSIVE)
 				damage_mult = 1.5
+	P.agony *= damage_mult
 	P.damage *= damage_mult
 
 /obj/item/gun/proc/process_accuracy(obj/projectile, mob/living/user, atom/target, var/burst, var/held_twohanded)


### PR DESCRIPTION

## About The Pull Request
Makes pointblank shots increase agony damage dealt by the shot, just like how damage is increased.
## Changelog
:cl:
fix: Pointblank attacks will increase the agony damage just like normal damage.
/:cl:
