### PR TITLE
Make Bad shot and thick digits mutually exclusive

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -231,6 +231,7 @@
 	var_changes = list("gun_accuracy_mod" = -35)
 	custom_only = FALSE
 	varchange_type = TRAIT_VARCHANGE_MORE_BETTER
+	excludes = list(/datum/trait/negative/thick_digits)
 
 	//Traitgenes
 	is_genetrait = TRUE
@@ -473,6 +474,7 @@
 	desc = "Your hands are not shaped in a way that allows useage of guns."
 	cost = -4
 	custom_only = FALSE
+	excludes = list(/datum/trait/negative/bad_shooter)
 
 /datum/trait/negative/thick_digits/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
its like +1 point but like yeah
## About The Pull Request
Makes Bad shot which lowers gun accuracy, and Thick Digits which prevents use of guns entirely, mutually exclusive.

## Changelog
:cl:
fix: Made Bad shot and thick digits mutually exclusive
/:cl:
