### PR TITLE
Gets rid of monkeycube chestbursters

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -1985,7 +1985,7 @@
 	icon_state = "monkeycube"
 	desc = "Just add water!"
 	to_chat(user, "You unwrap the cube.")
-	wrapped = 0
+	wrapped = FALSE
 	flags |= OPENCONTAINER
 	return
 


### PR DESCRIPTION

## About The Pull Request
You eat 50 dragons - you are fine
You eat 1 monkey cube - you are dead.

This makes that no longer happen. Properly places the monkey in your gut (if applicable)
## Changelog
:cl: 
qol: You can now eat monkeys via eating the cube directly instead of having to wet it then eat it to avoid being chestbusted
/:cl:
