### PR TITLE
Forbid forensics items from lathe recycling

### DIFF
--- a/code/datums/components/materials/remote_materials.dm
+++ b/code/datums/components/materials/remote_materials.dm
@@ -161,11 +161,12 @@ handles linking back and forth.
 	SIGNAL_HANDLER
 	if(istype(target, /obj/item/multitool))
 		return OnMultitool(source, user, target)
+
 	if(istype(target, /obj/item/forensics))
-		return
+		return FALSE
 
 	if(mat_container_flags & MATCONTAINER_NO_INSERT)
-		return
+		return FALSE
 
 	if(istype(target, /obj/item/storage/bag/sheetsnatcher))
 		return mat_container.OnSheetSnatcher(source, target, user)


### PR DESCRIPTION
## About The Pull Request
Because forensic items are handled in after_attack(), they must be prevented from recycling in the lathes or the cannot be used on them.

## Changelog
Adds a check that prevents forensics items from being eaten by lathes.

:cl: Will
fix: Forensics items are no longer recycled in the lathe when trying to get samples
/:cl:
