### PR TITLE
Resleever minifix

### DIFF
--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -145,6 +145,8 @@ GLOBAL_LIST_EMPTY(active_autoresleevers)
 
 	var/slot = ghost.client.prefs.default_slot
 	if(tgui_alert(ghost, "Would you like to be resleeved?", "Resleeve", list("No","Yes")) != "Yes")
+		if(respawn >= world.time - ghost.timeofdeath) //We were given the option to resleeve due to an outside event, but closed the input box (be it by typing or otherwise) so we allow clicking the autosleever to revive.
+			ghost.timeofdeath = world.time - respawn
 		return
 	//This keeps people from dying in round, clicking the autoresleever, then swapping savefiles and clicking 'yes'
 	if(slot != ghost.client.prefs.default_slot && (!equip_body || !ghost_spawns))


### PR DESCRIPTION
## About The Pull Request
Makes it so that if outside forces (i.e ID passing resleever) gives you the resleever prompt but you accidentally close it (via typing in chat when the popup comes up) it allows you to manually click it to resleeve.
## Changelog
:cl: Diana
qol: You can manually resleeve with the autosleever if you're given the prompt and accidentally close it.
/:cl:
