### PR TITLE
Adds missing typecheck when starting a pull

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -120,7 +120,7 @@
 	set name = "Pull"
 	set category = "Object"
 
-	if(AM.Adjacent(src))
+	if(istype(AM) && AM.Adjacent(src))
 		src.start_pulling(AM)
 
 	return


### PR DESCRIPTION
## About The Pull Request
Appears to have been missed during TG clickcode. The TG code version filters for atom movable before trying to start a pull. Fixes a runtime when control clicking turf.

## Changelog
Adds istype(AM) check before starting a pull, matches TG code implementation with the exception of combat mode checks, for obvious reasons.

:cl: Willbird
fix: control clicking turf no longer runtimes attempting to pull it
/:cl:
