### PR TITLE
Fixed simple mob nutrition notifications

### DIFF
--- a/code/modules/mob/living/simple_mob/life.dm
+++ b/code/modules/mob/living/simple_mob/life.dm
@@ -60,13 +60,12 @@
 			healths.icon_state = "health7"
 
 	//Updates the nutrition while we're here
-	var/food_per = (nutrition / max_nutrition) * 100
-	switch(food_per)
-		if(90 to INFINITY)
+	switch(nutrition)
+		if(250 to INFINITY)
 			clear_alert("nutrition")
-		if(50 to 90)
+		if(150 to 250)
 			throw_alert("nutrition", /atom/movable/screen/alert/hungry)
-		if(-INFINITY to 50)
+		if(-INFINITY to 150)
 			throw_alert("nutrition", /atom/movable/screen/alert/starving)
 
 //VOREStation ADD START - I made this for catslugs but tbh it's probably cool to give to everything.


### PR DESCRIPTION


Note that the only thing this effects is the little HUD icon showing the hunger bar.
## About The Pull Request

Changed the threshold of simple mob nutrition notifications to match those of humans, as these were set to insane percentages previously. For most simple mobs, this means:
- Starving starts at <150 rather than <3000 nutrition
- Feeling hungry starts at <250 rather than <5400 nutrition

## Changelog
:cl:
fix: Fixed simple mobs requiring insane amounts of nutrition to remove their hunger bar.
/:cl:
