### PR TITLE
Robotics surgery hotfix

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -138,7 +138,7 @@
 	user.visible_message(span_notice("[user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool]."), \
 										span_notice("You open the maintenance hatch on [target]'s [affected.name] with \the [tool]."))
 	user.balloon_alert_visible("opens the maintenance hatch on [target]'s [affected.name]", "maintenance hatch on \the [affected.name] open")
-	affected.open = BONE_CUT
+	affected.open = BONE_RETRACTED
 
 /datum/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION

## About The Pull Request
Fixes a define typo that was made when swapping robotic surgery. It was previously a hard defined number '3' instead of using the define, but was improperly set to the wrong define (the third define in the file was 2.5, but the fourth define in the file is 3, when it needed to be 3)
## Changelog
:cl: Diana
fix: Robotics surgery works again 
/:cl:
