### PR TITLE
Allows toggling of reagent scans in deep scan devices

### DIFF
--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -28,12 +28,8 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(sediment_scan)
-		to_chat(usr, span_notice("\The [src] will no longer scan for reagents."))
-		sediment_scan = FALSE
-		return
-	to_chat(usr, span_notice("\The [src] will now scan for reagents."))
-	sediment_scan = TRUE
+	to_chat(usr, span_notice("\The [src] will [sediment_scan ? "no longer" : "now"] scan for reagents."))
+	sediment_scan = !sediment_scan
 
 /obj/item/mining_scanner/proc/ScanTurf(var/atom/target, var/mob/user)
 	var/list/metals = list(


### PR DESCRIPTION

## About The Pull Request

Adds a verb to deep scan devices that allows them to turn off the sediment scan info, as this pastes a lot of text.

I think usr is okay to use in verbs, right?

## Changelog
:cl:
qol: Adds a verb to deep scan devices that allows them to turn off the sediment scan info, as this pastes a lot of text.
/:cl:
