### PR TITLE
Inventory item movement hotfix

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -144,7 +144,7 @@
 		if(!(loc == user) || (loc && loc.loc == user))
 			return
 
-		if(user.restrained() || user.stat || user.is_paralyzed() || !user.incapacitated(INCAPACITATION_KNOCKOUT))
+		if(user.restrained() || user.stat || user.is_paralyzed() || user.incapacitated(INCAPACITATION_KNOCKOUT))
 			return
 
 		if((loc == user) && !(istype(over_object, /atom/movable/screen)) && !user.unEquip(src))


### PR DESCRIPTION

## About The Pull Request
Fixes inverted logic that made it so you were required to be knocked out to move storage items (i.e. backpacks, belts, etc) from your inventory to your hand
## Changelog
:cl: Diana
fix: Fixes a bug that prevented moving/unremoving storage items
/:cl:
