### PR TITLE
prevent shadekin conflagration in phase

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -221,6 +221,9 @@
 /datum/status_effect/fire_handler/fire_stacks/proc/deal_damage(seconds_per_tick)
 	owner.on_fire_stack(seconds_per_tick, src)
 
+	if(owner.is_incorporeal()) // Shadekin don't spread fire in phase, but still take damage
+		return
+
 	var/turf/location = get_turf(owner)
 	location.hotspot_expose(700, 25 * seconds_per_tick, TRUE)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -326,6 +326,8 @@
 // ++++ROCKDTBEN++++ MOB PROCS //END
 
 /mob/living/carbon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(is_incorporeal())
+		return
 	..()
 	var/temp_inc = max(min(BODYTEMP_HEATING_MAX*(1-get_heat_protection()), exposed_temperature - bodytemperature), 0)
 	bodytemperature += temp_inc

--- a/code/modules/mob/living/living_fire.dm
+++ b/code/modules/mob/living/living_fire.dm
@@ -2,6 +2,8 @@
 
 //altered this to cap at the temperature of the fire causing it, using the same 1:1500 value as /mob/living/carbon/human/handle_fire() in human/life.dm
 /mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(is_incorporeal())
+		return
 	if(exposed_temperature)
 		if(fire_stacks < exposed_temperature/1500) // Subject to balance
 			adjust_fire_stacks(2)
@@ -106,6 +108,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 //Called in MobBump() and Crossed()
 /mob/living/proc/spreadFire(mob/living/spread_to)
 	if(!istype(spread_to))
+		return
+
+	// Shadekin checkkkkk~~~
+	if(is_incorporeal() || spread_to.is_incorporeal())
 		return
 
 	// can't spread fire to mobs that don't catch on fire

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -370,6 +370,8 @@
 	return canmove
 
 /mob/living/silicon/robot/fire_act()
+	if(is_incorporeal())
+		return
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them
 		ignite_mob()
 


### PR DESCRIPTION
## About The Pull Request
Shadekin are getting set on fire in phase again.

## Changelog
Prevents shadekin, and any other mob using incorporeal components/vars from catching on fire in phase, and also spreading fire while in phase.

:cl: Willbird
fix: Fixes shadekin getting set on fire while in phase, and being able to spread fire while phased
/:cl:
