### PR TITLE
methane tank added to supply orders

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -57,6 +57,12 @@
 	cost = 15
 	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 
+/datum/supply_pack/atmos/canister_methane
+	name = "CH4 gas canister"
+	desc = "A large canister full of pure methane gas."
+	cost = 25
+	contains = list(/obj/machinery/portable_atmospherics/canister/methane)
+
 /datum/supply_pack/atmos/coolant_tank
 	name = "Coolant Tank"
 	desc = "A large tank full of liquid coolant."


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

## Changelog
There was no way to order methane from cargo, added it.

:cl: Will
qol: Methane canisters can now be ordered from cargo, like all other gasses.
/:cl:
