### PR TITLE
Fixes movement signal usage

### DIFF
--- a/code/datums/components/materials/machine_shim.dm
+++ b/code/datums/components/materials/machine_shim.dm
@@ -15,7 +15,7 @@
 	// Mob
 	host_mob = parent
 	RegisterSignal(host_mob, COMSIG_LIVING_LIFE, PROC_REF(on_mob_action))
-	RegisterSignal(host_mob, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(on_mob_action))
+	RegisterSignal(host_mob, COMSIG_MOVABLE_MOVED, PROC_REF(on_mob_action))
 	RegisterSignal(host_mob, COMSIG_MOB_LOGOUT, PROC_REF(on_mob_logout))
 
 	// Machine
@@ -34,7 +34,7 @@
 	linked_machine.in_use = FALSE
 	linked_machine = null
 	// Mob
-	UnregisterSignal(host_mob, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+	UnregisterSignal(host_mob, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(host_mob, COMSIG_LIVING_LIFE)
 	UnregisterSignal(host_mob, COMSIG_MOB_LOGOUT)
 	host_mob.reset_perspective() // Required, because our machine may have been operating a remote view

--- a/code/datums/components/recursive_move.dm
+++ b/code/datums/components/recursive_move.dm
@@ -83,12 +83,12 @@
 //Parent at top of heirarchy moved.
 /datum/component/recursive_move/proc/top_moved(var/atom/movable/am, var/atom/new_loc, var/atom/old_loc)
 	SIGNAL_HANDLER
-	SEND_SIGNAL(holder, COMSIG_MOVABLE_ATTEMPTED_MOVE, old_loc, new_loc)
+	SEND_SIGNAL(holder, COMSIG_MOVABLE_MOVED, old_loc, new_loc)
 
 //One of the parents other than the top parent moved.
 /datum/component/recursive_move/proc/heirarchy_changed(var/atom/old_loc, var/atom/movable/am, var/atom/new_loc)
 	SIGNAL_HANDLER
-	SEND_SIGNAL(holder, COMSIG_MOVABLE_ATTEMPTED_MOVE, old_loc, new_loc)
+	SEND_SIGNAL(holder, COMSIG_MOVABLE_MOVED, old_loc, new_loc)
 	//Rebuild our list of parents
 	reset_parents()
 	setup_parents()
@@ -130,4 +130,4 @@
 /obj/item/bananapeel/test/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/recursive_move)
-	RegisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(shmove))
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(shmove))

--- a/code/datums/components/remote_view.dm
+++ b/code/datums/components/remote_view.dm
@@ -53,7 +53,7 @@
 		RegisterSignal(host_mob, COMSIG_MOB_HANDLE_HUD_DARKSIGHT, PROC_REF(handle_hud_darkvision))
 	// Recursive move component fires this, we only want it to handle stuff like being inside a paicard when releasing turf lock
 	if(isturf(focused_on))
-		RegisterSignal(host_mob, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(handle_recursive_moved))
+		RegisterSignal(host_mob, COMSIG_MOVABLE_MOVED, PROC_REF(handle_recursive_moved))
 	// Focus on remote view
 	remote_view_target = focused_on
 	if(host_mob != remote_view_target) // Some items just offset our view, so we set ourselves as the view target, don't double dip if so!
@@ -88,7 +88,7 @@
 	if(settings.will_blind)
 		UnregisterSignal(host_mob, COMSIG_LIVING_STATUS_BLIND)
 	if(isturf(remote_view_target))
-		UnregisterSignal(host_mob, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+		UnregisterSignal(host_mob, COMSIG_MOVABLE_MOVED)
 	if(settings.will_death)
 		UnregisterSignal(host_mob, COMSIG_MOB_DEATH)
 	// Handle relayed movement
@@ -419,7 +419,7 @@
 	. = ..()
 	// Items can be nested deeply, so we need to update on any parent reorganization or actual move.
 	host_mob.AddComponent(/datum/component/recursive_move)
-	RegisterSignal(host_mob, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(handle_recursive_moved)) // Doesn't need override, basetype only ever registers this signal if we're looking at a turf
+	RegisterSignal(host_mob, COMSIG_MOVABLE_MOVED, PROC_REF(handle_recursive_moved)) // Doesn't need override, basetype only ever registers this signal if we're looking at a turf
 	// Check our inmob state
 	if(ismob(find_topmost_atom()))
 		needs_to_decouple = TRUE

--- a/code/datums/observation/helpers.dm
+++ b/code/datums/observation/helpers.dm
@@ -1,6 +1,6 @@
 /*
 /atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_ATTEMPTED_MOVE, old_loc, new_loc)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, new_loc)
 */
 /atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
@@ -16,10 +16,10 @@
 
 /*
 /proc/register_all_movement(var/event_source, var/datum/listener)
-	listener.RegisterSignal(event_source, COMSIG_MOVABLE_ATTEMPTED_MOVE, /atom/movable/proc/recursive_move)
+	listener.RegisterSignal(event_source, COMSIG_MOVABLE_MOVED, /atom/movable/proc/recursive_move)
 	//GLOB.dir_set_event.register(event_source, listener, /atom/proc/recursive_dir_set)
 
 /proc/unregister_all_movement(var/event_source, var/datum/listener)
-	listener.UnregisterSignal(event_source, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+	listener.UnregisterSignal(event_source, COMSIG_MOVABLE_MOVED)
 	//GLOB.dir_set_event.unregister(event_source, listener, /atom/proc/recursive_dir_set)
 */

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -471,7 +471,7 @@
 
 /atom/Entered(atom/movable/AM, atom/old_loc)
 	. = ..()
-	SEND_SIGNAL(AM, COMSIG_MOVABLE_ATTEMPTED_MOVE, old_loc, AM.loc)
+	SEND_SIGNAL(AM, COMSIG_MOVABLE_MOVED, old_loc, AM.loc)
 	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, AM, old_loc)
 	SEND_SIGNAL(AM, COMSIG_ATOM_ENTERING, src, old_loc)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -44,6 +44,8 @@
 	var/icon_tinted
 	var/id_tint
 
+	var/update_adjacent_tiles = TRUE
+
 /obj/machinery/door/attack_generic(var/mob/user, var/damage)
 	if(isanimal(user))
 		var/mob/living/simple_mob/S = user
@@ -602,7 +604,8 @@
 			bound_width = world.icon_size
 			bound_height = width * world.icon_size
 
-	update_nearby_tiles()
+	if(update_adjacent_tiles)
+		update_nearby_tiles()
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -6,11 +6,11 @@
 	var/obj/machinery/filler_object/filler2
 	open_sound_powered = 'sound/machines/door/WideOpen.ogg'
 	close_sound_powered = 'sound/machines/door/WideClose.ogg'
+	update_adjacent_tiles = FALSE
 
 /obj/machinery/door/airlock/multi_tile/Initialize(mapload)
 	. = ..()
 	SetBounds()
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(SetBounds))
 	apply_opacity_to_my_turfs(opacity)
 
 /obj/machinery/door/airlock/multi_tile/set_opacity()
@@ -21,10 +21,6 @@
 	for(var/turf/T in locs)
 		T.set_opacity(new_opacity)
 	update_nearby_tiles()
-
-/obj/machinery/door/airlock/multi_tile/Destroy()
-	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
-	return ..()
 
 /obj/machinery/door/airlock/multi_tile/proc/SetBounds()
 	SIGNAL_HANDLER

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -73,7 +73,7 @@
 // Do not do power stuff in New/Initialize until after ..()
 /obj/machinery/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(update_power_on_move))
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(update_power_on_move))
 	AddComponent(/datum/component/recursive_move)
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
@@ -83,7 +83,7 @@
 /obj/machinery/Destroy()
 	/*
 	if(ismovable(loc))
-		UnregisterSignal(loc, COMSIG_MOVABLE_ATTEMPTED_MOVE) // Unregister just in case
+		UnregisterSignal(loc, COMSIG_MOVABLE_MOVED) // Unregister just in case
 	*/
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(power, 0)
@@ -96,9 +96,9 @@
 	update_power_on_move(src, old_loc, loc)
 	/* No
 	if(ismovable(old_loc)) // Unregister recursive movement.
-		UnregisterSignal(old_loc, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+		UnregisterSignal(old_loc, COMSIG_MOVABLE_MOVED)
 	if(ismovable(loc)) // Register for recursive movement (if the thing we're inside moves)
-		RegisterSignal(loc, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(update_power_on_move), override = TRUE)
+		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(update_power_on_move), override = TRUE)
 	*/
 
 /obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)

--- a/code/game/mecha/equipment/tools/shield_omni.dm
+++ b/code/game/mecha/equipment/tools/shield_omni.dm
@@ -77,7 +77,7 @@
 /obj/item/shield_projector/rectangle/mecha/Initialize(mapload)
 	. = ..()
 	my_mech = loc
-	RegisterSignal(my_mech, COMSIG_MOVABLE_ATTEMPTED_MOVE, /obj/item/shield_projector/proc/update_shield_positions)
+	RegisterSignal(my_mech, COMSIG_MOVABLE_MOVED, /obj/item/shield_projector/proc/update_shield_positions)
 	my_mech.AddComponent(/datum/component/recursive_move)
 	update_shift(my_mech)
 
@@ -89,7 +89,7 @@
 	shift_y = round(y_dif, 1)
 
 /obj/item/shield_projector/rectangle/mecha/Destroy()
-	UnregisterSignal(my_mech, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+	UnregisterSignal(my_mech, COMSIG_MOVABLE_MOVED)
 	my_mech = null
 	. = ..()
 

--- a/code/game/objects/items/devices/communicator/phone.dm
+++ b/code/game/objects/items/devices/communicator/phone.dm
@@ -349,7 +349,7 @@
 	video_source = comm.camera
 	comm.visible_message(span_danger("[icon2html(src,viewers(src))] New video connection from [comm]."))
 	update_active_camera_screen()
-	RegisterSignal(video_source, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(update_active_camera_screen))
+	RegisterSignal(video_source, COMSIG_MOVABLE_MOVED, PROC_REF(update_active_camera_screen))
 	video_source.AddComponent(/datum/component/recursive_move)
 	update_icon()
 
@@ -357,7 +357,7 @@
 // Parameters: reason - the text reason to print for why it ended
 // Description: Ends the video call by clearing video_source
 /obj/item/communicator/proc/end_video(var/reason)
-	UnregisterSignal(video_source, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+	UnregisterSignal(video_source, COMSIG_MOVABLE_MOVED)
 	show_static()
 	video_source = null
 

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -40,14 +40,14 @@ GLOBAL_LIST_EMPTY(GPS_list)
 /obj/item/gps/proc/update_holder()
 
 	if(holder && loc != holder)
-		UnregisterSignal(holder, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+		UnregisterSignal(holder, COMSIG_MOVABLE_MOVED)
 		//GLOB.dir_set_event.unregister(holder, src)
 		holder.client?.screen -= compass
 		holder = null
 
 	if(istype(loc, /mob))
 		holder = loc
-		RegisterSignal(holder, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(update_compass), override = TRUE)
+		RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(update_compass), override = TRUE)
 		holder.AddComponent(/datum/component/recursive_move)
 		//GLOB.dir_set_event.register(holder, src, PROC_REF(update_compass))
 

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -154,7 +154,7 @@
 
 /obj/item/tvcamera/proc/update_feed()
 	if(camera.status)
-		SEND_SIGNAL(camera, COMSIG_MOVABLE_ATTEMPTED_MOVE) // Forward the movement signal
+		SEND_SIGNAL(camera, COMSIG_MOVABLE_MOVED) // Forward the movement signal
 
 //Assembly by roboticist
 

--- a/code/game/objects/items/weapons/id cards/cards.dm
+++ b/code/game/objects/items/weapons/id cards/cards.dm
@@ -280,7 +280,7 @@
 	if(isrobot(loc?.loc))
 		R = loc.loc
 		registered_name = R.braintype
-		RegisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(check_loc))
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(check_loc))
 
 /obj/item/card/id/cargo/miner/borg/proc/check_loc(atom/movable/mover, atom/old_loc, atom/new_loc)
 	SIGNAL_HANDLER
@@ -297,7 +297,7 @@
 
 /obj/item/card/id/cargo/miner/borg/Destroy()
 	if(R)
-		UnregisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+		UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 		R = null
 		last_robot_loc = null
 	. = ..()

--- a/code/game/objects/items/weapons/id cards/id_stacks.dm
+++ b/code/game/objects/items/weapons/id cards/id_stacks.dm
@@ -306,7 +306,7 @@
 	if(isrobot(loc?.loc))
 		R = loc.loc
 		registered_name = R.braintype
-		RegisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE, PROC_REF(check_loc))
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(check_loc))
 
 /obj/item/card/id/exploration/borg/proc/check_loc(atom/movable/mover, atom/old_loc, atom/new_loc)
 	SIGNAL_HANDLER
@@ -323,7 +323,7 @@
 
 /obj/item/card/id/exploration/borg/Destroy()
 	if(R)
-		UnregisterSignal(src, COMSIG_MOVABLE_ATTEMPTED_MOVE)
+		UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 		R = null
 		last_robot_loc = null
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes a mistake where some signals that were previously COMSIG_OBSERVER_MOVED got changed to COMSIG_MOVABLE_ATTEMPTED_MOVE when it should have been COMSIG_MOVABLE_MOVED 

TODO: Test banana

- [X]  Test multiairlock

## Changelog
:cl: Diana
code: Fixes signal usage in a few places
/:cl:
