### PR TITLE
Make Mute and Incomprehensible, mutually exclusive

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
@@ -92,6 +92,7 @@
 
 	is_genetrait = TRUE
 	hidden = FALSE
+	excludes = list(/datum/trait/negative/disability_wingdings)
 
 	sdisability=MUTE
 	activation_message="Your throat feels strange..."
@@ -152,6 +153,7 @@
 
 	is_genetrait = TRUE
 	hidden = FALSE
+	excludes = list(/datum/trait/negative/disability_mute)
 
 	disability=WINGDINGS
 	activation_message="You feel a little... Ga-hoo!"


### PR DESCRIPTION

## About The Pull Request
Prevents you from taking mute and incomprehensible simultaneously as they do not work together

## Changelog
:cl:
fix:Makes Mute and Incomprehensible, mutually exclusive
/:cl:
