### PR TITLE
remove hacked requirement for chem sprayer design

### DIFF
--- a/code/modules/research/tg/designs/weapon_designs.dm
+++ b/code/modules/research/tg/designs/weapon_designs.dm
@@ -214,7 +214,6 @@
 	materials = list(MAT_STEEL = 5000, MAT_STEEL = 2000)
 	build_path = /obj/item/reagent_containers/spray/chemsprayer
 	category = list(
-		RND_CATEGORY_HACKED,
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_RANGED
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE


### PR DESCRIPTION
## About The Pull Request
I think this was a copypasta issue. Close this if it is intended.

## Changelog
Removes the lathe hacking requirement on the chem sprayer.

:cl: Will
balance: chem sprayer does not require protolathe hacking to print
/:cl:

