### PR TITLE
Makes translocators able to properly use any device cell

### DIFF
--- a/code/game/objects/items/devices/translocator_vr.dm
+++ b/code/game/objects/items/devices/translocator_vr.dm
@@ -174,7 +174,7 @@ This device records all warnings given and teleport events for admin review in c
 		rebuild_radial_images()
 
 /obj/item/perfect_tele/attackby(obj/W, mob/user)
-	if(istype(W,cell_type) && !power_source)
+	if(istype(W, /obj/item/cell/device) && !power_source)
 		power_source = W
 		power_source.update_icon() //Why doesn't a cell do this already? :|
 		user.unEquip(power_source)


### PR DESCRIPTION

## About The Pull Request

For some reason, translocators are set to check for the typepath of the cell they initialize with, including subtypes. This meant higher tier translocators could only use specific cell types, since they initialize with better cells (normal starts with an adv cell, alien starts with void cell, ect) while the basic translocator could use any device cell as it uses the base `/obj/item/cell/device` cell, which includes all subtypes of device cells. 

This Pr makes it use a static istype() check instead of being dynamic to the translocator's cell type, so that the cell it requires is not tied to the cell it spawns with.
## Changelog
:cl:
fix: all tiers of translocators can use any power device power cell
/:cl:
