### PR TITLE
Allow marking atmos canisters with methane

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -342,6 +342,7 @@ update_flag
 					"\[O2\]" = "blue", \
 					"\[Phoron\]" = "orangeps", \
 					"\[CO2\]" = "black", \
+					"\[CH4\]" = "green", \
 					"\[Air\]" = "grey", \
 					"\[CAUTION\]" = "yellow", \
 				)


### PR DESCRIPTION
## About The Pull Request
Missed in the original methane PR. 

## Changelog
Adds green for methane tanks to canister marking.

:cl: Will
fix: Air canisters can be marked green for methane
/:cl: