### PR TITLE
Internal wounds & spleen tweak

### DIFF
--- a/code/datums/diseases/roanoke.dm
+++ b/code/datums/diseases/roanoke.dm
@@ -82,6 +82,8 @@
 				var/obj/item/organ/external/E = O.parent_organ
 				var/datum/wound/W = new /datum/wound/internal_bleeding(5)
 				E.wounds += W
+				E.update_damages()
+				M.handle_organs(TRUE) //Force an update so we start processing the internal bleeding.
 
 			if(M.stat == DEAD || M.allow_spontaneous_tf)
 				M.LoadComponent(/datum/component/xenochimera)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -17,11 +17,11 @@
 	last_dam = damage_this_tick
 
 // Takes care of organ related updates, such as broken and missing limbs
-/mob/living/carbon/human/proc/handle_organs()
+/mob/living/carbon/human/proc/handle_organs(force = FALSE)
 
 	var/force_process = recheck_bad_external_organs()
 
-	if(force_process)
+	if(force_process || force)
 		bad_external_organs.Cut()
 		for(var/obj/item/organ/external/Ex in organs)
 			bad_external_organs += Ex //VOREStation Edit - Silly and slow to |= this

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1072,6 +1072,8 @@
 		if(prob(selection.w_class * 5) && (affected.robotic < ORGAN_ROBOT)) //I'M SO ANEMIC I COULD JUST -DIE-.
 			var/datum/wound/internal_bleeding/I = new (min(selection.w_class * 5, 15))
 			affected.wounds += I
+			affected.update_damages()
+			H.handle_organs(TRUE) //Force an update so we start processing the internal bleeding.
 			H.custom_pain("Something tears wetly in your [affected] as [selection] is pulled free!", 50)
 
 		if (ishuman(U))

--- a/code/modules/organs/internal/appendix.dm
+++ b/code/modules/organs/internal/appendix.dm
@@ -41,6 +41,8 @@
 			var/datum/wound/W = new /datum/wound/internal_bleeding(20)
 			owner.adjustToxLoss(25)
 			groin.wounds += W
+			groin.update_damages()
+			owner.handle_organs(TRUE) //Force an update so we start processing the internal bleeding.
 			inflamed = 1
 */
 /obj/item/organ/internal/appendix/removed()

--- a/code/modules/organs/internal/spleen.dm
+++ b/code/modules/organs/internal/spleen.dm
@@ -17,13 +17,15 @@
 		//High toxins levels are dangerous
 		if(owner.getToxLoss() >= 30 && !owner.reagents.has_reagent(REAGENT_ID_ANTITOXIN))
 			//Healthy liver suffers on its own
-			if (src.damage < min_broken_damage)
+			if(src.damage < min_broken_damage)
 				src.damage += 0.2 * spleen_tick
+				owner.adjustToxLoss(-0.2) //The spleen takes damage but reduces toxins, up until it's broken.
 			//Damaged one shares the fun
 			else
 				var/obj/item/organ/internal/O = pick(owner.internal_organs)
 				if(O)
 					O.damage += 0.2 * spleen_tick
+					owner.adjustToxLoss(-0.1) //Only half as effective.
 
 		else if(!src.is_broken()) // If the spleen isn't severely damaged, it can help fight infections. Key word, can.
 			var/obj/item/organ/external/OEx = pick(owner.organs)
@@ -66,10 +68,12 @@
 	..()
 	if(owner)
 		owner.add_modifier(/datum/modifier/trait/haemophilia, round(15 MINUTES * spleen_efficiency))
-		var/obj/item/organ/external/Target = owner.get_organ(parent_organ)
+		var/obj/item/organ/external/target = owner.get_organ(parent_organ)
 		var/datum/wound/W = new /datum/wound/internal_bleeding(round(20 * spleen_efficiency))
 		owner.adjustToxLoss(15 * spleen_efficiency)
-		Target.wounds += W
+		target.wounds += W
+		target.update_damages()
+		owner.handle_organs(TRUE) //Force an update so we start processing the internal bleeding.
 
 /obj/item/organ/internal/spleen/minor
 	name = "vestigial spleen"

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -176,6 +176,8 @@
 		to_chat(user, span_danger(" You tear some blood vessels trying to fit such a big object in this cavity."))
 		var/datum/wound/internal_bleeding/I = new (10)
 		affected.wounds += I
+		affected.update_damages()
+		affected.owner.handle_organs(TRUE) //Force an update so we start processing the internal bleeding.
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1)
 	affected.implants += tool
 	tool.loc = affected


### PR DESCRIPTION

## About The Pull Request
Fixes a bug where internal wounds were being applied in some cases, but never processing due to the fact that the external limb didn't have any damage (and update_damages hadn't been called)

Makes it so the spleen removes toxins over time instead of simply causing damage (and killing itself and all organs) when there are toxins present. It still takes damage, but no longer will it take damage with no upside.
## Changelog
:cl: Diana
qol: Having a spleen will no longer cause you to suffer infinite organ damage while damaged by toxins. Instead, it'll convert that toxin damage into organ damage.
fix: Having your spleen rupture will now cause real internal bleeding instead of fake internal bleeding
/:cl:
