### PR TITLE
Reduce the stub toe chance from unlucky

### DIFF
--- a/code/datums/components/traits/unlucky.dm
+++ b/code/datums/components/traits/unlucky.dm
@@ -279,6 +279,8 @@
 		for(var/obj/structure/table/evil_table in the_turf)
 			if(!evil_table.material) //We only want tables, not just table frames.
 				continue
+			if(!prob(10)) //Reduce the chance further, due to the number of tables that are passed in normal play.
+				continue
 			living_guy.visible_message(span_danger("[living_guy] stubs [living_guy.p_their()] toe on [evil_table]!"), span_bolddanger("You stub your toe on [evil_table]!"))
 			living_guy.apply_damage(2 * damage_mod, BRUTE, pick(BP_L_FOOT, BP_R_FOOT), used_weapon = "blunt force trauma")
 			living_guy.adjustHalLoss(25) //It REALLY hurts.


### PR DESCRIPTION

## About The Pull Request

The current toe stubbing chance is really high, given that anywhere but hallways is absolutely packed with tables, and that you are constantly walking past multiple of them at any particular time. This makes unlucky go from funny random chance to annoying. This multiplies the current chance by 0.1 times.

This should still trigger pretty often, potentially multiple times per shift. But it shouldn't trigger almost every time you spend 10 minutes walking around your department anymore.

## Changelog
:cl:
qol: Made unlucky trigger toe stubbing one tenth as often.
/:cl:
