### PR TITLE
Sheetsnatcher Silo Fix

### DIFF
--- a/code/datums/components/materials/remote_materials.dm
+++ b/code/datums/components/materials/remote_materials.dm
@@ -169,7 +169,7 @@ handles linking back and forth.
 		return FALSE
 
 	if(istype(target, /obj/item/storage/bag/sheetsnatcher))
-		return mat_container.OnSheetSnatcher(source, target, user)
+		return mat_container.OnSheetSnatcher(source, user, target)
 
 	return attempt_insert(user, target)
 


### PR DESCRIPTION
## About The Pull Request
Fixes sheetsnatcher bug that made putting things into the silo impossible.

## Changelog
Fixes order on sheetsnatcher proc call. Instead of the sheetsnatcher trying to put the user into the silo, the user now properly loads the snatcher into the silo instead.

:cl: Will
fix: sheetsnatcher properly calls oresilo storage proc
/:cl:
