### PR TITLE
Disposals delete remains

### DIFF
--- a/code/modules/recycling/disposal_machines.dm
+++ b/code/modules/recycling/disposal_machines.dm
@@ -382,9 +382,8 @@
 
 	// We don't ever want digestion remains going through disposals, but people understandably thing they're doing right by trashing them
 	// So let's just delete them instead!
-	for(var/obj/item/flushed_item in src)
-		if(istype(flushed_item, /obj/item/digestion_remains))
-			qdel(flushed_item)
+	for(var/obj/item/digestion_remains/flushed_item in src)
+		qdel(flushed_item)
 
 	flushing = TRUE
 	flick("[icon_state]-flush", src)


### PR DESCRIPTION

## About The Pull Request

Disposal chutes now delete any digestion remains when they flush, making them a safe place to throw them away.

As for why we want this option: New players often do not know how to handle digestion remains, not knowing you can destroy them in-hand. Understandably, they just bin them, but this gets them into trouble with exposing others to messy skulls. Alternatively, it also allows players to spice up their scenes a bit by just dumping skulls casually without the risk of squicking anyone!

## Changelog
:cl:
qol: Disposal chutes now delete any digestion remains when they flush, making them a safe place to throw them away.
/:cl:
