### PR TITLE
fix links in motd

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -326,6 +326,7 @@
 			DelayedMessageAdmins("MOTD file [motd_file] didn't exist")
 
 	motd = motd_contents.Join("\n")
+	motd = GLOB.is_valid_url.Replace(motd, span_linkify("$1"))
 
 	var/tm_info = GLOB.revdata.GetTestMergeInfo()
 	if(motd || tm_info)

--- a/config/example/motd.txt
+++ b/config/example/motd.txt
@@ -1,5 +1,5 @@
 <h1>Welcome to Space Station 13!</h1>
 
--<i>This server is running the <a href="https://ss13polaris.com/">Polaris</a> modification of the <a href="https://baystation12.net/">Baystation12</a> SS13 code.</i>
+-<i>This server is running the https://ss13polaris.com modification of the https://baystation12.net SS13 code.</i>
 <br><br>
-<strong>Bugtracker:</strong> <a href="https://github.com/PolarisSS13/Polaris/issues">for posting of bugs and issues.</a>
+<strong>Bugtracker:</strong> https://github.com/PolarisSS13/Polaris/issues for posting of bugs and issues.</a>


### PR DESCRIPTION

## About The Pull Request
We allowed linking in the motd, but the a tags directly were sanitized. The linkify exists to actually set links. This was lost during the config controller update. Also updates the example to make it clear that we don't have markup links anymore. Links need to be plaintext https. No markup to work.
## Changelog
:cl:
fix: linking in motd
/:cl:
