### PR TITLE
Fix Remote View Hud Causing Crashes During Destroy

### DIFF
--- a/code/datums/components/remote_view.dm
+++ b/code/datums/components/remote_view.dm
@@ -107,11 +107,12 @@
 		UnregisterSignal(remote_view_target, COMSIG_QDELETING)
 		UnregisterSignal(remote_view_target, COMSIG_MOB_RESET_PERSPECTIVE)
 		UnregisterSignal(remote_view_target, COMSIG_REMOTE_VIEW_CLEAR)
-	// Update the mob's vision right away
-	settings.detatch_from_mob(src, host_mob)
-	settings.handle_remove_visuals(src, host_mob)
-	host_mob.handle_vision()
-	host_mob.handle_regular_hud_updates()
+	// Update the mob's vision right away if it still exists
+	if(!QDELETED(host_mob))
+		settings.detatch_from_mob(src, host_mob)
+		settings.handle_remove_visuals(src, host_mob)
+		host_mob.handle_vision()
+		host_mob.handle_regular_hud_updates()
 	host_mob = null
 	remote_view_target = null
 	// Clear settings
@@ -218,18 +219,24 @@
 	SIGNAL_HANDLER
 	SHOULD_NOT_OVERRIDE(TRUE)
 	PRIVATE_PROC(TRUE)
+	if(!host_mob)
+		return FALSE
 	return settings.handle_relay_movement(src, host_mob, direction)
 
 /datum/component/remote_view/proc/handle_hud_override(datum/source)
 	SIGNAL_HANDLER
 	SHOULD_NOT_OVERRIDE(TRUE)
 	PRIVATE_PROC(TRUE)
+	if(!host_mob)
+		return
 	return settings.handle_hud_override(src, host_mob)
 
 /datum/component/remote_view/proc/handle_hud_health(datum/source)
 	SIGNAL_HANDLER
 	SHOULD_NOT_OVERRIDE(TRUE)
 	PRIVATE_PROC(TRUE)
+	if(!host_mob)
+		return
 	return settings.handle_hud_health(src, host_mob)
 
 /datum/component/remote_view/proc/handle_hud_darkvision(datum/source)
@@ -237,12 +244,16 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 	RETURN_TYPE(null)
 	PRIVATE_PROC(TRUE)
+	if(!host_mob)
+		return
 	settings.handle_hud_darkvision(src, host_mob)
 
 /datum/component/remote_view/proc/handle_mob_vision_update(datum/source)
 	SIGNAL_HANDLER
 	SHOULD_NOT_OVERRIDE(TRUE)
 	PRIVATE_PROC(TRUE)
+	if(!host_mob)
+		return
 	return settings.handle_apply_visuals(src, host_mob)
 
 // Accessors

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -297,9 +297,9 @@
 /mob/proc/restore_remote_views()
 	if(!loc) // Nullspace during respawn
 		return FALSE
-	if(isturf(loc)) // Cannot be remote if it was a turf, also obj and turf flags overlap so stepping into space triggers remoteview endlessly.
+	if(QDELETED(loc) || QDELETED(src)) // location or ourselves is qdeleted, don't restart remote viewing during destroy
 		return FALSE
-	if(QDELETED(loc))
+	if(isturf(loc)) // Cannot be remote if it was a turf, also obj and turf flags overlap so stepping into space triggers remoteview endlessly.
 		return FALSE
 	// Check if we actually need to drop our current remote view component, as this is expensive to do, and leads to more difficult to understand error prone logic
 	var/datum/component/remote_view/remote_comp = GetComponent(/datum/component/remote_view)


### PR DESCRIPTION
## About The Pull Request
If a mob is remote viewing with a hud and gets qdeleted it'll runtime horribly because it tries to update the no longer existing mob's hud during the component's removal.

## Changelog
Checks for host mob being qdeleted during remoteview destroy instead of assuming the mob exists
Adds some more protection to other signals to prevent performing actions during deletion

:cl: Will
fix: Remoteview crashing during mob qdel
/:cl:
