### PR TITLE
Anomaly Harvesting QoL

### DIFF
--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -53,6 +53,4 @@
 
 /datum/decl/hierarchy/outfit/job/science/scientist/anomalist
 	name = OUTFIT_JOB_NAME(JOB_ALT_ANOMALIST)
-	belt = /obj/item/anomaly_scanner
-	l_pocket = /obj/item/anomaly_choice
-	r_pocket = /obj/item/anomaly_releaser/science
+	backpack_contents = list(/obj/item/storage/box/anomaly = 1)

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -120,18 +120,17 @@
 	return
 
 /obj/effect/anomaly/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/analyzer))
+	if(istype(I, /obj/item/analyzer) || (istype(I, /obj/item/anomaly_scanner) && !stats))
 		if(anomaly_core)
 			to_chat(user, span_notice("Analyzing... [src]'s stabilized field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
 			return TRUE
-	if(istype(I, /obj/item/anomaly_scanner))
+	if(istype(I, /obj/item/anomaly_scanner) && stats)
 		var/obj/item/anomaly_scanner/scanner = I
-		if(stats)
-			if(!do_after(user, 1 SECOND, src))
-				return
-			scanner.buffered_anomaly = WEAKREF(src)
-			scanner.tgui_interact(user)
-			return TRUE
+		if(!do_after(user, 1 SECOND, src))
+			return
+		scanner.buffered_anomaly = WEAKREF(src)
+		scanner.tgui_interact(user)
+		return TRUE
 	return ..()
 
 /obj/effect/anomaly/bullet_act(obj/item/projectile/proj)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -149,6 +149,6 @@
 	starts_with = list(
 		/obj/machinery/anomaly_harvester,
 		/obj/item/anomaly_releaser/science,
-		/obj/item/anomaly_choice,
+		/obj/item/assembly/signaler/anomaly/choice/,
 		/obj/item/anomaly_scanner
 	)

--- a/code/modules/anomalies/anomaly.dm
+++ b/code/modules/anomalies/anomaly.dm
@@ -65,6 +65,9 @@
 /obj/item/anomaly_scanner
 	name = "anomaly scanner"
 	desc = "A hand-held anomaly scanner, able to distinguish the particles that might affect a stable anomaly."
+	description_info = "Click on an emitter to change into an anomalous emitter.<br>\
+	Click on an anomaly harvester to link the scanned anomaly to it.<br>\
+	Danger type adds severity. Unstable changes state. Containment stabilizes at the cost of health. Transformation adds modifiers."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "anom_scanner"
 	slot_flags = SLOT_BELT
@@ -168,38 +171,43 @@
 	starts_with = list(
 		/obj/item/anomaly_releaser,
 		/obj/item/anomaly_scanner,
-		/obj/item/anomaly_choice,
+		/obj/item/assembly/signaler/anomaly/choice,
 		/obj/item/clothing/gloves/black
 	)
 
-/obj/item/anomaly_choice
+/obj/item/assembly/signaler/anomaly/choice
 	name = "latent anomaly core"
 	desc = "A supposedly inert anomaly core. It hums softly if held close."
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "inert"
+	worth = 0
+	var/picked = FALSE
+	anomaly_type = /obj/effect/anomaly/flux // Default
 
-/obj/item/anomaly_choice/attack_self(mob/user, modifiers)
+/obj/item/assembly/signaler/anomaly/choice/attack_self(mob/user, modifiers)
 	. = ..(user)
 	if(.)
 		return TRUE
 
+	if(picked)
+		return TRUE
+
 	var/list/choices = list()
-	var/list/core_types = subtypesof(/obj/item/assembly/signaler/anomaly)
+	var/list/core_types = subtypesof(/obj/effect/anomaly)
 
 	// Two random cores
 	for(var/i = 0, i < 2, i++)
 		var/type = pick(core_types)
-		var/obj/item/assembly/signaler/anomaly/core = new type
-		choices[capitalize(core.name)] = type
+		var/obj/effect/anomaly/anom = new type
+		choices[capitalize(anom.name)] = type
 
 	// Guaranteed
-	var/preset = /obj/item/assembly/signaler/anomaly/flux
-	var/obj/item/assembly/signaler/anomaly/preset_core = new preset
-	choices[capitalize(preset_core.name)] = preset
+	var/preset = /obj/effect/anomaly/flux
+	var/obj/effect/anomaly/preset_anom = new preset
+	choices[capitalize(preset_anom.name)] = preset
 
 	var/choice = tgui_input_list(user, "Choose an anomaly core.", "Anomaly Core Selection", choices)
 
-	if(choice)
-		var/type = choices[choice]
-		new type(get_turf(src))
-		qdel(src)
+	if(choice && !picked)
+		anomaly_type = choices[choice]
+		picked = TRUE

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -231,6 +231,10 @@
 		anomalous = !anomalous
 		burst_delay = anomalous ? 3 : 8
 		to_chat(user, span_notice("The beam is now set to [anomalous ? "anomalous." : "normal."]"))
+		if(anomalous)
+			description_info = "Use a multitool to change the particle type."
+		else
+			description_info = initial(description_info)
 		return
 	if(W.has_tool_quality(TOOL_MULTITOOL) && anomalous)
 		var/chosen_particle = tgui_input_list(user, "Select particle type", "Particle Selection", ANOMALY_PARTICLE_ALL)

--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -32,6 +32,10 @@
 		to_chat(user, span_notice("Analyzing... [src]'s stabilized field is fluctuating along frequency [format_frequency(frequency)], code [code]."))
 		return TRUE
 
+	if(istype(W, /obj/item/anomaly_scanner))
+		to_chat(user, span_notice("Sealed anomalous energies detected. Use of a releaser will unleash these energies."))
+		return TRUE
+
 	if(istype(W, /obj/item/anomaly_releaser))
 		var/obj/item/anomaly_releaser/releaser = W
 		if(releaser.used)


### PR DESCRIPTION

## About The Pull Request

Adds a few pointers towards the right directions with anomaly harvesting items.

## Changelog
:cl: Guti
qol: Normal anomalies can now be scanned with the anomaly scanner for it's frequencies.
qol: The anomaly scanner will indicate the user to use a releaser, if used on a core.
qol: Added particle descriptions when examining the anomaly scanner.
fix: Fixed Anomalis spawning without PDA
/:cl:
