### PR TITLE
remote view look upwards

### DIFF
--- a/code/datums/components/remote_view.dm
+++ b/code/datums/components/remote_view.dm
@@ -60,6 +60,9 @@
 		RegisterSignal(remote_view_target, COMSIG_QDELETING, PROC_REF(handle_endview))
 		RegisterSignal(remote_view_target, COMSIG_MOB_RESET_PERSPECTIVE, PROC_REF(on_remotetarget_reset_perspective))
 		RegisterSignal(remote_view_target, COMSIG_REMOTE_VIEW_CLEAR, PROC_REF(handle_forced_endview))
+	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
+	if(settings.use_zoom_hud && host_mob.hud_used.hud_shown)
+		host_mob.toggle_zoom_hud()
 	// Set view to size, null is default
 	host_mob.set_viewsize(viewsize)
 
@@ -111,6 +114,8 @@
 		UnregisterSignal(remote_view_target, COMSIG_REMOTE_VIEW_CLEAR)
 	// Reset to default size
 	host_mob.set_viewsize()
+	if(settings.use_zoom_hud && !host_mob.hud_used.hud_shown)
+		host_mob.toggle_zoom_hud()
 	// Update the mob's vision right away if it still exists
 	if(!QDELETED(host_mob))
 		settings.detatch_from_mob(src, host_mob)
@@ -293,9 +298,6 @@
 	RegisterSignal(host_item, COMSIG_ITEM_DROPPED, PROC_REF(handle_endview))
 	RegisterSignal(host_item, COMSIG_ITEM_EQUIPPED, PROC_REF(handle_endview))
 	RegisterSignal(host_item, COMSIG_REMOTE_VIEW_CLEAR, PROC_REF(handle_forced_endview))
-	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
-	if(host_mob.hud_used.hud_shown)
-		host_mob.toggle_zoom_hud()
 	// Unfortunately too many things read this to control item state for me to remove this.
 	// Oh well! better than GetComponent() everywhere. Lets just manage item/zoom in this component though...
 	our_item.zoom = TRUE
@@ -325,8 +327,6 @@
 	// Feedback
 	if(show_message)
 		host_mob.visible_message(span_filter_notice("[host_item.zoomdevicename ? "[host_mob] looks up from the [host_item.name]" : "[host_mob] lowers the [host_item.name]"]."))
-	if(!host_mob.hud_used.hud_shown)
-		host_mob.toggle_zoom_hud()
 	host_item.zoom = FALSE
 	// return view offset
 	if(host_mob.client)

--- a/code/datums/components/remote_view.dm
+++ b/code/datums/components/remote_view.dm
@@ -6,7 +6,7 @@
 	VAR_PROTECTED/mob/host_mob
 	VAR_PROTECTED/atom/remote_view_target
 
-/datum/component/remote_view/Initialize(atom/focused_on, vconfig_path)
+/datum/component/remote_view/Initialize(atom/focused_on, viewsize, vconfig_path)
 	. = ..()
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -60,6 +60,8 @@
 		RegisterSignal(remote_view_target, COMSIG_QDELETING, PROC_REF(handle_endview))
 		RegisterSignal(remote_view_target, COMSIG_MOB_RESET_PERSPECTIVE, PROC_REF(on_remotetarget_reset_perspective))
 		RegisterSignal(remote_view_target, COMSIG_REMOTE_VIEW_CLEAR, PROC_REF(handle_forced_endview))
+	// Set view to size, null is default
+	host_mob.set_viewsize(viewsize)
 
 /datum/component/remote_view/RegisterWithParent()
 	// Update the mob's vision after we attach.
@@ -107,6 +109,8 @@
 		UnregisterSignal(remote_view_target, COMSIG_QDELETING)
 		UnregisterSignal(remote_view_target, COMSIG_MOB_RESET_PERSPECTIVE)
 		UnregisterSignal(remote_view_target, COMSIG_REMOTE_VIEW_CLEAR)
+	// Reset to default size
+	host_mob.set_viewsize()
 	// Update the mob's vision right away if it still exists
 	if(!QDELETED(host_mob))
 		settings.detatch_from_mob(src, host_mob)
@@ -281,7 +285,7 @@
 	VAR_PRIVATE/obj/item/host_item
 	VAR_PRIVATE/show_message
 
-/datum/component/remote_view/item_zoom/Initialize(atom/focused_on, vconfig_path, obj/item/our_item, viewsize, tileoffset, show_visible_messages)
+/datum/component/remote_view/item_zoom/Initialize(atom/focused_on, viewsize, vconfig_path, obj/item/our_item, tileoffset, show_visible_messages)
 	. = ..()
 	host_item = our_item
 	RegisterSignal(host_item, COMSIG_QDELETING, PROC_REF(handle_endview))
@@ -292,7 +296,6 @@
 	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
 	if(host_mob.hud_used.hud_shown)
 		host_mob.toggle_zoom_hud()
-	host_mob.set_viewsize(viewsize)
 	// Unfortunately too many things read this to control item state for me to remove this.
 	// Oh well! better than GetComponent() everywhere. Lets just manage item/zoom in this component though...
 	our_item.zoom = TRUE
@@ -322,8 +325,6 @@
 	// Feedback
 	if(show_message)
 		host_mob.visible_message(span_filter_notice("[host_item.zoomdevicename ? "[host_mob] looks up from the [host_item.name]" : "[host_mob] lowers the [host_item.name]"]."))
-	// Reset to default
-	host_mob.set_viewsize()
 	if(!host_mob.hud_used.hud_shown)
 		host_mob.toggle_zoom_hud()
 	host_item.zoom = FALSE
@@ -347,7 +348,7 @@
  */
 /datum/component/remote_view/mremote_mutation
 
-/datum/component/remote_view/mremote_mutation/Initialize(atom/focused_on, vconfig_path)
+/datum/component/remote_view/mremote_mutation/Initialize(atom/focused_on, viewsize, vconfig_path)
 	if(!ismob(focused_on)) // What are you doing? This gene only works on mob targets, if you adminbus this I will personally eat your face.
 		return COMPONENT_INCOMPATIBLE
 	. = ..()
@@ -381,7 +382,7 @@
 	VAR_PRIVATE/datum/view_coordinator // The object containing the viewer_list, with look() and unlook() logic
 	VAR_PRIVATE/list/viewers // list from the view_coordinator, lists in byond are pass by reference, so this is the SAME list as on the coordinator! If you pass a null this will explode.
 
-/datum/component/remote_view/viewer_managed/Initialize(atom/focused_on, vconfig_path, datum/coordinator, list/viewer_list)
+/datum/component/remote_view/viewer_managed/Initialize(atom/focused_on, viewsize, vconfig_path, datum/coordinator, list/viewer_list)
 	. = ..()
 	if(!islist(viewer_list)) // BAD BAD BAD NO
 		CRASH("Passed a viewer_list that was not a list, or was null, to /datum/component/remote_view/viewer_managed component. Ensure the viewer_list exists before passing it into AddComponent.")
@@ -413,7 +414,7 @@
 /datum/component/remote_view/mob_holding_item
 	var/needs_to_decouple = FALSE // if the current top level atom is a mob
 
-/datum/component/remote_view/mob_holding_item/Initialize(atom/focused_on, vconfig_path)
+/datum/component/remote_view/mob_holding_item/Initialize(atom/focused_on, viewsize, vconfig_path)
 	if(!isobj(focused_on)) // You shouldn't be using this if so.
 		return COMPONENT_INCOMPATIBLE
 	. = ..()
@@ -485,7 +486,7 @@
 		spawn(0)
 			// Decouple the view to the turf on drop, or we'll be stuck on the mob that dropped us forever
 			if(!QDELETED(cache_mob))
-				cache_mob.AddComponent(/datum/component/remote_view, focused_on = release_turf, vconfig_path = /datum/remote_view_config/turf_decoupling)
+				cache_mob.AddComponent(/datum/component/remote_view, focused_on = release_turf, viewsize = null, vconfig_path = /datum/remote_view_config/turf_decoupling)
 				cache_mob.client.eye = release_turf // Yes--
 				cache_mob.client.perspective = EYE_PERSPECTIVE // --this is required too.
 				if(!isturf(cache_mob.loc)) // For stuff like paicards

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -376,7 +376,7 @@
 /// Begin coordinated remote viewing, this will call look() when the view begins, and unlook() when it ends.
 /datum/proc/start_coordinated_remoteview(mob/user, atom/target, list/viewer_managed_list, remote_view_config_path = null)
 	ASSERT(islist(viewer_managed_list))
-	user.AddComponent(/datum/component/remote_view/viewer_managed, focused_on = target, vconfig_path = remote_view_config_path, coordinator = src, viewer_list = viewer_managed_list)
+	user.AddComponent(/datum/component/remote_view/viewer_managed, focused_on = target, viewsize = null, vconfig_path = remote_view_config_path, coordinator = src, viewer_list = viewer_managed_list)
 
 /// Called from /datum/component/remote_view/viewer_managed during Initilize().
 /datum/proc/look(mob/user)

--- a/code/datums/remote_view_config.dm
+++ b/code/datums/remote_view_config.dm
@@ -2,6 +2,7 @@
 	// Signal config for remote view component. This controls what signals will be subbed to during init.
 	var/forbid_movement = TRUE
 	var/relay_movement = FALSE
+	var/use_zoom_hud = FALSE
 	// Status effects that will knock us out of remote view
 	var/will_death = TRUE
 	var/will_stun = TRUE
@@ -96,12 +97,23 @@
 	will_sleep = FALSE
 	will_blind = FALSE
 
+/// Remote view that only allows decoupling a turf view by movement. Seperate from effect_immune to allow for easier removal in the future if the underlying issue that makes this needed is someday fixed
+/datum/remote_view_config/looking_up
+	forbid_movement = TRUE
+	use_zoom_hud = TRUE
+
 /// Remote view that relays movement to the remote_view_target
 /datum/remote_view_config/relay_movement
 	relay_movement = TRUE
 
+/// Remote view that relays movement and hides most of the hud
+/datum/remote_view_config/zoomed_item
+	relay_movement = TRUE
+	use_zoom_hud = TRUE
+
 /// Remote view that respects camera vision flags and checking for functionality of the camera.
 /datum/remote_view_config/camera_standard
+	use_zoom_hud = TRUE
 
 /datum/remote_view_config/camera_standard/handle_apply_visuals( datum/component/remote_view/owner_component, mob/host_mob)
 	var/obj/machinery/camera/view_camera = owner_component.get_target()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -863,7 +863,7 @@ GLOBAL_LIST_EMPTY(blood_overlays_by_type)
 		can_zoom = FALSE
 
 	if(!zoom && can_zoom)
-		M.AddComponent(/datum/component/remote_view/item_zoom, focused_on = M, vconfig_path = /datum/remote_view_config/allow_movement, our_item = src, viewsize = viewsize, tileoffset = tileoffset, show_visible_messages = TRUE)
+		M.AddComponent(/datum/component/remote_view/item_zoom, focused_on = M, vconfig_path = /datum/remote_view_config/zoomed_item, our_item = src, viewsize = viewsize, tileoffset = tileoffset, show_visible_messages = TRUE)
 		return
 	SEND_SIGNAL(src,COMSIG_REMOTE_VIEW_CLEAR)
 

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -14,7 +14,7 @@
 
 	var/show_nothing = TRUE
 	var/turf/above_turf = GetAbove(src)
-	if(above_turf && above_turf.CanZPass(src, DOWN))
+	if(above_turf && (above_turf.CanZPass(src, DOWN) || istype(above_turf, /turf/simulated/floor/glass)))
 		if(is_remote_viewing())
 			reset_perspective()
 			return

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -12,8 +12,18 @@
 		to_chat(usr, span_warning("You appear to be in a place without any sort of concept of direction. You have bigger problems to worry about."))
 		return
 
+	var/show_nothing = TRUE
+	var/turf/above_turf = GetAbove(src)
+	if(above_turf && above_turf.CanZPass(src, DOWN))
+		if(is_remote_viewing())
+			reset_perspective()
+			return
+		AddComponent(/datum/component/remote_view, focused_on = above_turf, viewsize = 5, vconfig_path = /datum/remote_view_config/turf_decoupling)
+		show_nothing = FALSE
+
 	if(!T.is_outdoors()) // They're inside.
-		to_chat(usr, "You see nothing interesting.")
+		if(show_nothing)
+			to_chat(usr, "You see nothing interesting.")
 		return
 
 	else // They're outside and hopefully on a planet.

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -18,7 +18,7 @@
 		if(is_remote_viewing())
 			reset_perspective()
 			return
-		AddComponent(/datum/component/remote_view, focused_on = above_turf, viewsize = 5, vconfig_path = /datum/remote_view_config/turf_decoupling)
+		AddComponent(/datum/component/remote_view, focused_on = above_turf, viewsize = 5, vconfig_path = /datum/remote_view_config/looking_up)
 		show_nothing = FALSE
 
 	if(!T.is_outdoors()) // They're inside.

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -14,7 +14,7 @@
 
 	var/show_nothing = TRUE
 	var/turf/above_turf = GetAbove(src)
-	if(above_turf && (above_turf.CanZPass(src, DOWN) || istype(above_turf, /turf/simulated/floor/glass)))
+	if(istype(above_turf, /turf/simulated/open) || istype(above_turf, /turf/space) || istype(above_turf, /turf/simulated/floor/glass)) // Typecheck because CanZPass() doesn't work right, because our actual loc is at the destination so it always returns true if on a floor.
 		if(is_remote_viewing())
 			reset_perspective()
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1009,7 +1009,7 @@
 
 	var/mob/target = input ("Who do you want to project your mind to?") as mob in creatures
 	if(target)
-		AddComponent(/datum/component/remote_view/mremote_mutation, focused_on = target, vconfig_path = null)
+		AddComponent(/datum/component/remote_view/mremote_mutation, focused_on = target, viewsize = null, vconfig_path = null)
 		return
 
 /mob/living/carbon/human/get_visible_gender(mob/user, force)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -177,7 +177,7 @@
 
 	// ok, we're alive, camera is good and in our network...
 	src.current = C
-	src.AddComponent(/datum/component/remote_view, focused_on = C, vconfig_path = /datum/remote_view_config/camera_standard)
+	src.AddComponent(/datum/component/remote_view, focused_on = C, viewsize = null, vconfig_path = /datum/remote_view_config/camera_standard)
 	return 1
 
 /mob/living/silicon/pai/verb/reset_record_view()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -310,10 +310,10 @@
 	if(remote_comp?.looking_at_target_already(loc))
 		return FALSE
 	if(isitem(loc) || isbelly(loc) || ismecha(loc)) // Requires more careful handling than structures because they are held by mobs
-		AddComponent(/datum/component/remote_view/mob_holding_item, focused_on = loc, vconfig_path = /datum/remote_view_config/inside_object)
+		AddComponent(/datum/component/remote_view/mob_holding_item, focused_on = loc, viewsize = null, vconfig_path = /datum/remote_view_config/inside_object)
 		return TRUE
 	if(loc.flags & REMOTEVIEW_ON_ENTER) // Handle atoms that begin a remote view upon entering them.
-		AddComponent(/datum/component/remote_view, focused_on = loc, vconfig_path = /datum/remote_view_config/inside_object)
+		AddComponent(/datum/component/remote_view, focused_on = loc, viewsize = null, vconfig_path = /datum/remote_view_config/inside_object)
 		return TRUE
 	return FALSE
 
@@ -568,7 +568,7 @@
 	var/mob/mob_eye = targets[eye_name]
 
 	if(client && mob_eye)
-		AddComponent(/datum/component/remote_view, focused_on = mob_eye, vconfig_path = null)
+		AddComponent(/datum/component/remote_view, focused_on = mob_eye, viewsize = null, vconfig_path = null)
 		if(is_admin)
 			client.adminobs = TRUE
 			if(mob_eye == client.mob || !is_remote_viewing())


### PR DESCRIPTION

![dreamseeker_RY8YR19ePB](https://github.com/user-attachments/assets/4b6b5fa9-379e-47b3-b1cd-e6a3b2f71262)


## About The Pull Request
Updates the look upward verb to give a remote view one z level above you (if possible). Lets you see in slightly smaller radius than normal. Also updates remote view to allow a view size being passed for any remote view subtype.

## Changelog
Lookup now starts remotely viewing the turf above you.
Remoteview arguments updated to pass in a view size(not just on zooming items)
Remoteview setting datum can now specify if a view type hides most of the hud on zoom

:cl: Will
qol: Look upward verb now lets you look upward one z level
code: remote views with zoom hude or different sizes are easier to start
/:cl:
