### PR TITLE
Makes ambulant blood not a genetrait [GBP IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
@@ -205,7 +205,7 @@
 	cost = 0
 	can_take = ORGANICS
 
-	is_genetrait = TRUE
+	is_genetrait = FALSE
 	hidden = FALSE
 	activity_bounds = DNA_HARDER_BOUNDS // Shouldn't be easy for genetics to find this
 


### PR DESCRIPTION

## About The Pull Request
This was being used to changeling test, If a changeling DIDN'T have it, you could instakill them. If they DID have it, it meant they got to live longer while they were tested, ultimately doing the opposite of what the trait entails. This happened on numerous shifts and has gone from 'negative' to generally 'positive' trait.
## Changelog
:cl: Diana
balance: Ambulant blood no longer is a gene trait.
/:cl:
