### PR TITLE
Laserpointer changes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -92,8 +92,8 @@
 /obj/machinery/camera/proc/internal_process()
 	return
 
-/obj/machinery/camera/emp_act(severity, recursive)
-	if(!isEmpProof() && prob(100/severity))
+/obj/machinery/camera/emp_act(severity, recursive, forced)
+	if(!isEmpProof() && (forced || prob(100/severity)))
 		if(!affected_by_emp_until || (world.time > affected_by_emp_until))
 			affected_by_emp_until = max(affected_by_emp_until, world.time + (90 SECONDS / severity))
 			stat |= EMPED


### PR DESCRIPTION

## About The Pull Request
Cleans up laser pointer code a bit
Makes it so having TOO STRONG of a laser won't break it
Makes it so laser pointering someone without eyes doesn't return early and break the entire chain
Makes it so that being blind (or otherwise unable to see) makes it so you can't uber blind someone
Makes it so that using a laser pointer (no matter the strength) on someone with FLASH_PROTECTION_MAJOR (dispersed eyes, welding goggles, welding mask, etc) does not affect them

Fixes a bug where lasers that were too strong would fail to EMP a camera due to division by 0 error. 

Gets rid of the double-RNG with laser pointers when it comes to hitting a camera.
## Changelog
:cl: Diana
fix: Laser pointers can no longer be too strong and fail to flash someone's eyes/EMP camera because of it
fix: Laser pointering someone without eyes will no longer break the laser pointer forever
fix: You can no flash blind people with the laser pointer
fix: Laser pointers now respect welding masks, welding goggles, and anything else with normal flash immunity.
fix: Laser pointers now take flash sensitivity into effect 
qol: Laser pointers now do their job better, dealing increasing damage and effects based on severity.
code: Cleans up the laser pointer code to make it more easily readable.
/:cl:
