### PR TITLE
Fix diagonal movement of bots

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -433,7 +433,7 @@
 
 	for(var/dir_to_check in GLOB.alldirs) // Cardinals first.
 		var/turf/T = get_step(src, dir_to_check)
-		if(!T || !T.Adjacent(src))
+		if(!T || T.density || !T.Adjacent(src))
 			continue
 		if(!LinkBlockedWithAccess(src, T, ID))
 			L.Add(T)


### PR DESCRIPTION
## About The Pull Request

Fixes a small issue with bot pathfinding.
This issue caused anything using bot pathfinding to sometimes get stuck on walls.

## Changelog

:cl: Nova
fix: Fixed bot pathfinders getting stuck on diagonals
/:cl:
