### PR TITLE
Fixes swoopie runtime

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -516,7 +516,7 @@ GLOBAL_LIST_EMPTY(additional_antag_types)
 	var/list/dudes = list()
 	for(var/mob/living/carbon/human/man in GLOB.player_list)
 		if(man.client)
-			if(man.client.prefs.economic_status == CLASS_LOWER)
+			if((man.client.prefs.economic_status == CLASS_LOWER) || (man.client.prefs.economic_status == CLASS_BROKE))
 				dudes += man
 			else if(man.client.prefs.economic_status == CLASS_LOWMID && prob(50))
 				dudes += man

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -534,3 +534,7 @@
 			expanding_turfs += next_turf
 
 	return expanding_turfs
+
+// /empulse handles emp acting stuff in range. You can override this to do specialty stuff, but otherwise we don't want it to do a recursive check.
+/turf/emp_act(severity, recursive)
+	return

--- a/code/modules/env_message/env_message.dm
+++ b/code/modules/env_message/env_message.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(env_messages)
 	if(!istype(src) || !get_turf(src) || !src.ckey)
 		return
 
-	var/new_message = tgui_input_text(src, "Type in your message. It will be displayed to players who hover over the spot where you are right now. If you already have a message somewhere, it will be removed in the process. Please refrain from abusive or deceptive messages, but otherwise, feel free to be creative!", "Env Message", MAX_MESSAGE_LEN)
+	var/new_message = tgui_input_text(src, "Type in your message. It will be displayed to players who hover over the spot where you are right now. If you already have a message somewhere, it will be removed in the process. Please refrain from abusive or deceptive messages, but otherwise, feel free to be creative!", "Env Message", max_length = MAX_MESSAGE_LEN)
 
 	if(!new_message)
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -56,7 +56,7 @@
 		init_vore()
 	Vac = new /obj/item/vac_attachment/swoopie(src)
 	if(istype(Vac))
-		Vac.output_dest = vore_selected
+		Vac.output_dest = WEAKREF(vore_selected)
 		Vac.vac_power = 3
 		Vac.vac_owner = src
 
@@ -202,9 +202,10 @@
 					L.remove_from_mob(Vac, src)
 				else
 					Vac.forceMove(src)
-		if(!Vac.output_dest)
+		var/atom/movable/vac_output = Vac.output_dest?.resolve()
+		if(!vac_output)
 			if(isbelly(vore_selected))
-				Vac.output_dest = vore_selected
+				Vac.output_dest = WEAKREF(vore_selected)
 	if(!istype(T) || !istype(Vac) || !has_AI() || Vac.loc != src || stat)
 		return
 	if(istype(T, /turf/simulated))


### PR DESCRIPTION

## About The Pull Request
Fixes swoopies runtiming
Fixes environmental message.
Fixes being economic class of broke not making you a NT opposed member. (Broke and Poor do now. Underpaid still has a 50% chance to make you non-NT opposed for traitors.)
Fixes EMPs accidentally double-hitting contents on a turf.
## Changelog
:cl: Diana
fix: Swoopies no longer runtime
fix: Environmental message works now.
fix: Antag NT opposed now considers broke instead of just underpaid/poor
fix: EMPs will no longer doubletap things.
/:cl:
