### PR TITLE
Banned Mail Jobs List

### DIFF
--- a/code/controllers/subsystems/mail.dm
+++ b/code/controllers/subsystems/mail.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(mail)
 	var/mail_waiting = 0					// Pending mail
 	var/mail_per_process = 0.55				// Mail to be generated
 	var/admin_mail = list()					// Mail added by Spawn Mail
+	var/list/banned_jobs = list(JOB_OUTSIDER,JOB_ANOMALY,JOB_VR,JOB_MAINT_LURKER,JOB_TALON_CAPTAIN,JOB_TALON_DOCTOR,JOB_TALON_ENGINEER,JOB_TALON_GUARD,JOB_TALON_PILOT,JOB_TALON_MINER) // Jobs that can't receive mail
 
 /datum/controller/subsystem/mail/fire()
 	mail_waiting += mail_per_process
@@ -24,7 +25,7 @@ SUBSYSTEM_DEF(mail)
 	// Collect recipients
 	var/list/mail_recipients = list()
 	for(var/mob/living/carbon/human/player_human in GLOB.player_list)
-		if(player_human.stat != DEAD && player_human.client && player_human.client.inactivity <= 10 MINUTES && player_human.job != JOB_OUTSIDER && player_human.job != JOB_ANOMALY && player_human.job != JOB_VR && !player_is_antag(player_human.mind) && !isbelly(player_human.loc)) // Only alive, active and NT employeers should be getting mail.
+		if(player_human.stat != DEAD && player_human.client && player_human.client.inactivity <= 10 MINUTES && !(player_human.job in banned_jobs) && !player_is_antag(player_human.mind) && !isbelly(player_human.loc)) // Only alive, active and NT employeers should be getting mail.
 			mail_recipients += player_human
 
 	// Creates mail for all the mail waiting to arrive, if there's nobody to receive it, it will be a chance of junk mail.


### PR DESCRIPTION
## About The Pull Request
Expands the banned jobs handling for the mail subsystem and adds Talon jobs. Whilst this probably needs slightly more vigorous testing, it seems to work as-intended so far when I gently massage the subsystem controllers for testing purposes. No runtimes in console either.

Fixes #17519, fixes #17423, and fixes #18704

## Changelog
:cl:
fix: non-station personnel (talon, lurkers, etc.) should no longer receive mail in cargo shipments
/:cl: