### PR TITLE
Corrects plastique explosive blast size

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -13,7 +13,7 @@
 	var/atom/target = null
 	var/open_panel = 0
 	var/image_overlay = null
-	var/blast_dev = 3
+	var/blast_dev = 0
 	var/blast_heavy = 1
 	var/blast_light = 2
 	var/blast_flash = 3
@@ -100,6 +100,7 @@
 	name = "seismic charge"
 	desc = "Used to dig holes in specific areas without too much extra hole."
 
+	blast_dev = 3
 	blast_heavy = 2
 	blast_light = 4
 	blast_flash = 7


### PR DESCRIPTION

<img width="689" height="815" alt="plastique" src="https://github.com/user-attachments/assets/b777b40a-66e5-40e3-ad8c-283b13d842d9" />


## About The Pull Request
The base plastique explosive charge size was much larger than its originally intended purpose to break holes in walls and destroy doors for breaching. The seismic charge keeps the original devastation however. 

Image top left is new plastique explosive, bottom right is seismic charge (and what plastique did before this change)

## Changelog
Reduced plastique explosive devastation to 1, seismic charge unaffected.

:cl: Will
fix: plastique explosive explosion reduced, seismic charge unchanged
/:cl:

