### PR TITLE
shapechange trait upport

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
@@ -1406,3 +1406,39 @@
 		to_chat(pred, span_vnotice("Your [belly] manages to [lowertext(belly.vore_verb)] \the [target]."))
 		to_chat(target, span_vwarning("You are [lowertext(belly.vore_verb)]ed by \The [pred]'s [belly]!"))
 		return pred.begin_instant_nom(src, target, pred, belly, FALSE)
+
+/mob/living/proc/name_change_verb()
+	set name = "Change Name"
+	set desc = "Change your name. Notifies admins."
+	set category = "Abilities.Superpower"
+
+	if(last_special > world.time)
+		return
+
+	var/chosen_name = tgui_input_text(src,"What would you like your name to become?", "Name change",name, MAX_NAME_LEN)
+
+	if(!chosen_name || !length(chosen_name))
+		return
+
+	last_special = world.time + (5 SECONDS) //don't spam check the global list pls
+	for(var/mob/checkplayer in GLOB.player_list)
+		if(checkplayer == src)
+			continue
+		if(!checkplayer.client) //no client, no problem
+			continue
+		if(checkplayer.name == chosen_name)
+			if(checkplayer.client.prefs.resleeve_lock)
+				to_chat(src, span_notice("\The [checkplayer]'s preferences forbid you from impersonating them."))
+				message_admins("[key_name(src)] attempted to impersonate [key_name(checkplayer)], but preferences prevented it.")
+				log_admin("[key_name(src)] attempted to impersonate [key_name(checkplayer)], but preferences prevented it.")
+				return
+			message_admins("[key_name(src)] impersonated [key_name(checkplayer)]!")
+			log_admin("[key_name(src)] impersonated [key_name(checkplayer)]!")
+
+
+	message_admins("[key_name(src)] set their name to [chosen_name]")
+	log_admin("[key_name(src)] set their name to [chosen_name]")
+	if(dna)
+		dna.real_name = chosen_name
+	real_name = chosen_name
+	name = chosen_name

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
@@ -1415,7 +1415,7 @@
 	if(last_special > world.time)
 		return
 
-	var/chosen_name = tgui_input_text(src,"What would you like your name to become?", "Name change",name, MAX_NAME_LEN)
+	var/chosen_name = tgui_input_text(src, "What would you like your name to become?", "Name change", name, MAX_NAME_LEN)
 
 	if(!chosen_name || !length(chosen_name))
 		return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities.dm
@@ -1429,15 +1429,11 @@
 		if(checkplayer.name == chosen_name)
 			if(checkplayer.client.prefs.resleeve_lock)
 				to_chat(src, span_notice("\The [checkplayer]'s preferences forbid you from impersonating them."))
-				message_admins("[key_name(src)] attempted to impersonate [key_name(checkplayer)], but preferences prevented it.")
-				log_admin("[key_name(src)] attempted to impersonate [key_name(checkplayer)], but preferences prevented it.")
+				log_and_message_admins("[key_name(src)] attempted to impersonate [key_name(checkplayer)], but preferences prevented it.", src)
 				return
-			message_admins("[key_name(src)] impersonated [key_name(checkplayer)]!")
-			log_admin("[key_name(src)] impersonated [key_name(checkplayer)]!")
+			log_and_message_admins("[key_name(src)] impersonated [key_name(checkplayer)]!", src)
 
-
-	message_admins("[key_name(src)] set their name to [chosen_name]")
-	log_admin("[key_name(src)] set their name to [chosen_name]")
+	log_and_message_admins("[key_name(src)] set their name to [chosen_name]", src)
 	if(dna)
 		dna.real_name = chosen_name
 	real_name = chosen_name

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -946,3 +946,14 @@
 	if(G)
 		G.radiation_healing = initial(G.radiation_healing)
 		G.radiation_nutrition = initial(G.radiation_nutrition)
+
+/datum/trait/positive/shapeshifting
+	name = "Shapeshifter"
+	desc = "You're able to shift your appearance."
+	cost = 3 //this trait is functionally wholly cosmetic, but it is less flavor-restricted than cocoon, and takes less time, so it's a bit pricier
+	custom_only = FALSE
+
+/datum/trait/positive/shapeshifting/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	add_verb(H, /mob/living/carbon/human/proc/innate_shapeshifting)
+	add_verb(H, /mob/living/proc/name_change_verb)

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -952,6 +952,7 @@
 	desc = "You're able to shift your appearance."
 	cost = 3 //this trait is functionally wholly cosmetic, but it is less flavor-restricted than cocoon, and takes less time, so it's a bit pricier
 	custom_only = FALSE
+	hidden = TRUE
 
 /datum/trait/positive/shapeshifting/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request
Upports the shapechange trait from chomp, and adds a name change functionality, which checks prefs
This trait is hidden by default for virgo. Can be enabled if desired.

## Changelog
:cl:
add: shapechange trait
/:cl: