### PR TITLE
Ambulant blood forbidden for synths

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
@@ -203,6 +203,7 @@
 	desc = "Your blood reacts to hostile stimulation such as burning when seperated from your body, as if it was its own creature. You WILL be mistaken for a changeling, you may want to document this in your medical records."
 	var_changes = list("ambulant_blood" = TRUE)
 	cost = 0
+	can_take = ORGANICS
 
 	is_genetrait = TRUE
 	hidden = FALSE


### PR DESCRIPTION
## About The Pull Request
Synths ain't got no blood! Trait is non-functional on them, and is a point exploit downstream.

## Changelog
Forbids ambulant blood for fbps.

:cl: Will
fix: forbids synths from taking ambulant blood
/:cl:

