### PR TITLE
Fixes mob offset

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -4,7 +4,7 @@
 	var/step_mechanics_pref = TRUE		// Allow participation in macro-micro step mechanics
 	var/pickup_pref = TRUE				// Allow participation in macro-micro pickup mechanics
 	var/center_offset = 0.5				// Center offset for uneven scaling symmetry.
-	var/offset_override = FALSE			// Pref toggle for center offset.
+	var/offset_override = TRUE			// Pref toggle for center offset.
 
 /mob/living
 	var/holder_default


### PR DESCRIPTION

## About The Pull Request

Have your monkeys experienced crumpling when doing Genetics or Virology, or Punpun became a cyclops out of nowhere? Fear no more! This PR will de-crumple your mobs.

Ugly, one-eyed monkey
<img width="106" height="90" alt="image" src="https://github.com/user-attachments/assets/fd0e9626-acaa-4f77-9f06-1fc6818f4153" />

Most precious, the thing we all missed. Two eyes.
<img width="88" height="72" alt="image" src="https://github.com/user-attachments/assets/85a84f95-32bc-4c51-a306-4b02a4fa3090" />


## Changelog
:cl: Guti
fix: Fixed mob offset
/:cl:
