### PR TITLE
Mechfab Fixes

### DIFF
--- a/code/modules/research/tg/machinery/mech_fabricator.dm
+++ b/code/modules/research/tg/machinery/mech_fabricator.dm
@@ -240,7 +240,7 @@
 		return FALSE
 
 	var/turf/exit = get_step(src, drop_direction)
-	if (exit.density)
+	if(exit.density)
 		if(verbose)
 			atom_say("Warning. Exit port obstructed. Please clear obstructions or reorient machine, then retry.")
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Tweaks the mechfab to avoid a situation where it could be deadlocked and require the output tile to be deconstructed in order to continue.

Gently tested, seems to work as intended and doesn't spam the chat with the warning message.

## Changelog
:cl:
qol: mech part fabricator now has a clearer message when you try to change its output direction whilst it's printing
fix: mech part fabricator now completely refuses to start printing a part if its output direction is invalid; ongoing queues should be frozen until the output is reoriented
/:cl:
