### PR TITLE
Giving someone a grab no longer leaves a deleted grab

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -18,6 +18,13 @@
 		to_chat(src, span_warning("You don't have anything in your hands to give to \the [target]."))
 		return
 
+	if(istype(I, /obj/item/grab)) // Drop grabs, this is an edge case
+		var/obj/item/grab/check_grab = I
+		if(check_grab.affecting)
+			visible_message(span_danger("\The [src] breaks their grip on [check_grab.affecting]!"))
+		drop_from_inventory(check_grab)
+		return
+
 	src.visible_message(span_notice("\The [src] holds out \the [I] to \the [target]."), span_notice("You hold out \the [I] to \the [target], waiting for them to accept it."))
 
 	if(tgui_alert(target,"[src] wants to give you \a [I]. Will you accept it?","Item Offer",list("Yes","No")) != "Yes")


### PR DESCRIPTION
## About The Pull Request
Using the give verb to pass a grabbed mob would result in the grab being dropped on the ground. Now it just releases the grab. This is an edge case that missed being handled, and was probably just considered normal before grabs were cleaned up before, so it was never reported until now.

## Changelog
Adds a grab check when passing an item to another player via the give verb

:cl: Will
fix: Attempting to pass mob grabs to another player no longer drops a qdeleted grab on the floor
/:cl:
