### PR TITLE
Honey Extractor QOL

### DIFF
--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -185,6 +185,12 @@
 	RefreshParts()
 	update_icon()
 
+/obj/machinery/honey_extractor/examine(mob/user)
+	. = ..()
+
+	if(Adjacent(user))
+		. += "It has [honey] units of honey in its storage tank."
+
 /obj/machinery/honey_extractor/power_change()
 	. = ..()
 	var/delay = rand(0,15)


### PR DESCRIPTION
## About The Pull Request

Adds the ability to divine the honey contents of a honey extractor by examining it if you're standing right next to it.

## Changelog

:cl:
qol: Examining a Honey Extractor when you're next to it will now tell you how much honey it contains (if any)
/:cl: