### PR TITLE
Added a spice crate to cargo

### DIFF
--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -34,6 +34,19 @@
 	containertype = /obj/structure/closet/crate/freezer/centauri
 	containername = "Artisanal food crate"
 
+/datum/supply_pack/supply/condiments
+	name = "Cooking seasonings crate"
+	desc = "Essential seasonings and spices for cooking."
+	contains = list(
+			/obj/item/reagent_containers/food/condiment/small/saltshaker = 6,
+			/obj/item/reagent_containers/food/condiment/small/peppermill = 6,
+			/obj/item/reagent_containers/food/condiment/spacespice = 3,
+			/obj/item/reagent_containers/food/condiment/sugar = 3,
+			)
+	cost = 30
+	containertype = /obj/structure/closet/crate/freezer/centauri
+	containername = "Cooking seasonings crate"
+
 
 /datum/supply_pack/supply/toner
 	name = "Toner cartridges"


### PR DESCRIPTION
## About The Pull Request

Adds a simple spice crate option to the cargo computer for the kitchen to use..
Gives a way to acquire more pepper if it's all used up, and some extra use for cargo.
## Changelog

:cl: Nova
qol: Add spice crate option to be requested from cargo.
/:cl:
