### PR TITLE
change vehicle desc

### DIFF
--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -200,7 +200,7 @@
 
 /obj/vehicle/train/engine/examine(mob/user)
 	. = ..()
-	if(ishuman(user) && Adjacent(user))
+	if(Adjacent(user))
 		. += "The power light is [on ? "on" : "off"].\nThere are[key ? "" : " no"] keys in the ignition."
 		. += "The charge meter reads [cell? round(cell.percent(), 0.01) : 0]%"
 

--- a/code/modules/vehicles/janicart.dm
+++ b/code/modules/vehicles/janicart.dm
@@ -80,8 +80,6 @@
 /obj/vehicle/train/engine/janicart/examine(mob/user)
 	. = ..()
 	if(Adjacent(user))
-		. += "The power light is [on ? "on" : "off"].\nThere are[key ? "" : " no"] keys in the ignition."
-		. += "The charge meter reads [cell? round(cell.percent(), 0.01) : 0]%"
 		. += "This [callme] contains [reagents.total_volume] unit\s of water!"
 		if(mybag)
 			. += "\A [mybag] is hanging on the [callme]."


### PR DESCRIPTION

## About The Pull Request
fixes #19036

removes some odd decision as of why only humans saw if vehicles were turned on which then got duplicated into the janicart, leading to duped examines for humans
## Changelog
:cl:
fix: janicart examine dupe
/:cl:
