### PR TITLE
Fixes a harddel when destroying disposal component linked objects

### DIFF
--- a/code/datums/components/machinery/disposal_connection.dm
+++ b/code/datums/components/machinery/disposal_connection.dm
@@ -59,6 +59,7 @@
 	SIGNAL_HANDLER
 	SHOULD_NOT_OVERRIDE(TRUE)
 	if(connected_trunk)
+		connected_trunk.linked = null
 		UnregisterSignal(connected_trunk, COMSIG_DISPOSAL_SEND)
 		connected_trunk = null
 


### PR DESCRIPTION

## About The Pull Request
Disposal trunks weren't getting properly unlinked when `COMSIG_DISPOSAL_UNLINK` was sent and somehow nobody noticed. this was probably causing a harddel when the linked object was deleted since it's reference wasnt cleared.

_Please dont be mad Kash-_
## Changelog
:cl:
fix: Fixes an uncleared hardref on disposal pipe trunks when deleting their linked object
/:cl:
