### PR TITLE
Adds can shaking 

### DIFF
--- a/code/modules/food/food/cans.dm
+++ b/code/modules/food/food/cans.dm
@@ -27,7 +27,11 @@
 		reagents.splash(user, shaken/2)
 		reagents.trans_to(foam, shaken/2)
 		if(shaken > 50)
-			explosion(get_turf(src), -1, -1, -1, 1)
+			if(HAS_TRAIT(user, TRAIT_UNLUCKY) && prob(0.1))
+				explosion(get_turf(src), -1, -1, -1, 7)
+				user.gib()
+			else
+				explosion(get_turf(src), -1, -1, -1, 1)
 			qdel(src)
 
 /obj/item/reagent_containers/food/drinks/cans/process()


### PR DESCRIPTION

## About The Pull Request

Adds the ability to shake cans, making them foam and spill on the the user that opens it. Don't shake them too much.

Unlucky people have a chance to have them foam shaken or not.

## Changelog
:cl: Guti
add: Added can shaking
/:cl:
