### PR TITLE
noticeboard persistance fix

### DIFF
--- a/code/modules/persistence/effects/paper.dm
+++ b/code/modules/persistence/effects/paper.dm
@@ -16,7 +16,7 @@
 		return
 	var/obj/item/paper/paper = new paper_type(creating)
 	paper.info = token["message"]
-	paper.name = token["title"]
+	paper.name = token["name"]
 	if(!paper.name)
 		paper.name = "No Title"
 	paper.last_modified_ckey = token["author"]


### PR DESCRIPTION
## About The Pull Request
Noticeboards save the title of their notices incorrectly.

## Changelog
Noticeboards saved their paper's title under "name" in the persistence json, but read it as "title". This means that it would always get a null answer, and replace the title with "No Title". Unfortunately by now there is likely no fix for any currently saved papers, as they would have saved their title to that each round. The failure was during reading only.

:cl: Will
fix: noticeboards properly save the title of their pinned pages
/:cl:
