### PR TITLE
Blood drawing fix

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -306,7 +306,7 @@ BLOOD_VOLUME_SURVIVE = 40
 	var/datum/reagent/B = get_blood(container.reagents)
 	if(!B)
 		B = new /datum/reagent/blood
-	B.holder = container
+	B.holder = container.reagents
 	B.volume += amount
 
 	//set reagent data


### PR DESCRIPTION
## About The Pull Request
Turns out syringe and IV stands have been broken for 13 years. Except the bug only became fully blocking with a runtime 2 weeks ago because update_total() now checks the holder.my_atom each time to do some new logic. The syringe was setting the holder of the blood reagent to the syringe itself... and not the syringe's reagent datum. So the my_atom var didn't exist!

## Changelog
take_blood() proc properly uses the correct holder when creating the blood reagent.

:cl: Will
fix: Drawing blood with syringes and IV stands works properly again.
/:cl:
