### PR TITLE
don't send empty messsages to chat

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/stardog.dm
@@ -1447,6 +1447,11 @@
 		we_process = FALSE
 		return PROCESS_KILL
 
+/turf/simulated/floor/water/digestive_enzymes/Destroy()
+	if(we_process)
+		STOP_PROCESSING(SSturfs, src)
+	. = ..()
+
 /turf/simulated/floor/water/digestive_enzymes/proc/can_digest(atom/movable/digest_target)
 	. = FALSE
 	if(digest_target.loc != src)


### PR DESCRIPTION

## About The Pull Request
We have balloon alerts... no need to create empty to_chat calls
## Changelog
:cl:
fix: empty to chat runtime for digestive turfs
/:cl:
