### PR TITLE
Fixes dark maw not eating captured prey

### DIFF
--- a/code/_helpers/vore.dm
+++ b/code/_helpers/vore.dm
@@ -4,7 +4,7 @@
 
 /// Most basic check of them all.
 /// Checks if PRED can eat PREY.
-/proc/can_vore(mob/living/pred, mob/living/prey)
+/proc/can_vore(mob/living/pred, mob/living/prey, allow_incorporeal = FALSE)
 	if(pred == prey)
 		return FALSE
 	if(!istype(pred) || !istype(prey))
@@ -14,7 +14,8 @@
 	if(!is_vore_predator(pred))
 		return FALSE
 	if(prey.is_incorporeal() || pred.is_incorporeal())
-		return FALSE
+		if(!allow_incorporeal)
+			return FALSE
 	if(!pred.vore_selected)
 		return FALSE
 	if(!pred.can_be_afk_pred && (!pred.client || pred.away_from_keyboard))
@@ -25,8 +26,8 @@
 
 /// Basic spont vore check.
 /// Checks if both have spont vore enable
-/proc/can_spontaneous_vore(mob/living/pred, mob/living/prey)
-	if(!can_vore(pred, prey))
+/proc/can_spontaneous_vore(mob/living/pred, mob/living/prey, allow_incorporeal = FALSE)
+	if(!can_vore(pred, prey, allow_incorporeal))
 		return FALSE
 	if(!pred.can_be_drop_pred || !prey.can_be_drop_prey)
 		return FALSE
@@ -60,8 +61,8 @@
 		return FALSE
 	return TRUE
 
-/proc/can_phase_vore(mob/living/pred, mob/living/prey)
-	if(!can_spontaneous_vore(pred, prey))
+/proc/can_phase_vore(mob/living/pred, mob/living/prey, allow_incorporeal = FALSE)
+	if(!can_spontaneous_vore(pred, prey, allow_incorporeal))
 		return FALSE
 	if(!pred.phase_vore || !prey.phase_vore)
 		return FALSE

--- a/code/datums/components/species/shadekin/powers/dark_maw.dm
+++ b/code/datums/components/species/shadekin/powers/dark_maw.dm
@@ -156,7 +156,7 @@
 /obj/effect/abstract/dark_maw/proc/do_trigger(var/mob/living/L)
 	var/will_vore = 1
 
-	if(!(target in owner) || !can_phase_vore(owner, L))
+	if(!(target in owner) || !can_phase_vore(owner, L, TRUE))
 		will_vore = 0
 
 	if(!src || src.gc_destroyed)


### PR DESCRIPTION

## About The Pull Request

Adds an extra check to override if either prey/pred should be incorporeal on the vore helpers

## Changelog
:cl: Guti
fix: Fixed Dark Maw not eating captured prey, if prefs aligned
/:cl:
