### PR TITLE
Fixes teshari CE being unselectable

### DIFF
--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -29,7 +29,7 @@
 	#define JOB_ALT_SECURITY_MANAGER "Security Manager"
 
 #define JOB_CHIEF_ENGINEER "Chief Engineer"
-	// Cheif Engineer alt titles
+	// Chief Engineer alt titles
 	#define JOB_ALT_HEAD_ENGINEER "Head Engineer"
 	#define JOB_ALT_FOREMAN "Foreman"
 	#define JOB_ALT_MAINTENANCE_MANAGER "Maintenance Manager"

--- a/code/modules/client/preference_setup/loadout/loadout_xeno.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno.dm
@@ -303,7 +303,7 @@
 		cloaks[initial(cloak_type.name)] = cloak_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
-/datum/gear/suit/cloak/dept/ce
+/datum/gear/suit/dept/cloak/ce
 	display_name = "chief engineer cloak (Teshari)"
 	path = /obj/item/clothing/suit/storage/teshari/cloak/jobs/ce
 	allowed_roles = list(JOB_CHIEF_ENGINEER)

--- a/code/modules/clothing/suits/aliens/teshari.dm
+++ b/code/modules/clothing/suits/aliens/teshari.dm
@@ -133,7 +133,7 @@
 //Engineering
 
 /obj/item/clothing/suit/storage/teshari/cloak/jobs/ce
-	name = "cheif engineer cloak"
+	name = "chief engineer cloak"
 	desc = "A soft Teshari cloak made for the "+ JOB_CHIEF_ENGINEER
 	icon_state = "tesh_cloak_ce"
 
@@ -151,7 +151,7 @@
 
 /obj/item/clothing/suit/storage/teshari/cloak/jobs/cmo
 	name = "chief medical officer cloak"
-	desc = "A soft Teshari cloak made the Cheif Medical Officer"
+	desc = "A soft Teshari cloak made the Chief Medical Officer"
 	icon_state = "tesh_cloak_cmo"
 
 /obj/item/clothing/suit/storage/teshari/cloak/jobs/medical

--- a/code/modules/clothing/under/xenos/teshari.dm
+++ b/code/modules/clothing/under/xenos/teshari.dm
@@ -231,7 +231,7 @@
 	icon_state = "tesh_uniform_hop"
 
 /obj/item/clothing/under/teshari/undercoat/jobs/ce
-	name = "cheif engineer undercoat"
+	name = "chief engineer undercoat"
 	desc = "A traditional Teshari garb made for the " + JOB_CHIEF_ENGINEER
 	icon_state = "tesh_uniform_ce"
 
@@ -257,7 +257,7 @@
 
 /obj/item/clothing/under/teshari/undercoat/jobs/cmo
 	name = "chief medical officer undercoat"
-	desc = "A traditional Teshari garb made for the Cheif Medical Officer"
+	desc = "A traditional Teshari garb made for the Chief Medical Officer"
 	icon_state = "tesh_uniform_cmo"
 
 /obj/item/clothing/under/teshari/undercoat/jobs/qm


### PR DESCRIPTION

## About The Pull Request

Teshari CEs no longer confined to Cloak Selection

## Changelog
:cl: Guti
fix: Teshari CE cloak can now be properly selected
spellcheck: Changes multiple instances of "Cheif" to "Chief"
/:cl:
