### PR TITLE
Allow throwing things at yourself again

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1332,7 +1332,7 @@
 		return FALSE //Grab processing has a chance of returning null
 
 	// Help intent + Adjacent = pass item to other
-	if(a_intent == I_HELP && Adjacent(target) && isitem(item) && ishuman(target))
+	if(a_intent == I_HELP && Adjacent(target) && isitem(item) && ishuman(target) && target != src)
 		var/obj/item/I = item
 		var/mob/living/carbon/human/H = target
 		if(H.in_throw_mode && H.a_intent == I_HELP && unEquip(I))


### PR DESCRIPTION

## About The Pull Request
Adds a check to make sure the target of passing items via help intent isn't the same as the one initiating it. This was preventing the interaction of tossing items and held mobs at yourself to initiate spont vore. I also doubt many need to hand items to themselves.
## Changelog
:cl:
fix: Fixed throwing items/mobs at yourself not triggering spont vore
/:cl:
