### PR TITLE
Fixes not being able to fall onto tables

### DIFF
--- a/code/datums/elements/vore/spontaneous_vore.dm
+++ b/code/datums/elements/vore/spontaneous_vore.dm
@@ -51,6 +51,11 @@
 	if(!drop_mob || drop_mob == source)
 		return
 
+	if((drop_mob.status_flags & HIDING))
+		var/obj/structure/table/is_there_a_table = locate() in landing //Don't eat people hiding under tables
+		if(is_there_a_table)
+			return
+
 	//pred = drop_mob
 	//prey = source
 	//result: source is eaten by drop_mob

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,6 +1,8 @@
 /obj/structure/table/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
+	if(mover.z > z)
+		return TRUE //This allows mobs to drop down onto tables from above
 	if(flipped == 1)
 		if(get_dir(mover, target) == GLOB.reverse_dir[dir]) // From elsewhere to here, can't move against our dir
 			return !density


### PR DESCRIPTION

## About The Pull Request

Fixes #18995

Allows players to fall from above onto tables, and climb down onto them using normal mechanics. People typically expect to be able to fall onto tables from above (often for the purposes of landing on them specifically or onto people on said table). It looks and feels like a bug when you can't because there's no reason you should hover in the air 6ft above a table.

It will also be funny when people fall onto tables expecting to magically fly over them for the first few days.

Also includes a check for mobs hiding under tables when you land on them, to protect them from being squished/eaten.

## Changelog
:cl:
fix: People flying above tables when they should fall down.
/:cl:
