### PR TITLE
pai fixes

### DIFF
--- a/code/datums/components/traits/crowd_detection.dm
+++ b/code/datums/components/traits/crowd_detection.dm
@@ -96,10 +96,10 @@
 	var/list/in_range = list()
 	if(!istype(M))
 		return in_range
-	var/social_check = only_people && !istype(M, /mob/living/carbon) && !istype(M, /mob/living/silicon/robot) && !istype(M, /mob/living/silicon/pai)
+	var/social_check = only_people && !iscarbon(M) && !isrobot(M) && !ispAI(M)
 	var/self_invisible_check = M == human_parent || M.invisibility > human_parent.see_invisible
 	var/ckey_check = only_people && !M.ckey
-	var/overall_checks = M == human_parent || M.stat == DEAD || social_check || ckey_check
+	var/overall_checks = M == human_parent || M.stat == DEAD || social_check || ckey_check || (ispAI(M) && !M.ckey)
 	if(invis_matters && self_invisible_check)
 		return in_range
 	if((M.faction == FACTION_NEUTRAL || M.faction == human_parent.faction) && !overall_checks)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -224,7 +224,7 @@
 /mob/living/silicon/pai/proc/change_chassis(new_chassis)
 	if(!(new_chassis in SSpai.get_chassis_list()))
 		new_chassis = PAI_DEFAULT_CHASSIS
-	var/datum/pai_sprite/chassis_data = SSpai.chassis_data(chassis_name)
+	var/datum/pai_sprite/chassis_data = SSpai.chassis_data(new_chassis)
 	if(chassis_data.emagged && !src.card.emagged)
 		return
 	chassis_name = new_chassis
@@ -260,6 +260,7 @@
 	resize(1, FALSE, TRUE, TRUE, FALSE)
 
 	icon = chassis_data.sprite_icon
+	icon_state = chassis_data.sprite_icon_state
 	pixel_x = chassis_data.pixel_x
 	default_pixel_x = pixel_x
 	pixel_y = chassis_data.pixel_y


### PR DESCRIPTION
## About The Pull Request
Fixes some small bugs caught on pais

## Changelog
Fixes the unconscious pai mob inside pai cards still counting as a viable mob for minor lonelyness
Fixes the wrong value being used when getting a new pai chassis

:cl: Will
fix: pai correctly uses the new chassis data when changing chassis(would sometimes turn you invisible)
fix: paicards no longer comfort minor loneliness if they do not have a client
/:cl:
