### PR TITLE
Fix Loadout items not properly initializing their own metadata on copy

### DIFF
--- a/code/modules/client/preference_setup/loadout/02_loadout.dm
+++ b/code/modules/client/preference_setup/loadout/02_loadout.dm
@@ -228,7 +228,10 @@ GLOBAL_LIST_EMPTY_TYPED(gear_datums, /datum/gear)
 				if(confirm != "Yes")
 					return TOPIC_HANDLED
 
-			pref.gear_list["[copy_to]"] = check_list_copy(active_gear_list)
+			var/list/slot_copy = check_list_copy(active_gear_list)
+			for(var/gear_name in slot_copy)
+				slot_copy[gear_name] = check_list_copy(slot_copy[gear_name])
+			pref.gear_list["[copy_to]"] = slot_copy
 			return TOPIC_REFRESH
 
 		if("toggle_gear")


### PR DESCRIPTION

## About The Pull Request

copy_loadout used check_list_copy on the outer gear list only, leaving the inner tweak metadata lists as shared references. Modifications to gear tweaks in the copied slot would write into the shared inner lists, affecting the original slot until a save/reload cycle broke the reference.

Fix: deep copy both levels, matching the pattern used for body_markings in 03_body.dm.
## Changelog
:cl:
fix: Copy loadout now correctly makes unique metadata entries for gear. So that changing the color on one pair of glasses doesnt affect the ones in your other loadout.
/:cl:
