### PR TITLE
fixes some item logic

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -967,7 +967,10 @@ GLOBAL_LIST_EMPTY(blood_overlays_by_type)
 		return default_worn_icon
 
 	//5: Use our species_sheet as a fallback if we have one. A 'default' sprite is better than nothing at all (or a misaligned sprite)
-	if(species_sheet)
+	//We ONLY do this if our species is 'abnormally shaped' i.e. tesh/vox/werebeast.
+	//It should be noted that if this is true, we FAILED to confirm the icon exists in our file. I.E: We're going to use the 'no name' item_state in the .dmi
+	//Otherwise, the human sprite (default_icon) looks fine on MOST species.
+	if(species_sheet && (body_type == SPECIES_TESHARI || body_type == SPECIES_VOX || body_type == SPECIES_WEREBEAST))
 		return species_sheet
 
 	//6: provided default_icon


### PR DESCRIPTION

## About The Pull Request
Fixes some item state logic where it was using the fallback species_icon instead of the fallback default_icon.
For reference:
Species_icon fallback is done if we don't have any proper sprite for the species in the file AND we have a mutant shape (teshari, vox, werebeast)
default_icon fallback is done if we don't have any proper sprite for the species in the file BUT we have a humanoid shape.
## Changelog
:cl: Diana
fix: Items now use the proper species fallback
/:cl:
