### PR TITLE
Some recharger adjustments

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -69,57 +69,74 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 			if(C)				// Sometimes we get things without cells in it.
 				. += "Current charge: [C.charge] / [C.maxcharge]"
 
+///Checks valid items to see if there's any reasons we wouldn't allow them to be put in.
+/obj/machinery/recharger/proc/do_allowed_checks(obj/item/G, mob/user)
+	. = FALSE
+	if(charging)
+		to_chat(user, span_warning("\A [charging] is already charging here."))
+		return
+	// Checks to make sure he's not in space doing it, and that the area got proper power.
+	if(!powered())
+		to_chat(user, span_warning("\The [src] blinks red as you try to insert [G]!"))
+		return
+	if(istype(G, /obj/item/gun/energy))
+		var/obj/item/gun/energy/E = G
+		if(E.self_recharge)
+			to_chat(user, span_notice("\The [E] has no recharge port."))
+			return
+	if(istype(G, /obj/item/modular_computer))
+		var/obj/item/modular_computer/C = G
+		if(!C.battery_module)
+			to_chat(user, span_notice("\The [C] does not have a battery installed. "))
+			return
+	if(istype(G, /obj/item/flash))
+		var/obj/item/flash/F = G
+		if(F.use_external_power)
+			to_chat(user, span_notice("\The [F] has no recharge port."))
+			return
+	if(istype(G, /obj/item/weldingtool/electric))
+		var/obj/item/weldingtool/electric/EW = G
+		if(EW.use_external_power)
+			to_chat(user, span_notice("\The [EW] has no recharge port."))
+			return
+	if(!G.get_cell() && !is_type_in_list(G, GLOB.recharger_battery_exempt))
+		to_chat(user, "\The [G] does not have a battery installed.")
+		return
+	if(istype(G, /obj/item/paicard))
+		var/obj/item/paicard/ourcard = G
+		if(ourcard.panel_open)
+			to_chat(user, span_warning("\The [ourcard] won't fit in the recharger with its panel open."))
+			return
+		if(ourcard.pai)
+			if(ourcard.pai.stat == CONSCIOUS)
+				to_chat(user, span_warning("\The [ourcard] boops... it doesn't need to be recharged!"))
+				return
+		else
+			to_chat(user, span_warning("\The [ourcard] doesn't have a personality!"))
+			return
+	return TRUE
+
+/obj/machinery/recharger/MouseDrop_T(obj/item/G as obj, mob/user as mob)
+	if((!small && is_type_in_list(G, GLOB.allowed_recharger_devices)) || (small && is_type_in_list(G, GLOB.allowed_wallcharger_devices)))
+		if(!do_allowed_checks(G, user))
+			return
+
+		G.forceMove(src)
+		charging = G
+		update_icon()
+		user.visible_message("[user] inserts [charging] into [src].", "You insert [charging] into [src].")
+
 /obj/machinery/recharger/attackby(obj/item/G as obj, mob/user as mob)
 	if((!small && is_type_in_list(G, GLOB.allowed_recharger_devices)) || (small && is_type_in_list(G, GLOB.allowed_wallcharger_devices)))
-		if(charging)
-			to_chat(user, span_warning("\A [charging] is already charging here."))
+		if(!do_allowed_checks(G, user))
 			return
-		// Checks to make sure he's not in space doing it, and that the area got proper power.
-		if(!powered())
-			to_chat(user, span_warning("\The [src] blinks red as you try to insert [G]!"))
-			return
-		if(istype(G, /obj/item/gun/energy))
-			var/obj/item/gun/energy/E = G
-			if(E.self_recharge)
-				to_chat(user, span_notice("\The [E] has no recharge port."))
-				return
-		if(istype(G, /obj/item/modular_computer))
-			var/obj/item/modular_computer/C = G
-			if(!C.battery_module)
-				to_chat(user, span_notice("\The [C] does not have a battery installed. "))
-				return
-		if(istype(G, /obj/item/flash))
-			var/obj/item/flash/F = G
-			if(F.use_external_power)
-				to_chat(user, span_notice("\The [F] has no recharge port."))
-				return
-		if(istype(G, /obj/item/weldingtool/electric))
-			var/obj/item/weldingtool/electric/EW = G
-			if(EW.use_external_power)
-				to_chat(user, span_notice("\The [EW] has no recharge port."))
-				return
-		if(!G.get_cell() && !is_type_in_list(G, GLOB.recharger_battery_exempt))
-			to_chat(user, "\The [G] does not have a battery installed.")
-			return
-		if(istype(G, /obj/item/paicard))
-			var/obj/item/paicard/ourcard = G
-			if(ourcard.panel_open)
-				to_chat(user, span_warning("\The [ourcard] won't fit in the recharger with its panel open."))
-				return
-			if(ourcard.pai)
-				if(ourcard.pai.stat == CONSCIOUS)
-					to_chat(user, span_warning("\The [ourcard] boops... it doesn't need to be recharged!"))
-					return
-			else
-				to_chat(user, span_warning("\The [ourcard] doesn't have a personality!"))
-				return
 		if(HAS_TRAIT(user, TRAIT_UNLUCKY) && prob(10))
 			user.visible_message("[user] inserts [charging] into [src] backwards!", "You insert [charging] into [src] backwards!")
 			user.drop_item()
-			G.loc = get_turf(src)
+			G.forceMove(get_turf(src))
 			return
 		user.drop_item()
-		G.loc = src
+		G.forceMove(src)
 		charging = G
 		update_icon()
 		user.visible_message("[user] inserts [charging] into [src].", "You insert [charging] into [src].")
@@ -155,7 +172,7 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 		if(charging)
 			user.visible_message("[user] removes [charging] from [src].", "You remove [charging] from [src].")
 			charging.update_icon()
-			charging.loc = src.loc
+			charging.forceMove(src.loc)
 			charging = null
 			update_icon()
 
@@ -168,63 +185,19 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 	if(!charging)
 		update_use_power(USE_POWER_IDLE)
 		icon_state = icon_state_idle
+		return
 
 	//PAI Cards
 	else if(istype(charging, /obj/item/paicard))
-		var/obj/item/paicard/pcard = charging
-		if(pcard.is_damage_critical())
-			pcard.forceMove(get_turf(src))
-			charging = null
-			pcard.damage_random_component()
-			update_icon()
-		else if(pcard.pai.bruteloss)
-			pcard.pai.adjustBruteLoss(-5)
-		else if(pcard.pai.fireloss)
-			pcard.pai.adjustFireLoss(-5)
-		else
-			charging = null
-			update_icon()
-			src.visible_message(span_notice("\The [src] ejects the [pcard]!"))
-			pcard.forceMove(get_turf(src))
-			pcard.pai.full_restore()
+		charge_pai(charging)
+		return
 	//Charging cell-loaded guns.
 	else if(istype(charging, /obj/item/gun/projectile/cell_loaded))
-		var/obj/item/gun/projectile/cell_loaded/cellgun = charging
-		var/obj/item/ammo_magazine/magazine = cellgun.ammo_magazine //CAN BE NULL.
-		var/obj/item/ammo_casing/microbattery/batt = cellgun.chambered //CAN BE NULL.
-
-		//First, we charge the currently chambered battery if there is one.
-		if(batt && !(batt.shots_left >= initial(batt.shots_left)))
-			icon_state = icon_state_charging
-			batt.shots_left++
-			update_use_power(USE_POWER_ACTIVE)
-			return
-		//Second, we charge the batteries in the magazine.
-		else if(magazine && LAZYLEN(magazine.stored_ammo))
-			for(var/obj/item/ammo_casing/microbattery/shot_to_charge in magazine)
-				if(shot_to_charge.shots_left >= initial(shot_to_charge.shots_left))
-					continue
-				shot_to_charge.shots_left++
-				icon_state = icon_state_charging
-				update_use_power(USE_POWER_ACTIVE)
-				return //only heal one at a time.
-		//If the chambered battery AND the magazine are all full, we are done.
-		icon_state = icon_state_charged
-		update_use_power(USE_POWER_IDLE)
+		charge_cell_gun(charging)
 		return
 	//Charging cell magazines
 	else if(istype(charging, /obj/item/ammo_magazine/cell_mag))
-		var/obj/item/ammo_magazine/cell_mag/magazine = charging
-		if(LAZYLEN(magazine.stored_ammo))
-			for(var/obj/item/ammo_casing/microbattery/shot_to_charge in magazine)
-				if(shot_to_charge.shots_left >= initial(shot_to_charge.shots_left))
-					continue
-				shot_to_charge.shots_left++
-				icon_state = icon_state_charging
-				update_use_power(USE_POWER_ACTIVE)
-				return
-		icon_state = icon_state_charged
-		update_use_power(USE_POWER_IDLE)
+		charge_cell_magazine(charging)
 		return
 	else
 		//Everything Else
@@ -240,15 +213,75 @@ GLOBAL_LIST_INIT(recharger_battery_exempt, list(
 
 		//NSFW Batteries
 		else if(istype(charging, /obj/item/ammo_casing/microbattery))
-			var/obj/item/ammo_casing/microbattery/batt = charging
-			if(batt.shots_left >= initial(batt.shots_left))
-				icon_state = icon_state_charged
-				update_use_power(USE_POWER_IDLE)
-			else
-				icon_state = icon_state_charging
-				batt.shots_left++
-				update_use_power(USE_POWER_ACTIVE)
+			charge_microbattery(charging)
 			return
+
+///Charges PAIs.
+/obj/machinery/recharger/proc/charge_pai(obj/item/paicard/pcard)
+	if(pcard.is_damage_critical())
+		pcard.forceMove(get_turf(src))
+		charging = null
+		update_icon()
+		return
+	if(pcard.pai.bruteloss || pcard.pai.fireloss)
+		pcard.pai.adjustBruteLoss(-5)
+		pcard.pai.adjustFireLoss(-5)
+	else
+		charging = null
+		update_icon()
+		visible_message(span_notice("\The [src] ejects the [pcard]!"))
+		pcard.forceMove(get_turf(src))
+		pcard.pai.full_restore()
+
+///Charges microbatteries. One projectile at a time.
+/obj/machinery/recharger/proc/charge_microbattery(obj/item/ammo_casing/microbattery/batt)
+	if(batt.shots_left >= initial(batt.shots_left))
+		batt.shots_left = initial(batt.shots_left)
+		icon_state = icon_state_charged
+		update_use_power(USE_POWER_IDLE)
+	else
+		icon_state = icon_state_charging
+		batt.shots_left++
+		update_use_power(USE_POWER_ACTIVE)
+
+///Charges cell magazines, one projectile at a time.
+/obj/machinery/recharger/proc/charge_cell_magazine(obj/item/ammo_magazine/cell_mag/magazine)
+	if(LAZYLEN(magazine.stored_ammo))
+		for(var/obj/item/ammo_casing/microbattery/shot_to_charge in magazine)
+			if(shot_to_charge.shots_left >= initial(shot_to_charge.shots_left))
+				continue
+			shot_to_charge.shots_left++
+			icon_state = icon_state_charging
+			update_use_power(USE_POWER_ACTIVE)
+			return
+	icon_state = icon_state_charged
+	update_use_power(USE_POWER_IDLE)
+
+///Charges cell guns. First charges the currently chambered battery, then the batteries in the magazine.
+/obj/machinery/recharger/proc/charge_cell_gun(obj/item/gun/projectile/cell_loaded/cellgun)
+	var/obj/item/ammo_magazine/magazine = cellgun.ammo_magazine //CAN BE NULL.
+	var/obj/item/ammo_casing/microbattery/batt = cellgun.chambered //CAN BE NULL.
+
+	//First, we charge the currently chambered battery if there is one.
+	if(batt && !(batt.shots_left >= initial(batt.shots_left)))
+		icon_state = icon_state_charging
+		batt.shots_left++
+		update_use_power(USE_POWER_ACTIVE)
+		return
+	//Second, we charge the batteries in the magazine.
+	else if(magazine && LAZYLEN(magazine.stored_ammo))
+		for(var/obj/item/ammo_casing/microbattery/shot_to_charge in magazine)
+			if(shot_to_charge.shots_left >= initial(shot_to_charge.shots_left))
+				continue
+			shot_to_charge.shots_left++
+			icon_state = icon_state_charging
+			update_use_power(USE_POWER_ACTIVE)
+			return //only heal one at a time.
+	//If the chambered battery AND the magazine are all full, we are done.
+	icon_state = icon_state_charged
+	update_use_power(USE_POWER_IDLE)
+	return
+
 
 /obj/machinery/recharger/emp_act(severity)
 	if(stat & (NOPOWER|BROKEN) || !anchored)


### PR DESCRIPTION

## About The Pull Request
Makes some tweaks and QoL adjustments to the recharger.

Allows you to drag-drop items into the recharger.

Converts charging PAIs, micro batteries, micro magazines, and cell guns into their own helper procs.

Makes it so critically damaged (inoperable) PAIs are simply ejected instead of being damaged further in chargers.

Makes it so that PAI charging code is a bit tidier.
## Changelog
:cl: Diana
qol: You can now drag-drop items onto chargers
code: Recharger code is a bit better
code: Got rid of some loc = X
/:cl:
