### PR TITLE
Disable afk prey pref for dead people

### DIFF
--- a/code/_helpers/vore.dm
+++ b/code/_helpers/vore.dm
@@ -20,7 +20,7 @@
 		return FALSE
 	if(!pred.can_be_afk_pred && (!pred.client || pred.away_from_keyboard))
 		return FALSE
-	if(!prey.can_be_afk_prey && (!prey.client || prey.away_from_keyboard))
+	if(!prey.is_dead() && !prey.can_be_afk_prey && (!prey.client || prey.away_from_keyboard))
 		return FALSE
 	if(!prey.allowmobvore && isanimal(pred) && !pred.ckey || (!pred.allowmobvore && isanimal(prey) && !prey.ckey))
 		return FALSE

--- a/code/modules/vore/eating/vore_procs.dm
+++ b/code/modules/vore/eating/vore_procs.dm
@@ -192,7 +192,7 @@
 			return FALSE
 		to_chat(user, span_vnotice("The predator prefers not to be fed while AFK"))
 		return FALSE
-	if(!prey.can_be_afk_prey && (!prey.client || prey.away_from_keyboard))
+	if(!prey.is_dead() && !prey.can_be_afk_prey && (!prey.client || prey.away_from_keyboard))
 		if(user == prey)
 			to_chat(user, span_vwarning("You aren't set as being able to prey while AFK"))
 			return FALSE


### PR DESCRIPTION

## About The Pull Request
Dying in game will cause the AFK prey pref to prevent noms. To allow medborgs and other such interactions to still work in this case, and since bypassing the pref maliciously by using this would be a serious issue for a moderator to look at anyways, the AFK prey pref will be disabled if dead.
## Changelog
:cl: Cerami
fix: Disables the AFK prey preference from functioning while someone is dead
/:cl:
