### PR TITLE
Add basic consent for body writing.

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -185,7 +185,7 @@
 	else if(istype(I, /obj/item/pen))
 		if(!ishuman(src))
 			return FALSE
-		var/mob/living/carbon/human/us = src
+		var/mob/living/carbon/human/canvas_user = src
 
 		if(!isliving(user))
 			return FALSE
@@ -205,9 +205,21 @@
 		if(!message)
 			return TRUE
 
-		add_attack_logs(attacker, us, "wrote \"[message]\"")
+		to_chat(canvas_user, span_notice("[attacker] is attempting to write on your [affecting.name]!"))
+		attacker.visible_message(span_notice("[attacker] starts writing on [canvas_user]'s [affecting.name]."), \
+			span_notice("You start writing on [canvas_user]'s [affecting.name]..."))
 
-		LAZYSET(us.body_writing, affecting.organ_tag, message)
+		// Progress bar for writing on someone for better consent check.
+		if(!do_after(attacker, 3 SECONDS, target = canvas_user, max_distance = 1))
+			to_chat(attacker, span_warning("You stop writing on [canvas_user]."))
+			return TRUE
+
+		add_attack_logs(attacker, canvas_user, "wrote \"[message]\"")
+
+		LAZYSET(canvas_user.body_writing, affecting.organ_tag, message)
+
+		attacker.visible_message(span_notice("[attacker] finishes writing on [canvas_user]'s [affecting.name]."), \
+			span_notice("You finish writing on [canvas_user]'s [affecting.name]."))
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
Fixes that body writing is currently instant, and completely silent in chat. Possibly consent breaking users.

Adds a progress bar to body writing.
Adds basic messages for writing on, being written on, and having writing being interrupted. 
Moving away from a user, or struggling now stops body writing.

## Changelog

:cl: Nova
fix: Fixed body writing being silent in chat, and instant
fix: Fixed body writing having no message notifications.
add: Added ability to resist / move away from being body written.
/:cl: Nova