### PR TITLE
Fixes vorebelly temperatures ignoring prefs

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -879,7 +879,7 @@
 			if(allowtemp)
 				loc_temp = b.bellytemperature
 			else
-				loc_temp = T20C //Default "safe" temp.
+				loc_temp = species.body_temperature //Should be safe for just about anyone
 		else
 			loc_temp = environment.temperature
 


### PR DESCRIPTION

## About The Pull Request

Did you know that ever since vorebelly temps were added, the pref added to guard against dangerous temps in guts didn't work? This somehow hasn't been noticed, or otherwise hasn't been picked up, so im here now.

Also fixed a poor order of operation that now minorly breaks phased species xenomorphs (they wont regen plasma) but prevents phased alarune and some others from doing weird atmos stuff when they shouldnt care about it but that's probably it's own issue that should be refactored if for some reason someone decides to use species xenomorphs and not carbon xenomorphs (it should all be doing stuff in the organs anyways)
Anyhow, free goodboy points :3333

## Changelog
:cl:
fix: Fixed smelting prey who'd prefer to not be smelted
fix: Running special atmos checks while phased or otherwise incorporeal
/:cl:
