### PR TITLE
Laying down is random once again

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1852,6 +1852,31 @@
 	rest_dir = !rest_dir
 	update_transform(TRUE)
 
+// These are here mostly for people who wish to use macros for funny things, so they can lay in specific directions.
+// They're hidden so they dont clog up the verb panel normally.
+/mob/living/carbon/human/verb/lay_right()
+	set name = "Rest Right"
+	set hidden = TRUE
+
+	rest_dir = FALSE
+	resting = !resting
+	to_chat(src, span_notice("You are now [resting ? "resting" : "getting up"]."))
+
+/mob/living/carbon/human/verb/lay_left()
+	set name = "Rest Left"
+	set hidden = TRUE
+
+	rest_dir = TRUE
+	resting = !resting
+	to_chat(src, span_notice("You are now [resting ? "resting" : "getting up"]."))
+
+/mob/living/carbon/human/verb/lay_same()
+	set name = "Rest Same"
+	set hidden = TRUE
+
+	resting = !resting
+	to_chat(src, span_notice("You are now [resting ? "resting" : "getting up"]."))
+
 /mob/living/carbon/human/get_digestion_nutrition_modifier()
 	return species.digestion_nutrition_modifier
 


### PR DESCRIPTION

## About The Pull Request

When you lay down, the direction you lay down in is random, again. You can still toggle the direction you want to be laying in using the flip resting direction verb if you want to lay in a specific direction
## Changelog
:cl:
qol: Resting is random again, getting up and laying back down wont always result in you laying in the same direction every time
/:cl:
