### PR TITLE
fix detailed ss stat view

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -195,7 +195,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			"cost_ms" = subsystem.cost,
 			"tick_usage" = subsystem.tick_usage,
 			"usage_per_tick" = average,
-			"overtime" = subsystem.tick_overrun,
+			"tick_overrun" = subsystem.tick_overrun,
 			"initialized" = subsystem.initialized,
 			"initialization_failure_message" = subsystem.initialization_failure_message,
 		))


### PR DESCRIPTION

## About The Pull Request
That var was renamed, but never adjusted in the data
## Changelog
:cl:
fix: detailed subsystem stat view crashing
/:cl:
