### PR TITLE
Gives Vox a Voice Box

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -74,13 +74,13 @@
 
 
 	has_organ = list(
-		O_HEART =    /obj/item/organ/internal/heart/vox,
-		O_LUNGS =    /obj/item/organ/internal/lungs/vox,
-		O_VOICE =	 /obj/item/organ/internal/voicebox,
-		O_LIVER =    /obj/item/organ/internal/liver/vox,
-		O_KIDNEYS =  /obj/item/organ/internal/kidneys/vox,
-		O_BRAIN =    /obj/item/organ/internal/brain/vox,
-		O_EYES =     /obj/item/organ/internal/eyes,
+		O_HEART =	/obj/item/organ/internal/heart/vox,
+		O_LUNGS =	/obj/item/organ/internal/lungs/vox,
+		O_VOICE =	/obj/item/organ/internal/voicebox/vox,
+		O_LIVER =	/obj/item/organ/internal/liver/vox,
+		O_KIDNEYS =	/obj/item/organ/internal/kidneys/vox,
+		O_BRAIN =	/obj/item/organ/internal/brain/vox,
+		O_EYES =	/obj/item/organ/internal/eyes,
 		)
 
 	genders = list(NEUTER)

--- a/code/modules/organs/subtypes/vox.dm
+++ b/code/modules/organs/subtypes/vox.dm
@@ -26,5 +26,9 @@
 	parent_organ = BP_TORSO
 	color = "#0033cc"
 
+/obj/item/organ/internal/voicebox/vox
+	color = "#3c5b7b"
+	will_assist_languages = list(LANGUAGE_VOX) //Fixes them from knowing galcommon off the rip.
+
 /obj/item/organ/external/groin/vox //vox have an extended ribcage for extra protection.
 	encased = "lower ribcage"


### PR DESCRIPTION
## About The Pull Request
Gives vox a vox voice box...Just recolored and lets them speak their native tongue.
Also means that if they don't take galcommon at the start it won't magically give them gal common.
## Changelog
:cl:
fix: Vox now have a proper voice box with coloration that normal vox organs have. This prevents them from being forced to know galcommon if they opt to not take it.
/:cl:
