### PR TITLE
Allows for the narration

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -89,7 +89,7 @@ ADMIN_VERB(drop_everything, R_ADMIN, "Drop Everything", ADMIN_VERB_NO_DESCRIPTIO
 	if (!check_rights_for(src, R_HOLDER))
 		return
 
-	var/msg = tgui_input_text(usr, "Message:", text("Subtle PM to [M.key]"))
+	var/msg = tgui_input_text(usr, "Message:", text("Subtle PM to [M.key]"), encode = FALSE)
 
 	if (!msg)
 		return
@@ -115,7 +115,7 @@ ADMIN_VERB(drop_everything, R_ADMIN, "Drop Everything", ADMIN_VERB_NO_DESCRIPTIO
 	if (!check_rights_for(src, R_HOLDER))
 		return
 
-	var/msg = tgui_input_text(usr, "Message:", text("Enter the text you wish to appear to everyone:"))
+	var/msg = tgui_input_text(usr, "Message:", text("Enter the text you wish to appear to everyone:"), encode = FALSE)
 
 	if (!msg)
 		return


### PR DESCRIPTION

## About The Pull Request
Makes admin global narrate and admin subtle PM allow for using HTML...This was added previously but a TGUI update appears to have made it so it auto-encodes, which is fine in 99% of scenarios but for these it uses special encoding handling.
## Changelog
:cl:
admin: Global narrate and Admin Subtle PM can now use HTML
/:cl:
