### PR TITLE
Make vacpacks actually accessible

### DIFF
--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -74,6 +74,7 @@
 			/obj/item/reagent_containers/spray/cleaner,
 			/obj/item/reagent_containers/glass/rag,
 			/obj/item/grenade/chem_grenade/cleaner = 3,
+			/obj/item/vac_attachment,
 			/obj/item/clothing/glasses/hud/janitor,
 			/obj/structure/mopbucket
 			)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -86,6 +86,7 @@
 		/obj/item/lightreplacer,
 		/obj/item/storage/bag/trash,
 		/obj/item/storage/belt/janitor,
+		/obj/item/vac_attachment,
 		/obj/item/clothing/shoes/galoshes,
 		/obj/item/clothing/glasses/hud/janitor
 		)


### PR DESCRIPTION
## About The Pull Request
Now that vacpacks aren't horribly overpowered (#19143) we should let people actually play with em!

Adds 1 to the janitor's closet, and 1 to the janitor supply crate in cargo.

Doesn't add them to borgs, don't feel like testing it lol

## Changelog

:cl:
add: Vac-packs are now obtainable in the janitor's closet and janitor crate in cargo! This is a very powerful vacuum cleaner that slurps up ~~crew mates~~ all sorts of trash :), and spits it out in a trash bag or vore belly~
/:cl:
