### PR TITLE
Fixes fulton beacons to be useable for their intended purpose

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -143,7 +143,7 @@
 
 /obj/item/fulton_core/attack_self(mob/user)
 	var/turf/T = get_turf(user)
-	if(do_after(user, 15, target = user) && !QDELETED(src))
+	if(do_after(user, 1.5 SECONDS, target = user) && !QDELETED(src))
 		new /obj/structure/extraction_point(get_turf(user))
 		qdel(src)
 


### PR DESCRIPTION

## About The Pull Request

fulton beacons were accidentally re-nerfed when a section of code was reverted on accident at one point or something
beacons are able to be placed anywhere due to bluespace, and this fixes that again. Extraction packs must be used outdoors, though
## Changelog
:cl
fix: Fixed fultons being useless, recovery beacons can be placed "indoors" again!
code: Removed a doubled definition that was there for some reason
/:cl:
