### PR TITLE
Fix job availability countdown

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -92,7 +92,7 @@
 			// reasons you can't select it
 			"banned" = !!jobban_isbanned(user, job.title),
 			"denylist_days" = !job.player_old_enough(user.client),
-			"available_in_days" = !job.available_in_days(user.client),
+			"available_in_days" = job.available_in_days(user.client),
 			"denylist_playtime" = !job.player_has_enough_playtime(user.client),
 			"available_in_hours" = job.available_in_playhours(user.client),
 			"denylist_whitelist" = !is_job_whitelisted(user, job.title),


### PR DESCRIPTION
## About The Pull Request

Fixes the number of hours until a job is available.

Fixes #18984

Can not test locally due to this requiring a database.

## Changelog
:cl:
fix: Fixes the number of hours until a job is available.
/:cl:
