### PR TITLE
Surgery Runtime Fix

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -218,9 +218,12 @@
 			to_chat(user, span_warning("You must remain close to and keep focused on your patient to conduct surgery."))
 			user.balloon_alert(user, "you must stay focused on your patient!")
 
+	if(!affected) // If the limb was just attached, get it to adjust germ levels
+		affected = M.get_organ(zone)
+
 	if(success)
 		selected_surgery.end_step(user, M, zone, src)
-		if(prob(100-cleanliness)) //Infection chance based on cleanliness.
+		if(affected && prob(100-cleanliness)) //Infection chance based on cleanliness.
 			affected.adjust_germ_level(rand(10,20))
 	else
 		selected_surgery.fail_step(user, M, zone, src)


### PR DESCRIPTION
## About The Pull Request
Reattaching limbs done in unclean environments had a probability to runtime due to attempting to set a null organ's germ value. Fixes a runtime that makes surgery on that limb completely impossible for the rest of the round on that mob.

## Changelog
Added a check after organ reattachment surgery to get the newly attached organ to apply germs, if that fails then the proc at least won't runtime and prevent any future surgeries from happening. 

:cl: Will
fix: Attaching a limb while in a dirty environment no longer makes additional surgeries on that limb impossible
/:cl:
