### PR TITLE
Small clickfix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -84,7 +84,7 @@
 		CtrlClickOn(A)
 		return
 
-	//Replaces thee old 'stat||paralysis||stunned' check
+	//Replaces the old 'stat||paralysis||stunned' check
 	//Not fully implemented yet.
 	if(INCAPACITATED_IGNORING(src, INCAPABLE_RESTRAINTS|INCAPABLE_STASIS))
 		return
@@ -118,10 +118,16 @@
 	var/obj/item/W = get_active_hand()
 
 	if(!currently_restrained && W == A) // Handle attack_self
-		W.attack_self(src)
-		trigger_aiming(TARGET_CAN_CLICK)
-		update_inv_active_hand(0)
-		return 1
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
+			W.attack_self_secondary(src, modifiers)
+			trigger_aiming(TARGET_CAN_CLICK)
+			update_inv_active_hand(0)
+			return TRUE
+		else
+			W.attack_self(src, modifiers)
+			trigger_aiming(TARGET_CAN_CLICK)
+			update_inv_active_hand(0)
+			return TRUE
 
 	//Atoms on your person
 	// A is your location but is not a turf; or is on you (backpack); or is on something on you (box in backpack); sdepth is needed here because contents depth does not equate inventory storage depth.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -26,7 +26,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * returns TRUE if the attack was handled by a signal handler and no further processing should occur.
  * returns FALSE if a signal handler did NOT handle it, resulting in the normal chain.
 */
-/obj/item/proc/attack_self(mob/user)
+/obj/item/proc/attack_self(mob/user, modifiers)
 	SHOULD_CALL_PARENT(TRUE)
 	if(!user)
 		CRASH("attack_self was called without a user!")

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -149,6 +149,9 @@
 	if(.)
 		return TRUE
 	var/turf/T = get_turf(user)
+	if(!T)
+		to_chat(user, span_warning("You must be standing on solid ground to deploy an extraction beacon!"))
+		return
 	if(do_after(user, 1.5 SECONDS, target = user) && !QDELETED(src))
 		new /obj/structure/extraction_point(get_turf(user))
 		qdel(src)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -153,23 +153,27 @@
 	set category = "Object"
 	set src = usr
 
+	if(ismecha(loc))
+		return
+
+	if(INCAPACITATED_IGNORING(src, INCAPABLE_GRAB))
+		return
+
+	if(stat || paralysis || stunned)
+		return
+
+	if(restrained())
+		return
+
 	if(!checkClickCooldown())
 		return
 
 	setClickCooldown(1)
 
-	if(istype(loc,/obj/mecha)) return
-
-	if(hand)
-		var/obj/item/W = l_hand
-		if (W)
-			W.attack_self(src)
-			update_inv_l_hand()
-	else
-		var/obj/item/W = r_hand
-		if (W)
-			W.attack_self(src)
-			update_inv_r_hand()
+	var/obj/item/inhand = get_active_hand()
+	if(inhand)
+		inhand.attack_self(src)
+		update_inv_active_hand()
 	return
 
 /mob/living/abiotic(var/full_body = 0)


### PR DESCRIPTION

## About The Pull Request
Adds ability to right-click use item on self. attack_self_secondary (Nothing uses this, yet.)
Fixes a typo in a comment
Adds some sanity checks with the 'Activate-Held-Object' button, as it was revealed that it bypasses incapacitation, stat, etc checks.
Prevents fultons from being deployed unless the user is on a turf.
## Changelog
:cl: Diana
fix: You can no longer activate grenades in your hand while dead.
code: Rightclick functionality with held objects is possible now.
fix: Fultons can no longer be deployed inside of things.
/:cl:
