### PR TITLE
Yet another fluid pump runtime fix

### DIFF
--- a/code/game/turfs/flooring/gas_cracks.dm
+++ b/code/game/turfs/flooring/gas_cracks.dm
@@ -28,7 +28,7 @@
 	var/i = 0
 	while(i++ < 4) // Do this a few times
 		var/turf/simulated/mineral/M = pick(orange(5,src))
-		if(!istype(M) && M.resources)
+		if(!istype(M) || !M.resources)
 			return
 		for(var/metal in GLOB.deepore_fracking_reagents)
 			if(!(metal in M.resources))


### PR DESCRIPTION
## About The Pull Request
Solves a runtime caused by fluid pumps extracting from turfs without a resources list

## Changelog
Fixed fluid pump runtime on resource-less turfs. 

:cl: Will
fix: Runtime when a fluidpump tries to extract from an empty resource list turf
/:cl:
