### PR TITLE
Fix Synth Instruments

### DIFF
--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -67,7 +67,7 @@
 		var/pref_volume = M?.client?.prefs.read_preference(/datum/preference/numeric/volume/sound_instruments)
 		if(!pref_volume)
 			continue
-		M.playsound_local(get_turf(parent), null, volume * (pref_volume/100), FALSE, K.frequency, null, channel, null, copy)
+		M.playsound_local(get_turf(parent), null, volume * (pref_volume/100), FALSE, K.frequency, channel = channel, S = copy)
 		// Could do environment and echo later but not for now
 
 /**


### PR DESCRIPTION
## About The Pull Request
Non-legacy instruments were not playing because of a single comma

## Changelog
Corrected sound arguments for synthed instruments, the sound file is actually passed to the sound argument, instead of if the sound is affected by pressure argument.

:cl: Will
fix: non-legacy instruments should now play music
/:cl:

