### PR TITLE
Partial revert of previous SSchem change

### DIFF
--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(chemistry)
 					LAZYINITLIST(chemical_reactions_by_product[D.result])
 					chemical_reactions_by_product[D.result] |= D // for reverse lookup
 
-			// we want to maintain original chemistry behavior, but still document all reactions above, only add to this list with the first reactions
+			// we want to maintain original chemistry behavior, but still document all reactions above, only add to this list with the first reagent
 			if(i > 1)
 				continue
 			LAZYINITLIST(add_to[reagent_id])


### PR DESCRIPTION
## About The Pull Request
Corrects behavior of reaction list for SSchemistry to match old behavior.

Fixes https://github.com/VOREStation/VOREStation/issues/19157

Tested with corophizine and peridaxon, both recipes correctly behave now, and were reliably bugged after the change.

## Changelog
Only expands reaction list for the first reagent, to maintain player known recipes from before.

:cl: Will
fix: SSchemistry indexing order reverted to be based on first reagent in recipe (Recipes fixed to be match old recipe priorities)
/:cl:
