### PR TITLE
Fixes An Initilization Runtime On Cane Concealed Sword

### DIFF
--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -20,13 +20,11 @@
 	item_state = "crutch"
 
 /obj/item/cane/concealed
-	var/concealed_blade
+	var/obj/item/material/sword/katana/caneblade/concealed_blade
 
 /obj/item/cane/concealed/Initialize(mapload)
 	. = ..()
-	var/obj/item/material/sword/katana/caneblade/temp_blade = new(src)
-	concealed_blade = temp_blade
-	temp_blade.attack_self()
+	concealed_blade = new(src)
 
 /obj/item/cane/concealed/attack_self(mob/user)
 	. = ..(user)


### PR DESCRIPTION
## About The Pull Request
The concealed sword cane was calling attack_self() during init with no user. Even if this proc was legal to call without a user, it also would runtime as soon as it got to the first user dependent var check anyway. The intent seems to have been to unsheath the sword as soon as the cane spawns, but that's not possible with the current unsheathing code.

## Changelog
Removes non-working instant unsheathing code from concealed sword cane init

:cl: Will
fix: concealed sword cane runtime during init
/:cl:
