### PR TITLE
Always Randomize Name Hotfix

### DIFF
--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -380,7 +380,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 	if(preference.savefile_identifier == PREFERENCE_PLAYER)
 		preference.apply_to_client_updated(client, read_preference(preference.type))
-	else
+	else if (!istype(preference, /datum/preference/name/real_name)) // Recursive random_name preference emergency hotfix.
 		update_preview_icon()
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Fixes a stackover flow caused by "Always randomize name" preference. When the new name is saved to the file it'll eventually try to update the display mob. This then calls copy_to(), which reads the always randomized name pref, and makes a new random name that is saved to the file. Repeating the prior logic of updating the display mob. This happens until we finally overflow and crash out. 

This pr does not fix the core logic issue, it just stops the server exploding. Someone smarter than me at pref code needs to fix this properly. Sorry.

## Changelog
Adds a hotfix that prevents real_name preference save updating the preview mob (thus avoiding an inf recursion)

:cl: Will
fix: always randomize name preference temporarily hot-fixed
/:cl:
