### PR TITLE
Make showers not process while inactive + a little QoL

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -180,7 +180,7 @@
 /obj/machinery/shower/Destroy()
 	QDEL_NULL(soundloop)
 	QDEL_NULL(reagents)
-	STOP_MACHINE_PROCESSING()
+	STOP_MACHINE_PROCESSING(src)
 	return ..()
 
 //add heat controls? when emagged, you can freeze to death in it?


### PR DESCRIPTION

## About The Pull Request

Gives shower code a shower so it doesnt stink.
Showers are a bit nicer to use, and dont process when they're not being used !!!!

## Changelog
:cl:
qol: Showers now instantly run a wash call on things that go under them while active
code: Removed a fair few unnecessary variables on showers and replaced it with better code.
code: Showers can have their output reagent overridden, either by adminbus or subtypes.
code: Showers no longer run process() calls while inactive. This should free up a fair few SSmachines process calls that did literally nothing
/:cl:
