### PR TITLE
Fix drones being unable to ventcrawl

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
@@ -107,7 +107,7 @@ var/list/_slime_default_emotes = list(
 		drop_hat()
 	return ..()
 
-/mob/living/silicon/robot/drone/ventcrawl_get_item_whitelist()
+/mob/living/simple_mob/slime/ventcrawl_get_item_whitelist()
 	return list(
 		VENTCRAWL_BASE_WHITELIST,
 		VENTCRAWL_VORE_WHITELIST,


### PR DESCRIPTION
## About The Pull Request
Drone vent crawling was blocked by a copypasta error making them use the slime crawl list instead.

## Changelog
Corrected the path for slime ventcrawl items to not be drone's list instead.

:cl: Will
fix: Drone ventcrawling no longer using slime's vent crawling restriction list
/:cl:
