### PR TITLE
Fixes some charging mobs leaping straight into bellies

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/ddraig.dm
@@ -76,6 +76,7 @@
 	vore_default_mode = DM_DIGEST
 	vore_pounce_maxhealth = 125
 	vore_bump_emote = "tries to devour"
+	can_be_drop_prey = FALSE
 
 /mob/living/simple_mob/vore/ddraig/faster
 	special_attack_cooldown = 10 SECONDS

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/cyber_horror.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/cyber_horror.dm
@@ -34,6 +34,8 @@
 	var/emp_damage = 0
 	var/nanobot_chance = 40
 
+	can_be_drop_prey = FALSE
+
 /datum/say_list/cyber_horror
 	speak = list("H@!#$$P M@!$#",
 					"GHAA!@@#",

--- a/code/modules/mob/living/simple_mob/subtypes/vore/cryptdrake.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/cryptdrake.dm
@@ -59,6 +59,7 @@
 	vore_default_mode = DM_DIGEST
 	vore_pounce_maxhealth = 125
 	vore_bump_emote = "tries to devour"
+	can_be_drop_prey = FALSE
 
 /mob/living/simple_mob/vore/cryptdrake/Login()
 	. = ..()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/scel.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/scel.dm
@@ -81,6 +81,7 @@
 	vore_default_mode = DM_SELECT
 	vore_pounce_maxhealth = 125
 	vore_bump_emote = "tries to devour"
+	can_be_drop_prey = FALSE
 
 /mob/living/simple_mob/vore/scel/Login()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Fixed a handful of big strong mobs that have leap attacks literally throwing themselves into spont vore bellies. It was an oversight from when throw vore wasn't working properly.

## Changelog
:cl:
fix: Fixed a handful of big strong mobs that have leap attacks literally throwing themselves into spont vore bellies.
/:cl:
