### PR TITLE
fix default inputs on complex modal

### DIFF
--- a/tgui/packages/tgui/interfaces/common/ComplexModal.tsx
+++ b/tgui/packages/tgui/interfaces/common/ComplexModal.tsx
@@ -125,13 +125,11 @@ export const ComplexModal = (props: {
 
   const { modal } = data;
 
-  const [curValue, setCurValue] = useState(
-    modal?.value != null ? String(modal.value) : '',
-  );
+  const [curValue, setCurValue] = useState(String(modal?.value ?? ''));
 
   useEffect(() => {
     if (modal?.type === 'input') {
-      setCurValue(modal.value != null ? String(modal.value) : '');
+      setCurValue(String(modal.value ?? ''));
     }
   }, [modal?.value, modal?.type]);
 


### PR DESCRIPTION

## About The Pull Request
Our backend expects all inputs to be strings. If we pass through for example a default number, it will reach the game as null instead. So we need to cast those values here in the complex modal not to get dropped.
## Changelog
:cl:
fix: initial input getting dropped in the backend
/:cl:
