### PR TITLE
Makes grow/shrink traits non-exclusive

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1778,7 +1778,6 @@
 /datum/trait/neutral/nutritiongrow
 	name = "Growing"
 	desc = "After you consume enough nutrition, you start to slowly grow while metabolizing nutrition faster."
-	excludes = list(/datum/trait/neutral/nutritionshrink)
 	cost = 0
 	hidden = TRUE //Disabled on Virgo
 	added_component_path = /datum/component/nutrition_size_change/growing
@@ -1786,7 +1785,6 @@
 /datum/trait/neutral/nutritionshrink
 	name = "Shrinking"
 	desc = "If you don't eat enough, your body starts shrinking to make up the difference!"
-	excludes = list(/datum/trait/neutral/nutritiongrow)
 	cost = 0
 	hidden = TRUE //Disabled on Virgo
 	added_component_path = /datum/component/nutrition_size_change/shrinking


### PR DESCRIPTION

## About The Pull Request
Makes shrinking and growing traits not mutually exclusive.
These traits are not enabled on Virgo.
## Changelog
:cl: Diana
fix: You can take both growing & shrinking once more 
/:cl:
