### PR TITLE
Declutters Security Locker Contents, Buffs Legcuff Storage

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -205,8 +205,6 @@
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "legcuff"
-	throwforce = 0
-	w_class = ITEMSIZE_NORMAL
 	origin_tech = list(TECH_MATERIAL = 1)
 	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
 	cuff_type = "legcuffs"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -193,14 +193,10 @@
 	closet_appearance = /datum/decl/closet_appearance/secure_closet/security
 
 	starts_with = list(
-		/obj/item/clothing/under/rank/security/aces,
-		/obj/item/clothing/suit/storage/vest/aces,
 		/obj/item/clothing/suit/storage/vest/officer,
 		/obj/item/clothing/head/helmet,
 		/obj/item/cartridge/security,
 		/obj/item/radio/headset/headset_sec,
-		/obj/item/radio/headset/alt/headset_sec,
-		/obj/item/radio/headset/earbud/headset_sec,
 		/obj/item/storage/belt/security,
 		/obj/item/flash,
 		/obj/item/reagent_containers/spray/pepper,
@@ -210,14 +206,10 @@
 		/obj/item/taperoll/police,
 		/obj/item/hailer,
 		/obj/item/flashlight/flare,
-		/obj/item/clothing/accessory/storage/black_vest,
-		/obj/item/clothing/head/soft/sec/corp,
 		/obj/item/clothing/under/rank/security/corp,
 		///obj/item/ammo_magazine/m45/rubber, //VOREStation Removal,
 		/obj/item/gun/energy/taser,
 		/obj/item/cell/device/weapon,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/security,
-		/obj/item/clothing/shoes/boots/winter/security,
 		/obj/item/clothing/mask/gas/sechailer,
 		/obj/item/flashlight/maglight)
 

--- a/code/modules/economy/vending_machines.dm
+++ b/code/modules/economy/vending_machines.dm
@@ -545,6 +545,7 @@
 	icon_state = "sec"
 	req_access = list(ACCESS_SECURITY)
 	products = list(/obj/item/handcuffs = 8,
+					/obj/item/handcuffs/legcuffs = 8,
 					/obj/item/grenade/flashbang = 4,
 					/obj/item/flash = 5,
 					/obj/item/reagent_containers/food/snacks/donut/plain = 6,
@@ -554,6 +555,9 @@
 					/obj/item/gun/energy/stunrevolver = 4,
 					/obj/item/reagent_containers/spray/pepper = 6,
 					/obj/item/taperoll/police = 6,
+					/obj/item/cell/device/weapon = 8,
+					/obj/item/hailer = 3,
+					/obj/item/flashlight/maglight = 3,
 					/obj/item/clothing/glasses/omnihud/sec = 6)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,
 					/obj/item/storage/box/donut = 2,
@@ -1308,15 +1312,18 @@
 		/obj/item/clothing/under/rank/security/turtleneck = 5,
 		/obj/item/clothing/under/rank/security/modern = 5,
 		/obj/item/clothing/under/rank/security/aces = 5,
+		/obj/item/clothing/suit/storage/vest/aces = 5,
 		/obj/item/clothing/under/rank/security/skirt = 5,
 		/obj/item/clothing/shoes/boots/jackboots = 5,
 		/obj/item/clothing/head/soft/sec = 5,
 		/obj/item/clothing/head/beret/sec = 5,
+		/obj/item/clothing/head/soft/sec/corp = 5,
 		/obj/item/clothing/head/beret/sec/corporate/officer = 5,
 		/obj/item/clothing/suit/storage/toggle/labcoat/neo_bodyguard_dep = 5,
 		/obj/item/clothing/suit/storage/toggle/labcoat/neo_sec_blue_dep = 5,
 		/obj/item/clothing/suit/storage/toggle/labcoat/neo_sec_red_dep = 5,
 		/obj/item/clothing/suit/storage/toggle/labcoat/neo_police = 5,
+		/obj/item/clothing/under/rank/security/corp = 5,
 		/obj/item/clothing/under/rank/bodyguard_suit = 5,
 		/obj/item/clothing/under/rank/bodyguard_skirt = 5,
 		/obj/item/clothing/under/rank/bodyguard_turtleneck = 5,
@@ -1335,6 +1342,8 @@
 		/obj/item/clothing/under/rank/neo_runner = 5,
 		/obj/item/clothing/under/rank/neo_gorka/sec = 5,
 		/obj/item/clothing/suit/neo_runner_coat = 5,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/security = 5,
+		/obj/item/clothing/shoes/boots/winter/security = 5,
 		/obj/item/clothing/shoes/boots/jackboots/silver = 5,
 		/obj/item/clothing/shoes/boots/jackboots/white = 5,
 		/obj/item/clothing/mask/bandana/red = 5,
@@ -1350,7 +1359,11 @@
 		/obj/item/clothing/accessory/holster/hip/black = 2,
 		/obj/item/clothing/accessory/holster/leg = 2,
 		/obj/item/clothing/accessory/holster/leg/black = 2,
-		/obj/item/clothing/accessory/holster/waist/lanyard = 2
+		/obj/item/clothing/accessory/holster/waist/lanyard = 2,
+		/obj/item/clothing/accessory/storage/black_vest = 2,
+		/obj/item/radio/headset/alt/headset_sec = 3,
+		/obj/item/radio/headset/earbud/headset_sec = 3
+
 	)
 	req_log_access = ACCESS_HOP
 	has_logs = 1


### PR DESCRIPTION
Moved excessive clothing items from security lockers to security wardrobe vendors to declutter locker contents. Added some additional starting security items to SecTech vending machine.

Legcuffs have been adjusted to have the same throwforce as regular handcuffs (previously set to 0 for some reason) and to have the same weight_class, meaning they take up the same space as a normal pair of handcuffs. This means they can now be put into belts. (Previously, they inherited the flag which allows them to be placed into belts, but due to having a weight class of normal, they couldn't actually fit).

:cl:
add: Added additional starting security items to the SecTech vending machine.
qol: Moved excessive clothing options from security lockers to clothing vending machines.
balance: Reduced weight class on legcuffs from normal to small. They now take up the same space as regular handcuffs.
/:cl: