### PR TITLE
Entertainment monitor nullcheck

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -149,11 +149,13 @@ GLOBAL_LIST_EMPTY(entertainment_screens)
 	if(stat & NOPOWER)
 		return
 	showing = WEAKREF(thing)
-	pinboard.vis_contents = list(thing)
+	if(pinboard)
+		pinboard.vis_contents = list(thing)
 
 /obj/machinery/computer/security/telescreen/entertainment/proc/stop_showing()
 	// Reverse of the above
-	pinboard.vis_contents = null
+	if(pinboard)
+		pinboard.vis_contents = null
 	showing = null
 
 /obj/machinery/computer/security/telescreen/entertainment/proc/maybe_stop_showing(datum/weakref/thingref)


### PR DESCRIPTION
## About The Pull Request
Patches a runtime in entertainment monitor's destroy.

## Changelog
Not a complete fix, but doing so kinda needs a full recode of these.

:cl: Will
fix: Fixes an entertainment monitor runtime
/:cl:
