### PR TITLE
Unsimmed turfs have a base explosion resistance

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -32,3 +32,11 @@
 
 /turf/simulated/wall
 	explosion_resistance = 10
+
+
+// Lets pretend we're plating, these should only exist at places like central.
+/turf/unsimulated
+	explosion_resistance = 1
+
+/turf/unsimulated/wall
+	explosion_resistance = 10


### PR DESCRIPTION
## About The Pull Request
Prevents explosions in central command from propagating forever(at least until map edge).

## Changelog
Adds blast resistance to unsimmed and unsimmed wall turfs.

:cl: Willburd
fix: Unsimmed turfs now have a properly set blast resistance
/:cl:
