### PR TITLE
No shadekin knockdown on shuttle move

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -330,6 +330,8 @@
 					TA.ChangeTurf(get_base_turf_by_area(TA), 1, 1)
 		if(knockdown)
 			for(var/mob/living/M in A)
+				if(M.is_incorporeal())
+					continue
 				if(M.buckled)
 					to_chat(M, span_red("Sudden acceleration presses you into \the [M.buckled]!"))
 					shake_camera(M, 3, 1)


### PR DESCRIPTION
## About The Pull Request
Does not remove shadekin being gibbed under shuttles landing. Stops shadekin being thrown or knocked down by shuttles they are on moving if they are phased. This seems to be more of a physical interaction. This can be closed if throwing/knocking phased shadekin during shuttle movement is intended?

## Changelog
Shadekin in phase will not be knocked down by shuttle movement.

:cl: Will
fix: Phased shadekin are no longer knocked down or thrown when a shuttle they are inside of moves.
/:cl:
