### PR TITLE
vents should hibernate if welded

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -145,6 +145,9 @@
 	//broadcast_status()
 	if(!use_power || (stat & (NOPOWER|BROKEN)))
 		return 0
+	if(welded) // Don't do anything if welded
+		SSmachines.hibernate_vent(src)
+		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()
 


### PR DESCRIPTION
## About The Pull Request
Missed this in my ventcrawler pr. Makes vents hibernate if they are welded.

## Changelog
Disables vents when welded. Avoids server load from vents that can't do anything anyway.

:cl: Will
fix: Welded vents hibernate when they attempt to process air now
/:cl:
