### PR TITLE
Makes sizeoxadone more affordable

### DIFF
--- a/code/modules/reagents/reactions/instant/instant_vr.dm
+++ b/code/modules/reagents/reactions/instant/instant_vr.dm
@@ -5,9 +5,9 @@
 	name = REAGENT_SIZEOXADONE
 	id = REAGENT_ID_SIZEOXADONE
 	result = REAGENT_ID_SIZEOXADONE
-	required_reagents = list(REAGENT_ID_CLONEXADONE = 1, REAGENT_ID_TRAMADOL = 3, REAGENT_ID_PHORON = 1)
+	required_reagents = list(REAGENT_ID_SODIUM = 1, REAGENT_ID_TRAMADOL = 1)
 	catalysts = list(REAGENT_ID_PHORON = 5)
-	result_amount = 5
+	result_amount = 2
 
 /decl/chemical_reaction/instant/macrocillin
 	name = REAGENT_MACROCILLIN


### PR DESCRIPTION

## About The Pull Request

Changes the cost of sizeoxadone from (1 clonexadone, 3 tramadol and 1 phoron) to (1 sodium and 1 tramadol). It still uses phoron as a catalyst but that is not used up in the reaction.

The idea behind this is to eliminate the extremely high phoron cost of making size chems. There's already so many totally free ways to change your own or someone else's size that it makes no sense that you need to deplete half of the chemistry labs phoron stock to flavour that as a chemical effect.

## Changelog
:cl:
qol: Changes the cost of sizeoxadone from (1 clonexadone, 3 tramadol and 1 phoron) to (1 sodium and 1 tramadol). It still uses phoron as a catalyst but that is not used up in the reaction.
/:cl:
