### PR TITLE
Electric Guitar Path Fix

### DIFF
--- a/code/modules/instruments/instrument_data/hardcoded.dm
+++ b/code/modules/instruments/instrument_data/hardcoded.dm
@@ -23,7 +23,7 @@
 	name = "Electric Guitar"
 	id = "eguitar"
 	legacy_instrument_ext = "ogg"
-	legacy_instrument_path = "electric_guitar"
+	legacy_instrument_path = "eguitar"
 
 /datum/instrument/hardcoded/glockenspiel
 	name = "Glockenspiel"


### PR DESCRIPTION
## About The Pull Request
Electric guitar's music data path was wrong.

## Changelog
electric_guitar -> eguitar to match actual note file path

:cl: Will
fix: Electric guitar note files use correct path, electric guitar actually plays notes now
/:cl:
