### PR TITLE
Makes camera consoles (more) accessible via AI

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -31,6 +31,9 @@
 /obj/machinery/computer/security/tgui_interact(mob/user, datum/tgui/ui = null)
 	camera.tgui_interact(user, ui)
 
+/obj/machinery/computer/security/tgui_state(mob/user)
+	return GLOB.tgui_camera_view
+
 /obj/machinery/computer/security/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(stat & (BROKEN|NOPOWER))
@@ -45,9 +48,6 @@
 	..()
 
 /obj/machinery/computer/security/attack_ai(mob/user)
-	if(isAI(user))
-		to_chat(user, span_notice("You realise its kind of stupid to access a camera console when you have the entire camera network at your metaphorical fingertips"))
-		return
 	attack_hand(user)
 
 /obj/machinery/computer/security/proc/set_network(list/new_network)
@@ -83,7 +83,7 @@ GLOBAL_LIST_EMPTY(entertainment_screens)
 	light_range_on = 2
 	network = list(NETWORK_THUNDER)
 	circuit = /obj/item/circuitboard/security/telescreen/entertainment
-	camera_datum_type = /datum/tgui_module/camera/bigscreen
+	camera_datum_type = /datum/tgui_module/camera/virtual
 
 	var/obj/item/radio/radio = null
 	var/obj/effect/overlay/vis/pinboard

--- a/code/modules/tgui/modules/camera.dm
+++ b/code/modules/tgui/modules/camera.dm
@@ -317,4 +317,7 @@
 /datum/tgui_module/camera/bigscreen/tgui_state(mob/user)
 	return GLOB.tgui_physical_state_bigscreen
 
+/datum/tgui_module/camera/virtual/tgui_state(mob/user)
+	return GLOB.tgui_camera_view
+
 #undef DEFAULT_MAP_SIZE

--- a/code/modules/tgui/states/cameras.dm
+++ b/code/modules/tgui/states/cameras.dm
@@ -1,0 +1,25 @@
+/**
+ * tgui state: camera_view
+ *
+ * In addition to default checks, allows AI to interact and has a cutoff after it leaves view range.
+ * living adjacent user.
+ **/
+
+GLOBAL_DATUM_INIT(tgui_camera_view, /datum/tgui_state/camera_view, new)
+
+/datum/tgui_state/camera_view/can_use_topic(src_object, mob/user)
+	. = user.shared_tgui_interaction(src_object)
+	if(. > STATUS_CLOSE)
+		return min(., user.camera_view_can_use_topic(src_object))
+
+/mob/proc/camera_view_can_use_topic(src_object)
+	return STATUS_CLOSE
+
+/mob/living/camera_view_can_use_topic(src_object)
+	return shared_living_tgui_distance(src_object, viewcheck = TRUE)
+
+/mob/living/silicon/camera_view_can_use_topic(src_object)
+	return shared_living_tgui_distance(src_object, viewcheck = TRUE)
+
+/mob/living/silicon/ai/camera_view_can_use_topic(src_object)
+	return STATUS_INTERACTIVE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4796,6 +4796,7 @@
 #include "code\modules\tgui\states\admin.dm"
 #include "code\modules\tgui\states\always.dm"
 #include "code\modules\tgui\states\board_game.dm"
+#include "code\modules\tgui\states\cameras.dm"
 #include "code\modules\tgui\states\conscious.dm"
 #include "code\modules\tgui\states\contained.dm"
 #include "code\modules\tgui\states\deep_inventory.dm"


### PR DESCRIPTION

## About The Pull Request
In case you don't want to use multicam, or the map does not have multicam mapped in, or want to look at cameras that move (ex: helmet cams) without having to continually move your camera view to follow them.

Removes the broken attack_ai warning that never actually worked. At one point it was attempted by someone to make it so that AIs can't look at camera consoles, but this either broke somewhere down the line or never worked at all.
AI already is a very boring role, so this gives them a bit more flexibility in what they can do.

Fixes an unintended interaction where cyborgs could open up multiple camera consoles and have them open forever, allowing them to make a camera network that was better than AI multicam.
## Changelog
:cl: Diana
qol: AI can now use camera consoles in a more intuitive way.
fix: Cyborgs can no longer build a camera network with multiple camera consoles that follows them wherever they move.
/:cl:
