### PR TITLE
Trait adjustments [GBP IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -232,7 +232,7 @@
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("organic_food_coeff" = 0, "bloodsucker" = TRUE) //The verb is given in human.dm
-	excludes = list(/datum/trait/neutral/bloodsucker_freeform)
+	excludes = list(/datum/trait/neutral/bloodsucker_freeform, /datum/trait/positive/bloodsucker_plus)
 
 /datum/trait/neutral/bloodsucker/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -253,7 +253,7 @@
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("bloodsucker" = TRUE)
-	excludes = list(/datum/trait/neutral/bloodsucker)
+	excludes = list(/datum/trait/neutral/bloodsucker, /datum/trait/positive/bloodsucker_plus)
 
 /datum/trait/neutral/bloodsucker_freeform/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -542,12 +542,20 @@
 	can_take = ORGANICS
 	var_changes = list("virus_immune" = TRUE)
 
+/datum/trait/positive/linguist/expert
+	name = "Expert Linguist"
+	desc = "You are a expert of languages! For whatever reason you might have, you are able to learn many more languages than others. Your language cap is 5 slots."
+	cost = 3
+	var_changes = list("num_alternate_languages" = 8)
+	var_changes_pref = list("extra_languages" = 5)
+
 /datum/trait/positive/linguist/master
 	name = "Master Linguist"
 	desc = "You are a master of languages! For whatever reason you might have, you are able to learn many more languages than others. Your language cap is 12 slots."
 	cost = 2
 	var_changes = list("num_alternate_languages" = 15)
 	var_changes_pref = list("extra_languages" = 12)
+	hidden = TRUE
 
 /datum/trait/positive/densebones
 	name = "Dense Bones"
@@ -821,6 +829,7 @@
 	var_changes = list("item_slowdown_mod" = 0.0)
 	excludes = list(/datum/trait/positive/speed_fast,/datum/trait/positive/hardy,/datum/trait/positive/hardy_plus)
 
+/// ## MIGRATE THIS TO /datum/trait/neutral/bloodsucker_freeform
 /datum/trait/positive/bloodsucker_plus
 	name = "Evolved Bloodsucker"
 	desc = "Makes you able to gain nutrition by draining blood as well as eating food. To compensate, you get fangs that can be used to drain blood from prey."


### PR DESCRIPTION

## About The Pull Request
Makes Master Linguist hidden
Adds "Expert Linguist" - a 3 point trait that allows for 5 extra languages
Leaves a comment to change bloodsucker_plus to the neutral savetime with a savefile migration...Bloodsucker_plus is a positive trait that is worse than the neutral
## Changelog
:cl:
add: Adds 'Expert Linguist' a 3 point trait that lets you pick 5 extra languages.
del: Disables Master Linguist
/:cl:
