### PR TITLE
fix a var name issue, and nosleeve trait prevents being added to sleeve database

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -525,18 +525,18 @@ ADMIN_VERB(respawn_character, (R_ADMIN|R_REJUVINATE), "Spawn Character", "(Re)Sp
 		return
 
 	// Respect admin spawn record choice. There's really not a nice way to do this without butchering copy_to() code for an admin proc
-	var/old_mind_scan = picked_client.prefs.resleeve_scan
-	var/old_body_scan = picked_client.prefs.mind_scan
+	var/old_mind_scan = picked_client.prefs.mind_scan
+	var/old_body_scan = picked_client.prefs.resleeve_scan
 	if(!records) // Make em false for the copy_to()
-		picked_client.prefs.resleeve_scan = FALSE
 		picked_client.prefs.mind_scan = FALSE
+		picked_client.prefs.resleeve_scan = FALSE
 
 	//Write the appearance and whatnot out to the character
 	picked_client.prefs.copy_to(new_character)
 
 	// Restore pref state
-	picked_client.prefs.resleeve_scan = old_mind_scan
-	picked_client.prefs.mind_scan = old_body_scan
+	picked_client.prefs.mind_scan = old_mind_scan
+	picked_client.prefs.resleeve_scan = old_body_scan
 
 	//Write the appearance and whatnot out to the character
 	if(new_character.dna)

--- a/code/modules/client/preference_setup/general/11_misc.dm
+++ b/code/modules/client/preference_setup/general/11_misc.dm
@@ -99,7 +99,7 @@
 			if(QDELETED(character) || QDELETED(pref))
 				return // They might have been deleted during the wait
 			if(!character.virtual_reality_mob && !(/mob/living/carbon/human/proc/perform_exit_vr in character.verbs)) //Janky fix to prevent resleeving VR avatars but beats refactoring transcore
-				if(want_body_save)
+				if(want_body_save && !(character.species.flags & NO_SLEEVE)) // Nosleeve flag overrides character pref editor. Otherwise resleevable species still get one even if they took a trait to not be sleevable.
 					var/datum/transhuman/body_record/BR = new()
 					BR.init_from_mob(character, TRUE, pref.resleeve_lock)
 				if(want_mind_save)


### PR DESCRIPTION
## About The Pull Request
The temp var names used for the admin respawn proc were named backward. Fixed for clarity. No sleeve trait now prevents you from getting a body record at the start of the shift.

## Changelog
Renames some temp vars to actually make sense in admin respawn
Disables bodyscan at round start if you have NO_SLEEVE trait

:cl: Willbird
add: no sleeving trait prevents characters from having a round start body record
/:cl:
