### PR TITLE
Examine cell icons fix

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -1267,9 +1267,9 @@ GLOBAL_LIST_INIT(description_icons, list(
 	"stunbaton" = image(icon='icons/obj/weapons.dmi',icon_state="stunbaton_active"),
 	"slimebaton" = image(icon='icons/obj/weapons.dmi',icon_state="slimebaton_active"),
 
-	"power cell" = image(icon='icons/obj/power.dmi',icon_state="hcell"),
-	"device cell" = image(icon='icons/obj/power.dmi',icon_state="dcell"),
-	"weapon cell" = image(icon='icons/obj/power.dmi',icon_state="wcell"),
+	"power cell" = image(icon='icons/obj/power_cells_old.dmi',icon_state="b_st"),
+	"device cell" = image(icon='icons/obj/power_cells_old.dmi',icon_state="m_st"),
+	"weapon cell" = image(icon='icons/obj/power_cells_old.dmi',icon_state="m_sup"),
 
 	"hatchet" = image(icon='icons/obj/weapons.dmi',icon_state="hatchet"),
 	))


### PR DESCRIPTION
## About The Pull Request
Fixes #19266 by updating global paths to correct icons.

Tested, works, etc. - I'm pretty sure these are the right icons, at least for weapon and device.

## Changelog
:cl:
fix: fixed weapon cell icons in examine when guns/etc. are unloaded
/:cl: