### PR TITLE
Bow Loading Fix

### DIFF
--- a/code/modules/projectiles/guns/launcher/bows.dm
+++ b/code/modules/projectiles/guns/launcher/bows.dm
@@ -131,6 +131,7 @@
 	icon_state = "bow_hardlight"
 	item_state = "bow_hardlight"
 	desc = "An energy bow, capable of producing arrows from an internal power supply."
+	hardlight = TRUE
 
 /obj/item/gun/launcher/crossbow/bow/hardlight/unload(mob/user)
 	QDEL_NULL(bolt)
@@ -144,12 +145,13 @@
 		user.visible_message(span_infoplain(span_bold("[user]") + " relaxes the tension on [src]'s string."),span_infoplain("You relax the tension on [src]'s string."))
 		drawn = FALSE
 		update_icon()
-	else if(!bolt)
+		return
+	// Automatically knock the arrow as it forms
+	if(!bolt)
 		user.visible_message(span_infoplain(span_bold("[user]") + " fabricates a new hardlight projectile with [src]."),span_infoplain("You fabricate a new hardlight projectile with [src]."))
 		bolt = new /obj/item/arrow/energy(src)
 		update_icon()
-	else
-		draw(user)
+	draw(user)
 
 /obj/item/gun/launcher/crossbow/bow/glamour
 	name = "glamour bow"

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -91,7 +91,7 @@
 	if(.)
 		return TRUE
 	if(is_bow)
-		return TRUE
+		return FALSE
 	if(tension)
 		if(bolt)
 			user.visible_message("[user] relaxes the tension on [src]'s string and removes [bolt].","You relax the tension on [src]'s string and remove [bolt].")


### PR DESCRIPTION
## About The Pull Request
Due to attack_self recoding, bows were unable to be drawn. This pr fixes that.

## Changelog
Fixes bows being unable to draw
Makes hardlight bow form arrow and draw it in a continuous action. 

:cl: Will
fix: Bows can be drawn again
qol: drawing a hardlight bow spawns the projectile in the same action
/:cl:
