### PR TITLE
Makes bio augments not infectable by default

### DIFF
--- a/code/modules/organs/internal/augment/bio.dm
+++ b/code/modules/organs/internal/augment/bio.dm
@@ -6,7 +6,6 @@
 	icon_state = "augment_hybrid"
 	dead_icon = "augment_hybrid_dead"
 
-	robotic = ORGAN_ASSISTED
 	target_parent_classes = list(ORGAN_FLESH)
 
 /* Jensen Shades. Your vision can be augmented.
@@ -23,8 +22,6 @@
 	w_class = ITEMSIZE_TINY
 
 	organ_tag = O_AUG_EYES
-
-	robotic = ORGAN_ROBOT
 
 	parent_organ = BP_HEAD
 
@@ -83,6 +80,8 @@
 	organ_tag = O_AUG_PELVIC
 
 	parent_organ = BP_GROIN
+
+	robotic = ORGAN_ASSISTED //'chunk of meat'
 
 	target_parent_classes = list(ORGAN_FLESH, ORGAN_ROBOT)
 


### PR DESCRIPTION

## About The Pull Request
Makes bio augments not infectable by default.

The only bio augment that IS infectable is the locomotion implant.
## Changelog
:cl: Diana
fix: Medical implant will no longer become infected
/:cl:
