### PR TITLE
Makes EMPs only emp the stored MMI if it exists

### DIFF
--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -111,7 +111,8 @@
 	qdel(src)
 
 /obj/item/organ/internal/mmi_holder/emp_act(severity, recursive)
-	stored_mmi.emp_act(severity, recursive)
+	if(stored_mmi)
+		stored_mmi.emp_act(severity, recursive)
 
 /obj/item/organ/internal/mmi_holder/posibrain
 	name = "positronic brain interface"


### PR DESCRIPTION

## About The Pull Request
Makes EMPs only effect the mmi_holder if the stored_mmi exists.
## Changelog
:cl: Diana
code: Fixes a runtime pertaining to MMI holders.
/:cl:
