### PR TITLE
Fixes teleport crashes

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_INIT(bluespace_item_types, list(
 ))
 
 /proc/do_teleport(atom/movable/teleatom, atom/destination, precision = null, datum/effect/effect/effectin = null, datum/effect/effect/effectout = null, asoundin = null, asoundout = null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
-	if(istype(teleatom, /obj/effect) && !istype(ateleatom, /obj/effect/dummy/chameleon)) // Earliest check because otherwise sparks will fuck you up
+	if(istype(teleatom, /obj/effect) && !istype(teleatom, /obj/effect/dummy/chameleon)) // Earliest check because otherwise sparks will fuck you up
 		qdel(teleatom)
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Give me that fuck-up of the year. I forgot to delete effects that try to teleport.

## Changelog
:cl: Guti
fix: Fixes sparks recursively teleporting through shadekin portals
/:cl:
