### PR TITLE
Fixes teshari not being able to be holstered

### DIFF
--- a/code/modules/vore/resizing/holder_micro_vr.dm
+++ b/code/modules/vore/resizing/holder_micro_vr.dm
@@ -25,8 +25,6 @@
 		sprite_sheets = null
 		icon_state = "teshariplushie_white"
 		item_state = "teshariplushie_white"
-		// Add back slot
-		slot_flags = SLOT_FEET | SLOT_HEAD | SLOT_ID | SLOT_BACK
 
 /obj/item/holder/micro/make_worn_icon(var/body_type,var/slot_name,var/inhands,var/default_icon,var/default_layer,var/icon/clip_mask = null)
 	var/mob/living/carbon/human/H = held_mob


### PR DESCRIPTION

## About The Pull Request

Did you know... Teshari have the perfect size to be holstered? You can stuff them in any kind of sheath. This fixes the poor small feathery things being too large to fit in them.

## Changelog
:cl: Guti
fix: Fixed teshari not being able to be holstered
/:cl:
