### PR TITLE
Minor shadekin anonymity change

### DIFF
--- a/code/datums/components/species/shadekin/shadekin.dm
+++ b/code/datums/components/species/shadekin/shadekin.dm
@@ -313,6 +313,11 @@
 		name_data[1] = ""
 		return COMPONENT_ALT_NAME_CHANGED
 
+	// Suppress "(as Unknown)" for shadekin with voice changers, or no identification.
+	if(source.name != source.GetVoice())
+		name_data[1] = ""
+		return COMPONENT_ALT_NAME_CHANGED
+
 /// Signal handler for get_visible_name()
 /datum/component/shadekin/proc/on_get_visible_name(mob/living/source, list/name_data)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

This PR is solely to remove the (As Unknown) given to all messages from shadekin with no ID, or voice changers.

This is primarily a QoL that just cleans up the chat a bit for deliberately anonymous shadekin.

## Changelog
:cl: Nova
qol: removed "As Unknown" from shadekin without any ID, or with a voice changer.
/:cl: