### PR TITLE
Text To Speech Device Shows Talking Indicator

### DIFF
--- a/code/game/objects/items/devices/text_to_speech.dm
+++ b/code/game/objects/items/devices/text_to_speech.dm
@@ -27,7 +27,10 @@
 		named = 1
 		*/
 
+	user.client?.start_typing()
 	var/message = tgui_input_text(user,"Choose a message to relay to those around you.", "", "", MAX_MESSAGE_LEN)
+	user.client?.stop_thinking()
+
 	if(message)
 		audible_message("[icon2html(src, user.client)] \The [src.name] states, \"[message]\"", runemessage = "synthesized speech")
 		if(ismob(loc))

--- a/code/game/objects/items/devices/text_to_speech.dm
+++ b/code/game/objects/items/devices/text_to_speech.dm
@@ -27,6 +27,7 @@
 		named = 1
 		*/
 
+	user.client?.start_thinking()
 	user.client?.start_typing()
 	var/message = tgui_input_text(user,"Choose a message to relay to those around you.", "", "", MAX_MESSAGE_LEN)
 	user.client?.stop_thinking()


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Fixes an issue where people are ignored due to showing no indication they are typing while using the tool.

## Changelog
Using the TTS device text input prompt will now flag you as typing.

:cl: Will
add: TTS device now shows a typing indicator while in use.
/:cl:

