### PR TITLE
change real name to read preference

### DIFF
--- a/code/modules/vore/eating/exportpanel_vr.dm
+++ b/code/modules/vore/eating/exportpanel_vr.dm
@@ -29,7 +29,7 @@
 
 	data["db_version"] = "0.3"
 	data["db_repo"] = "vorestation"
-	data["mob_name"] = host.real_name
+	data["mob_name"] = host.read_preference(/datum/preference/name/real_name)
 
 	for(var/belly in host.vore_organs)
 		if(isbelly(belly))


### PR DESCRIPTION

## About The Pull Request
Instead of relying to the mob name, we just read the actual pref name...
## Changelog
:cl:
fix: vorepanel export showing null while used in the lobby menu for the name
/:cl:
