### PR TITLE
Chem duplication exploit fix

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -237,7 +237,7 @@
 		var/has_clonexa = occupant.reagents.get_reagent_amount(REAGENT_ID_CLONEXADONE) >= 1
 		var/has_cryo_medicine = has_cryo || has_clonexa
 		if(beaker && !has_cryo_medicine)
-			beaker.reagents.trans_to_mob(occupant, 1, CHEM_BLOOD, 10)
+			beaker.reagents.trans_to_mob(occupant, 1, CHEM_BLOOD, 10, can_dialysis = FALSE)
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -116,7 +116,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(ishuman(loc))
 			var/mob/living/carbon/human/C = loc
 			if (src == C.wear_mask && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
-				reagents.trans_to_mob(C, amount, CHEM_INGEST, 1.5) // I don't predict significant balance issues by letting blunts actually WORK.
+				reagents.trans_to_mob(C, amount, CHEM_INGEST, 1.5, can_dialysis = FALSE) // I don't predict significant balance issues by letting blunts actually WORK.
 		else // else just remove some of the reagents
 			reagents.remove_any(REM)
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -68,7 +68,7 @@
 			var/contained = reagentlist()
 			add_attack_logs(user,target,"Used [src.name] containing [contained]")
 
-			trans += reagents.trans_to_mob(target, min(amount_per_transfer_from_this, reagents.total_volume)/2, CHEM_INGEST) //Half injected, half ingested
+			trans += reagents.trans_to_mob(target, min(amount_per_transfer_from_this, reagents.total_volume)/2, CHEM_INGEST, can_dialysis = FALSE) //Half injected, half ingested
 			trans += reagents.trans_to_mob(target, min(amount_per_transfer_from_this, reagents.total_volume), CHEM_BLOOD) //I guess it gets into the bloodstream through the eyes or something
 			user.visible_message(span_warning("[user] squirts something into [target]'s eyes!"), span_notice("You transfer [trans] units of the solution."))
 

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -42,6 +42,7 @@
 	var/list/glass_special = null // null equivalent to list()
 
 	var/from_belly = FALSE
+	var/dialysis_returnable = TRUE
 	var/wiki_flag = 0 // Bitflags for secret/food/drink reagent sorting
 	var/supply_conversion_value = null
 	var/industrial_use = null // unique description for export off station


### PR DESCRIPTION

## About The Pull Request
Fixes an exploit where you could multiply a chemical by 10x it's amount through cryogenics (intended) and then dialysis it out to be able to utilize that chemical elsewhere (unintended)

Fixes an exploit where you could inject reagents into a cig and then stomach pump the chemicals out at a 1.5x rate, turning 10u into 15u

Fixes and exploit where you could dialysis+stomach pump reagents with a dropper to obtain 1.5x the reagents, turning 10u into 15u.
## Changelog
:cl:
fix: Fixes some chemical duplication exploits.
/:cl:
