### PR TITLE
Hoist Tweaks

### DIFF
--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -27,12 +27,13 @@
 	can_buckle = TRUE
 	anchored = TRUE
 	description_info = "Click and drag someone (or any object) to this to attach them to the clamp. If you are within reach, when you click and drag this to a turf adjacent to you, it will move the attached object there and release it."
+	plane = ABOVE_MOB_PLANE
 
 /obj/effect/hoist_hook/attack_hand(mob/living/user)
 	return // This has to be overridden so that it works properly.
 
 /obj/effect/hoist_hook/MouseDrop_T(atom/movable/AM,mob/user)
-	if (use_check(user, USE_DISALLOW_SILICONS))
+	if (use_check(user, 0))
 		return
 
 	if (!AM.simulated || AM.anchored)
@@ -57,7 +58,7 @@
 	..()
 	if(!Adjacent(usr) || !dest.Adjacent(usr)) return // carried over from the default proc
 
-	if (!ishuman(usr))
+	if (!(ishuman(usr) || issilicon(usr)))
 		return
 
 	if (usr.incapacitated())
@@ -94,7 +95,7 @@
 	icon = 'icons/obj/hoists.dmi'
 	icon_state = "hoist_base"
 	var/broken = 0
-	density = TRUE
+	density = FALSE
 	anchored = TRUE
 	name = "hoist"
 	desc = "A manual hoist, uses a clamp and pulley to hoist things."
@@ -175,9 +176,11 @@
 				source_hoist.break_hoist()
 			return
 
+/obj/structure/hoist/attack_robot(mob/living/user)
+	attack_hand(user)
 
 /obj/structure/hoist/attack_hand(mob/living/user)
-	if (!ishuman(user))
+	if (!(ishuman(user) || issilicon(user)))
 		return
 
 	if (user.incapacitated())
@@ -226,7 +229,7 @@
 	set category = "Object"
 	set src in range(1)
 
-	if (!ishuman(usr))
+	if (!(ishuman(usr) || issilicon(usr)))
 		return
 
 	if (isobserver(usr) || usr.incapacitated())

--- a/code/modules/research/tg/designs/misc_designs.dm
+++ b/code/modules/research/tg/designs/misc_designs.dm
@@ -436,7 +436,7 @@
 	name = "hoist kit"
 	desc = "A setup kit for a hoist that can be used to lift things."
 	id = "hoist_kit"
-	materials = list(MAT_STEEL = 15000)
+	materials = list(MAT_STEEL = 9000)
 	build_path = /obj/item/hoist_kit
 	build_type = AUTOLATHE | PROTOLATHE
 	category = list(

--- a/code/modules/research/tg/designs/misc_designs.dm
+++ b/code/modules/research/tg/designs/misc_designs.dm
@@ -431,3 +431,16 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design_techweb/hoist_kit
+	name = "hoist kit"
+	desc = "A setup kit for a hoist that can be used to lift things."
+	id = "hoist_kit"
+	materials = list(MAT_STEEL = 15000)
+	build_path = /obj/item/hoist_kit
+	build_type = AUTOLATHE | PROTOLATHE
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_CARGO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO

--- a/code/modules/research/tg/techwebs/nodes/mining_nodes.dm
+++ b/code/modules/research/tg/techwebs/nodes/mining_nodes.dm
@@ -14,6 +14,7 @@
 		// "recycler",
 		// "stack_machine",
 		// "stack_console",
+		"hoist_kit",
 	)
 
 /datum/techweb_node/mining


### PR DESCRIPTION
## About The Pull Request
Upports multiple changes done to hoists from outpost 21, to improve general usability. These items are rarely used.

## Changelog
Deployed hoistkits are no longer solid
Hoist claw always draws above mobs
Borgs can use deployed hoist kits
Adds hoistkit to techweb

:cl: Will
add: hoistkit added to techweb
add: borgs can now use unpacked hoist kits
refactor: General improvements to hoist kits
/:cl:
