### PR TITLE
Restores Inf Ice Slip

### DIFF
--- a/code/datums/components/turfslip.dm
+++ b/code/datums/components/turfslip.dm
@@ -48,7 +48,7 @@
 
 			if(TURFSLIP_ICE)
 				floor_type = "icy"
-				slip_dist = 1
+				slip_dist = 99 //Eternal slip for ice puzzles
 				slip_stun = 4
 				dirtslip = FALSE
 
@@ -79,7 +79,7 @@
 		if(slip_dist > 4)
 			slip_dist = 4
 
-	else if(ground.wet == TURFSLIP_LUBE)
+	else if(ground.wet >= TURFSLIP_LUBE) // Lube and above slips forever
 		// Lube slips forever, if we re-enter the lube then restore our slip
 		slip_dist = 99
 


### PR DESCRIPTION
## About The Pull Request
Restores old ice slip behavior where it slips forever until you hit a wall, as requested by event managers and poi makers.

## Changelog
Restores ice to slip forever, retains the 4 turf post-ice slip to allow chaining.

:cl: Will
balance: Ice slips you repeatedly instead of a set distance
/:cl:
