### PR TITLE
fix missing gift icons

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -103,7 +103,7 @@
 /obj/item/gift
 	name = "gift"
 	desc = "A wrapped item."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/gifts.dmi'
 	icon_state = "gift3"
 	var/size = 3.0
 	var/obj/item/gift = null

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -2,7 +2,7 @@
 /obj/effect/spresent
 	name = "strange present"
 	desc = "It's a ... present?"
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/gifts.dmi'
 	icon_state = "strangepresent"
 	density = TRUE
 	anchored = FALSE

--- a/code/game/objects/items/selectable_item_vr.dm
+++ b/code/game/objects/items/selectable_item_vr.dm
@@ -1,7 +1,7 @@
 /obj/item/selectable_item
 	name = "selectable item"
 	desc = "If you find this, you should definitely report this..."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/gifts.dmi'
 	icon_state = "gift1"
 	var/preface_string = "You are about to select an item. Are you sure you want to use it and select one?"
 	var/preface_title = "selectable item"


### PR DESCRIPTION
## About The Pull Request
Icons for gifts were moved from the items.dmi to gifts.dmi. However not all the objects that reference those icons were updated.

## Changelog
Fixes the icons of:
-selectable gift item
-human fullbody wrapping paper gift
-standard gift

:cl: Will
fix: wrapping up people in giftwrap no longer makes them invisible
fix: missing giftbox icons fixed on several objects
/:cl:

