### PR TITLE
Fixes do_after in lick wonds

### DIFF
--- a/code/modules/mob/living/carbon/lick_wounds.dm
+++ b/code/modules/mob/living/carbon/lick_wounds.dm
@@ -66,7 +66,7 @@
 				if(W.bandaged && W.salved && W.disinfected)
 					continue
 
-				if(!do_after(src, W.damage/5, W))
+				if(!do_after(src, W.damage/5, src))
 					to_chat(src, span_notice("You must stand still to clean wounds."))
 					break
 


### PR DESCRIPTION
## About The Pull Request
Makes do_after not runtime when using lick wounds
## Changelog
:cl: Diana
fix: Lick wounds works again
/:cl:
