### PR TITLE
Robot Consumables

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -110,7 +110,7 @@
 
 /obj/item/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R, var/rate)
 	SHOULD_CALL_PARENT(TRUE)
-	if(!synths || !LAZYLEN(synths))
+	if(!LAZYLEN(synths))
 		return
 
 	for(var/datum/matter_synth/T in synths)


### PR DESCRIPTION

## About The Pull Request
Makes it so that the /respawn_consumable proc for robots calls parent, meaning it'll always check to see if there's synths and recharge them if so.

Also gives the clown module a lube spray upon emag. Because it's funny.
## Changelog
:cl: Diana
add: Clown borg has a lube spray (when emagged)
code: respawn_conumsable parent call added 
/:cl:
