### PR TITLE
fixes a misplacement

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -192,7 +192,6 @@
 	surgery_name = "Clamp Bleeders"
 	allowed_tools = list(
 		/obj/item/surgical/hemostat = 100,	\
-		/obj/item/material/twohanded/fireaxe = 99, \
 		/obj/item/stack/cable_coil = 75, 	\
 		/obj/item/assembly/mousetrap = 25
 	)
@@ -362,6 +361,7 @@
 	surgery_name = "Amputate Limb"
 	allowed_tools = list(
 		/obj/item/surgical/circular_saw = 100, \
+		/obj/item/material/twohanded/fireaxe = 99, \
 		/obj/item/material/knife/machete/hatchet = 75
 	)
 	req_open = 0


### PR DESCRIPTION
Fireaxe is NOT bleeders but rather limb amputation
## About The Pull Request
Fixes being able to use a fireaxe as bleeders. Makes it allow you to amputate a limb as intended
## Changelog
:cl:
fix: Fireaxe no longer can be used as a pair of bleeders to stop bleeding.
fix: Fireaxe can now properly be used to amputate limbs.
/:cl:
