### PR TITLE
Fixes tsci infinite teleport

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -20,7 +20,7 @@
 	var/distance = 5
 
 	// Based on the distance used
-	var/teleport_cooldown = 0
+	COOLDOWN_DECLARE(teleport_cooldown)
 	var/teleporting = 0
 	var/starting_crystals = 0
 	var/max_crystals = 4
@@ -29,7 +29,6 @@
 	var/list/crystals = list()
 	var/obj/item/gps/inserted_gps
 	var/overmap_range = 3
-	var/fail_cooldown = 2 SECONDS
 
 /obj/machinery/computer/telescience/Destroy()
 	eject()
@@ -102,7 +101,7 @@
 		data["insertedGps"] = inserted_gps
 		data["rotation"] = rotation
 		data["currentZ"] = z_co
-		data["cooldown"] = max(0, min(100, round(teleport_cooldown - world.time) / 10))
+		data["cooldown"] = max(0, min(100, COOLDOWN_TIMELEFT(src, teleport_cooldown) / 10))
 		data["crystalCount"] = crystals.len
 		data["maxCrystals"] = max_crystals
 		data["maxPossibleDistance"] = FLOOR((max_crystals * powerCoefficient * 6), 1); // max efficiency is 6
@@ -189,7 +188,7 @@
 		return
 
 /obj/machinery/computer/telescience/proc/telefail()
-	teleport_cooldown = world.time + fail_cooldown
+	COOLDOWN_START(src, teleport_cooldown, (2 SECONDS))
 	switch(rand(99))
 		if(0 to 80)
 			sparks()
@@ -234,7 +233,7 @@
 
 /obj/machinery/computer/telescience/proc/doteleport(mob/user)
 
-	if(teleport_cooldown > world.time)
+	if(!COOLDOWN_FINISHED(src, teleport_cooldown))
 		return
 
 	if(telepad)
@@ -270,7 +269,7 @@
 			if(telepad.inoperable())
 				return
 			teleporting = 0
-			teleport_cooldown = world.time + (spawn_time * 2)
+			COOLDOWN_START(src, teleport_cooldown, (spawn_time * 2))
 			teles_left -= 1
 
 			// use a lot of power
@@ -348,7 +347,7 @@
 			updateDialog()
 
 /obj/machinery/computer/telescience/proc/teleport(mob/user)
-	if(teleport_cooldown > world.time)
+	if(!COOLDOWN_FINISHED(src, teleport_cooldown))
 		temp_msg = "ERROR! Teleportation console is cooling down. Please wait."
 		return
 	if(teleporting)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -29,6 +29,7 @@
 	var/list/crystals = list()
 	var/obj/item/gps/inserted_gps
 	var/overmap_range = 3
+	var/fail_cooldown = 2 SECONDS
 
 /obj/machinery/computer/telescience/Destroy()
 	eject()
@@ -154,9 +155,9 @@
 			if(last_target && inserted_gps)
 				// TODO - What was this even supposed to do??
 				//inserted_gps.locked_location = last_target
-				temp_msg = "Location saved."
+				temp_msg = "Function Deprecated. No action taken."
 			else
-				temp_msg = "ERROR! No data was stored."
+				temp_msg = "Function Deprecated. No action taken."
 
 		if("send")
 			sending = 1
@@ -188,6 +189,7 @@
 		return
 
 /obj/machinery/computer/telescience/proc/telefail()
+	teleport_cooldown = world.time + fail_cooldown
 	switch(rand(99))
 		if(0 to 80)
 			sparks()
@@ -348,6 +350,12 @@
 			updateDialog()
 
 /obj/machinery/computer/telescience/proc/teleport(mob/user)
+	if(teleport_cooldown > world.time)
+		temp_msg = "ERROR! Teleportation console is cooling down. Please wait."
+		return
+	if(teleporting)
+		temp_msg = "ERROR! Teleportation in progress. Please wait."
+		return
 	distance = CLAMP(distance, 0, get_max_allowed_distance())
 	if(rotation == null || distance == null || z_co == null)
 		temp_msg = "ERROR! Set a distance, rotation and sector."

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -236,8 +236,6 @@
 
 	if(teleport_cooldown > world.time)
 		return
-	if(teleporting)
-		return
 
 	if(telepad)
 		var/trueDistance = CLAMP(distance + distance_off, 1, get_max_allowed_distance())


### PR DESCRIPTION

## About The Pull Request
Fixes tsci allowing you to spam up to 10x fails within a second. Failed teleports now have a 2 second cooldown.
Makes it so using the deprecated 'store gps data' function tells you the function is deprecated.
Makes it so you can't cause failed teleports while the telepad is currently queuing up a teleport.
## Changelog
:cl: Diana
fix: Tsci can no longer be spam-failed
fix: Tsci can no longer cause a failure while an active teleport is ongoing.
/:cl:
