### PR TITLE
Vore test runtime fix

### DIFF
--- a/code/modules/unit_tests/vore_tests.dm
+++ b/code/modules/unit_tests/vore_tests.dm
@@ -1,6 +1,8 @@
 /datum/unit_test/proc/create_test_human(turf/loc = null)
 	if(!loc)
 		for(var/turf/simulated/floor/tiled/T in world)
+			if(!T.zone)
+				continue
 			var/pressure = T.zone.air.return_pressure()
 			if(90 < pressure && pressure < 120) // Find a turf between 90 and 120
 				loc = T


### PR DESCRIPTION
## About The Pull Request
Doesn't appear to apply to upstream, but if the first map loaded is unsuitable for unit testing, and the turf scan looking for a valid turf encounters a door. It will runtime. As zas does not place zones in door turfs. Fixes a downstream runtime where our underground uses planet atmos, and pois that spawn in it runtime when the turfscan reaches the doors in them.

documentation of a normal door ingame with no zone:
<img width="557" height="315" alt="prdoor" src="https://github.com/user-attachments/assets/d27211a7-e4ad-4970-98e8-cf42c9572984" />


## Changelog
Adds a zone nullcheck when locating a valid turf to place the test mob on.

:cl: Willburd
fix: runtime during vore unit tests on some downstream maps
/:cl:
