### PR TITLE
Prevents Nar'Sie from converting some turf types

### DIFF
--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -18,6 +18,18 @@
 /turf/simulated/wall/cultify()
 	cultify_wall()
 
+/turf/simulated/shuttle/wall/alien/cultify()
+	return
+
+/turf/simulated/flesh/cultify()
+	return
+
+/turf/simulated/gore/cultify() //The flesh is too strong for your occult magic.
+	return
+
+/turf/simulated/goreeyes/cultify()
+	return
+
 /turf/simulated/wall/cult/cultify()
 	return
 


### PR DESCRIPTION

## About The Pull Request
These turf types were getting cultified (and therefore destructable aftewards) which was unintended.
## Changelog
:cl: Diana
fix: Nar'Sie will no longer convert some otherwise indestructable turf types into cult turf.
/:cl:
