### PR TITLE
Cargo Material Purchasing

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/algae_generator_vr.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/algae_generator_vr.dm
@@ -292,6 +292,7 @@
 	hardness = 10
 	sheet_singular_name = "sheet"
 	sheet_plural_name = "sheets"
+	supply_conversion_value = 0.25
 
 /obj/item/stack/material/algae
 	name = "algae sheet"

--- a/code/datums/elements/sellable.dm
+++ b/code/datums/elements/sellable.dm
@@ -70,6 +70,8 @@
 /datum/element/sellable/material_stack/calculate_sell_value(obj/source)
 	var/obj/item/stack/P = source
 	var/datum/material/mat = P.get_material()
+	if(!mat || !mat.supply_conversion_value)
+		return 0
 	return P.get_amount() * mat.supply_conversion_value
 
 /datum/element/sellable/material_stack/calculate_sell_quantity(obj/source)

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -167,3 +167,136 @@
 	containertype = /obj/structure/closet/crate/grayson
 	contains = list(/obj/fiftyspawner/concrete)
 	containername = "Concrete bricks crate"
+
+/datum/supply_pack/materials/aluminium50
+	name = "50 aluminium ingots"
+	contains = list(/obj/fiftyspawner/aluminium)
+	cost = 120
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Aluminium ingots crate"
+
+/datum/supply_pack/materials/iron50
+	name = "50 iron ingots"
+	contains = list(/obj/fiftyspawner/iron)
+	cost = 30
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Iron ingots crate"
+
+/datum/supply_pack/materials/uranium50
+	name = "50 uranium ingots"
+	contains = list(/obj/fiftyspawner/uranium)
+	cost = 240
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Uranium ingots crate"
+
+/datum/supply_pack/materials/gold50
+	name = "50 gold ingots"
+	contains = list(/obj/fiftyspawner/gold)
+	cost = 240
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Gold ingots crate"
+
+/datum/supply_pack/materials/silver50
+	name = "50 silver ingots"
+	contains = list(/obj/fiftyspawner/silver)
+	cost = 120
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Silver ingots crate"
+
+/datum/supply_pack/materials/platinum50
+	name = "50 platinum ingots"
+	contains = list(/obj/fiftyspawner/platinum)
+	cost = 600
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Platinum ingots crate"
+
+/datum/supply_pack/materials/osmium50
+	name = "50 osmium ingots"
+	contains = list(/obj/fiftyspawner/osmium)
+	cost = 720
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Osmium ingots crate"
+
+/datum/supply_pack/materials/titanium50
+	name = "50 titanium ingots"
+	contains = list(/obj/fiftyspawner/titanium)
+	cost = 480
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Titanium ingots crate"
+
+/datum/supply_pack/materials/graphite50
+	name = "50 graphite ingots"
+	contains = list(/obj/fiftyspawner/graphite)
+	cost = 25
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Graphite ingots crate"
+
+/datum/supply_pack/materials/durasteel50
+	name = "50 durasteel ingots"
+	contains = list(/obj/fiftyspawner/durasteel)
+	cost = 1000
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Durasteel ingots crate"
+
+/datum/supply_pack/materials/plasteel50
+	name = "50 plasteel ingots"
+	contains = list(/obj/fiftyspawner/plasteel)
+	cost = 720
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Plasteel ingots crate"
+
+/datum/supply_pack/materials/diamond50
+	name = "50 diamond ingots"
+	contains = list(/obj/fiftyspawner/diamond)
+	cost = 960
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Diamond ingots crate"
+
+/datum/supply_pack/materials/verdantium50
+	name = "50 verdantium ingots"
+	contains = list(/obj/fiftyspawner/verdantium)
+	cost = 1000
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Verdantium ingots crate"
+
+/datum/supply_pack/materials/sandstone50
+	name = "50 sandstone blocks"
+	contains = list(/obj/fiftyspawner/sandstone)
+	cost = 10
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Sandstone blocks crate"
+
+/datum/supply_pack/materials/marble50
+	name = "50 marble blocks"
+	contains = list(/obj/fiftyspawner/marble)
+	cost = 10
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "marble blocks crate"
+
+/datum/supply_pack/materials/leather50
+	name = "50 leather bolts"
+	contains = list(/obj/fiftyspawner/leather)
+	cost = 120
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Leather bolts crate"
+
+/datum/supply_pack/materials/phoron50
+	name = "50 phoron ingots"
+	contains = list(/obj/fiftyspawner/phoron)
+	cost = 600
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Phoron ingots crate"
+
+/datum/supply_pack/materials/painite50
+	name = "50 painite ingots"
+	contains = list(/obj/fiftyspawner/painite)
+	cost = 480
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Painite ingots crate"
+
+/datum/supply_pack/materials/cloth50
+	name = "50 cloth bolts"
+	contains = list(/obj/fiftyspawner/cloth)
+	cost = 120
+	containertype = /obj/structure/closet/crate/grayson
+	containername = "Cloth bolts crate"

--- a/code/game/objects/structures/simple_doors_vr.dm
+++ b/code/game/objects/structures/simple_doors_vr.dm
@@ -14,6 +14,7 @@
 	sheet_singular_name = "quanta"
 	sheet_plural_name = "quanta"
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 3
 
 /obj/structure/simple_door/flock
 	name = "aperture"

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -316,6 +316,7 @@
 	icon_state = "wax"
 	default_type = MAT_WAX
 	pass_color = TRUE
+	supply_conversion_value = 0.5
 	strict_color_stacking = TRUE
 
 /obj/item/stack/material/wax/Initialize(mapload)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -316,7 +316,6 @@
 	icon_state = "wax"
 	default_type = MAT_WAX
 	pass_color = TRUE
-	supply_conversion_value = 0.5
 	strict_color_stacking = TRUE
 
 /obj/item/stack/material/wax/Initialize(mapload)
@@ -330,6 +329,7 @@
 	melting_point = T0C+300
 	weight = 1
 	pass_stack_colors = TRUE
+	supply_conversion_value = 0.5
 
 
 

--- a/code/modules/materials/fifty_spawner_mats.dm
+++ b/code/modules/materials/fifty_spawner_mats.dm
@@ -195,3 +195,15 @@
 /obj/fiftyspawner/plastitanium_glass
 	name = "stack of plastitanium glass"
 	type_to_spawn = /obj/item/stack/material/glass/plastitanium
+
+/obj/fiftyspawner/aluminium
+	name = "stack of aluminium"
+	type_to_spawn = /obj/item/stack/material/aluminium
+
+/obj/fiftyspawner/verdantium
+	name = "stack of verdantium"
+	type_to_spawn = /obj/item/stack/material/verdantium
+
+/obj/fiftyspawner/painite
+	name = "stack of painite"
+	type_to_spawn = /obj/item/stack/material/painite

--- a/code/modules/materials/materials/_materials.dm
+++ b/code/modules/materials/materials/_materials.dm
@@ -321,6 +321,7 @@ GLOBAL_LIST_INIT(name_to_material, populate_material_list())
 /datum/material/placeholder
 	name = "placeholder"
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0
 
 // Places a girder object when a wall is dismantled, also applies reinforced material.
 /datum/material/proc/place_dismantled_girder(var/turf/target, var/datum/material/reinf_material, var/datum/material/girder_material)

--- a/code/modules/materials/materials/alien_alloy.dm
+++ b/code/modules/materials/materials/alien_alloy.dm
@@ -12,6 +12,7 @@
 	weight = 500
 	protectiveness = 80 // 80%
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 5 // Neat if you somehow manage to sell this
 
 /datum/material/alienalloy/elevatorium
 	name = MAT_ALIEN_ELEVAT

--- a/code/modules/materials/materials/cult.dm
+++ b/code/modules/materials/materials/cult.dm
@@ -10,6 +10,7 @@
 	sheet_plural_name = "bricks"
 	conductive = 0
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0
 
 /datum/material/cult/place_dismantled_girder(var/turf/target)
 	new /obj/structure/girder/cult(target, MAT_CULT)

--- a/code/modules/materials/materials/gems.dm
+++ b/code/modules/materials/materials/gems.dm
@@ -115,6 +115,7 @@
 	sheet_plural_name = "gems"
 	icon_base = "stone"
 	table_icon_base = "stone"
+	supply_conversion_value = 10
 
 /datum/material/verdantium
 	name = MAT_VERDANTIUM

--- a/code/modules/materials/materials/glass.dm
+++ b/code/modules/materials/materials/glass.dm
@@ -18,6 +18,7 @@
 	created_window = /obj/structure/window/basic
 	created_fulltile_window = /obj/structure/window/basic/full
 	rod_product = /obj/item/stack/material/glass/reinforced
+	supply_conversion_value = 0.25
 
 /datum/material/glass/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
 
@@ -111,6 +112,7 @@
 	created_fulltile_window = /obj/structure/window/reinforced/full
 	wire_product = null
 	rod_product = null
+	supply_conversion_value = 0.25
 
 /datum/material/glass/phoron
 	name = MAT_PGLASS
@@ -124,6 +126,7 @@
 	created_fulltile_window = /obj/structure/window/phoronbasic/full
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/phoronrglass
+	supply_conversion_value = 5
 
 /datum/material/glass/phoron/reinforced
 	name = MAT_RPGLASS
@@ -137,3 +140,4 @@
 	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, MAT_PGLASS = SHEET_MATERIAL_AMOUNT)
 	rod_product = null
 	flags = MATERIAL_UNMELTABLE
+	supply_conversion_value = 5

--- a/code/modules/materials/materials/glass_vr.dm
+++ b/code/modules/materials/materials/glass_vr.dm
@@ -12,6 +12,7 @@
 	created_fulltile_window = /obj/structure/window/titanium/full
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/titanium
+	supply_conversion_value = 4
 
 /datum/material/glass/plastaniumglass
 	name = MAT_PLASTITANIUMGLASS
@@ -27,3 +28,4 @@
 	created_fulltile_window = /obj/structure/window/plastitanium/full
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/plastitanium
+	supply_conversion_value = 5

--- a/code/modules/materials/materials/metals/hull.dm
+++ b/code/modules/materials/materials/metals/hull.dm
@@ -9,6 +9,7 @@
 	icon_colour = "#666677"
 	flags = MATERIAL_UNMELTABLE | MATERIAL_NO_SYNTH
 	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT)
+	supply_conversion_value = 0.25
 
 /datum/material/steel/hull/place_sheet(var/turf/target) //Deconstructed into normal steel sheets.
 	new /obj/item/stack/material/steel(target)

--- a/code/modules/materials/materials/metals/metals.dm
+++ b/code/modules/materials/materials/metals/metals.dm
@@ -32,6 +32,7 @@
 	door_icon_base = "metal"
 	icon_colour = "#D1E6E3"
 	icon_reinf = "reinf_metal"
+	supply_conversion_value = 4
 
 /datum/material/titanium/generate_recipes()
 	..()
@@ -47,6 +48,7 @@
 	conductivity = 10
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
+	supply_conversion_value = 0.25
 
 /datum/material/lead
 	name = MAT_LEAD
@@ -57,7 +59,7 @@
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	radiation_resistance = 25 // Lead is Special and so gets to block more radiation than it normally would with just weight, totalling in 48 protection.
-	supply_conversion_value = 2
+	supply_conversion_value = 0.5
 
 /datum/material/gold
 	name = MAT_GOLD
@@ -79,7 +81,7 @@
 	conductivity = 63
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	supply_conversion_value = 2
+	supply_conversion_value = 1
 
 /datum/material/platinum
 	name = MAT_PLATINUM
@@ -104,6 +106,7 @@
 
 /datum/material/mhydrogen
 	name = MAT_METALHYDROGEN
+	display_name = "metallic hydrogen"
 	stack_type = /obj/item/stack/material/mhydrogen
 	icon_colour = "#E6C5DE"
 	conductivity = 100
@@ -118,6 +121,7 @@
 	sheet_plural_name = "ingots"
 	is_fusion_fuel = 1
 	conductive = 0
+	supply_conversion_value = 3
 
 /datum/material/tritium
 	name = MAT_TRITIUM
@@ -127,6 +131,7 @@
 	sheet_plural_name = "ingots"
 	is_fusion_fuel = 1
 	conductive = 0
+	supply_conversion_value = 4
 
 /datum/material/osmium
 	name = MAT_OSMIUM
@@ -152,6 +157,7 @@
 	conductivity = 18
 	melting_point = T0C+3600
 	radiation_resistance = 15
+	supply_conversion_value = 0.5
 
 /datum/material/bronze
 	name = MAT_BRONZE
@@ -162,6 +168,7 @@
 	integrity = 120
 	conductivity = 12
 	protectiveness = 9 // 33%
+	supply_conversion_value = 1
 
 /datum/material/tin
 	name = MAT_TIN
@@ -171,7 +178,7 @@
 	icon_colour = "#b2afaf"
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	supply_conversion_value = 1
+	supply_conversion_value = 0.5
 	hardness = 50
 	weight = 13
 
@@ -184,7 +191,7 @@
 	icon_colour = "#af633e"
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	supply_conversion_value = 1
+	supply_conversion_value = 0.5
 	weight = 13
 	hardness = 50
 
@@ -196,5 +203,5 @@
 	stack_type = /obj/item/stack/material/aluminium
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
-	supply_conversion_value = 2
+	supply_conversion_value = 1
 	weight = 10

--- a/code/modules/materials/materials/metals/steel.dm
+++ b/code/modules/materials/materials/metals/steel.dm
@@ -7,6 +7,7 @@
 	icon_base = "solid"
 	icon_reinf = "reinf_over"
 	icon_colour = "#666666"
+	supply_conversion_value = 0.15
 
 /datum/material/steel/generate_recipes()
 	..()

--- a/code/modules/materials/materials/organic/animal_products.dm
+++ b/code/modules/materials/materials/organic/animal_products.dm
@@ -5,6 +5,7 @@
 	integrity = 600
 	icon_base = "diona"
 	icon_reinf = "noreinf"
+	supply_conversion_value = 1
 
 /datum/material/diona/place_dismantled_product()
 	return

--- a/code/modules/materials/materials/organic/cloth.dm
+++ b/code/modules/materials/materials/organic/cloth.dm
@@ -140,6 +140,7 @@
 	conductive = 0
 	hardness = 5
 	integrity = 40
+	supply_conversion_value = 0.25
 	wiki_flag = WIKI_SPOILER
 
 /datum/material/cotton
@@ -153,6 +154,7 @@
 	conductive = 0
 	hardness = 5
 	integrity = 10
+	supply_conversion_value = 1
 	stack_type = /obj/item/stack/material/cotton
 
 /datum/material/fibers
@@ -169,3 +171,4 @@
 	pass_stack_colors = TRUE
 	hardness = 5
 	integrity = 5
+	supply_conversion_value = 1

--- a/code/modules/materials/materials/organic/grass.dm
+++ b/code/modules/materials/materials/organic/grass.dm
@@ -7,7 +7,7 @@
 	protectiveness = 0
 	conductive = 0
 	integrity = 10
-	supply_conversion_value = 1
+	supply_conversion_value = 0.1
 
 /datum/material/grass/generate_recipes()
 	recipes = list(

--- a/code/modules/materials/materials/organic/leather.dm
+++ b/code/modules/materials/materials/organic/leather.dm
@@ -9,7 +9,7 @@
 	protectiveness = 3 // 13%
 	conductive = 0
 	integrity = 40
-	supply_conversion_value = 3
+	supply_conversion_value = 2
 
 /datum/material/leather/generate_recipes()
 	recipes = list(

--- a/code/modules/materials/materials/organic/resin.dm
+++ b/code/modules/materials/materials/organic/resin.dm
@@ -13,6 +13,7 @@
 	explosion_resistance = 60
 	radiation_resistance = 10
 	stack_type = /obj/item/stack/material/resin
+	supply_conversion_value = 2
 
 /datum/material/resin/can_open_material_door(var/mob/living/user)
 	var/mob/living/carbon/M = user

--- a/code/modules/materials/materials/organic/wood.dm
+++ b/code/modules/materials/materials/organic/wood.dm
@@ -19,6 +19,7 @@
 	destruction_desc = "splinters"
 	sheet_singular_name = "plank"
 	sheet_plural_name = "planks"
+	supply_conversion_value = 0.25
 
 /datum/material/wood/generate_recipes()
 	..()
@@ -144,7 +145,7 @@
 	sheet_plural_name = "logs"
 	sheet_collective_name = "pile"
 	pass_stack_colors = TRUE
-	supply_conversion_value = 1
+	supply_conversion_value = 0.5
 
 /datum/material/wood/log/generate_recipes()
 	recipes = list(
@@ -171,7 +172,7 @@
 	stack_type = /obj/item/stack/material/stick
 	sheet_collective_name = "pile"
 	pass_stack_colors = TRUE
-	supply_conversion_value = 1
+	supply_conversion_value = 0.05
 	sheet_singular_name = "stick"
 	sheet_plural_name = "sticks"
 

--- a/code/modules/materials/materials/other_vr.dm
+++ b/code/modules/materials/materials/other_vr.dm
@@ -10,6 +10,7 @@
 	hardness = 500
 	weight = 500
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0
 
 /datum/material/fluff //This is to allow for 2 handed weapons that don't want to have a prefix.
 	name = " "
@@ -20,6 +21,7 @@
 	hardness = 60
 	weight = 20 //Strong as iron.
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0
 
 /datum/material/darkglass
 	name = MAT_DARKGLASS
@@ -28,6 +30,7 @@
 	table_icon_base = MAT_DARKGLASS
 	icon_colour = "#FFFFFF"
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0
 
 /datum/material/fancyblack
 	name = MAT_FANCYBLACK
@@ -36,3 +39,4 @@
 	table_icon_base = MAT_FANCYBLACK
 	icon_colour = "#FFFFFF"
 	wiki_flag = WIKI_SPOILER
+	supply_conversion_value = 0

--- a/code/modules/materials/materials/plastic.dm
+++ b/code/modules/materials/materials/plastic.dm
@@ -74,6 +74,7 @@
 	destruction_desc = "crumples"
 	radiation_resistance = 1
 	pass_stack_colors = TRUE
+	supply_conversion_value = 0.05
 
 /datum/material/cardboard/generate_recipes()
 	..()
@@ -97,9 +98,9 @@
 	)
 
 /datum/material/toy_foam
-	name = "foam"
-	display_name = "foam"
-	use_name = "foam"
+	name = MAT_FOAM
+	display_name = MAT_FOAM
+	use_name = MAT_FOAM
 	flags = MATERIAL_PADDING
 	ignition_point = T0C+232
 	melting_point = T0C+300
@@ -109,3 +110,4 @@
 	protectiveness = 0 // 0%
 	conductive = 0
 	can_sharpen = FALSE
+	supply_conversion_value = 0

--- a/code/modules/materials/materials/plastic.dm
+++ b/code/modules/materials/materials/plastic.dm
@@ -11,6 +11,7 @@
 	conductive = 0
 	conductivity = 2 // For the sake of material armor diversity, we're gonna pretend this plastic is a good insulator.
 	melting_point = T0C+371 //assuming heat resistant plastic
+	supply_conversion_value = 0.5
 
 /datum/material/plastic/generate_recipes()
 	..()

--- a/code/modules/materials/materials/snow.dm
+++ b/code/modules/materials/materials/snow.dm
@@ -14,6 +14,7 @@
 	sheet_singular_name = "pile"
 	sheet_plural_name = "pile" //Just a bigger pile
 	radiation_resistance = 1
+	supply_conversion_value = 0
 
 /datum/material/snow/generate_recipes()
 	recipes = list(

--- a/code/modules/materials/materials/snow.dm
+++ b/code/modules/materials/materials/snow.dm
@@ -41,6 +41,7 @@
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
 	radiation_resistance = 1
+	supply_conversion_value = 0
 
 /datum/material/snowbrick/generate_recipes()
 	recipes = list(

--- a/code/modules/materials/materials/stone.dm
+++ b/code/modules/materials/materials/stone.dm
@@ -14,6 +14,7 @@
 	door_icon_base = "stone"
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
+	supply_conversion_value = 0.5
 
 /datum/material/stone/generate_recipes()
 	..()
@@ -45,6 +46,7 @@
 	supply_conversion_value = 2
 	sheet_singular_name = "piece"
 	sheet_plural_name = "pieces"
+	supply_conversion_value = 0.1
 
 /datum/material/stone/flint/generate_recipes()
 	return
@@ -61,6 +63,7 @@
 	weight = 27
 	hardness = 60
 	var/image/texture
+	supply_conversion_value = 0.1
 
 /datum/material/stone/concrete/generate_recipes()
 	..()

--- a/code/modules/materials/materials/supermatter.dm
+++ b/code/modules/materials/materials/supermatter.dm
@@ -15,6 +15,7 @@
 	sheet_plural_name = "crystals"
 	is_fusion_fuel = 1
 	flags = MATERIAL_UNMELTABLE
+	supply_conversion_value = 30
 
 /datum/material/supermatter/generate_recipes()
 	recipes = list(

--- a/code/modules/materials/sheets/organic/animal_products.dm
+++ b/code/modules/materials/sheets/organic/animal_products.dm
@@ -40,7 +40,7 @@
 	stack_type = /obj/item/stack/material/fur
 	sheet_collective_name = "pile"
 	pass_stack_colors = TRUE
-	supply_conversion_value = 1
+	supply_conversion_value = 0.5
 	sheet_singular_name = "bundle"
 	sheet_plural_name = "bundles"
 	ignition_point = T0C+232

--- a/code/modules/unit_tests/material_tests.dm
+++ b/code/modules/unit_tests/material_tests.dm
@@ -63,8 +63,8 @@
 		var/datum/material/mat = value
 		if(!mat)
 			continue // how did we get here?
-		if(!mat.supply_conversion_value)
-			failures[name] = mat.type
+		if(isnull(mat.supply_conversion_value))
+			failures += mat.type
 
 	if(length(failures))
 		TEST_FAIL("[length(failures)] material\s had missing supply conversion values: [english_list(failures)].")

--- a/code/modules/unit_tests/material_tests.dm
+++ b/code/modules/unit_tests/material_tests.dm
@@ -54,3 +54,17 @@
 
 	if(failed)
 		TEST_FAIL("materials missing autolathe print recipies.")
+
+/datum/unit_test/materials_shall_have_sell_prices
+
+/datum/unit_test/materials_shall_have_sell_prices/Run()
+	var/list/failures = list()
+	for(var/name, value in GLOB.name_to_material)
+		var/datum/material/mat = value
+		if(!mat)
+			continue // how did we get here?
+		if(!mat.supply_conversion_value)
+			failures[name] = mat.type
+
+	if(length(failures))
+		TEST_FAIL("[length(failures)] material\s had missing supply conversion values: [english_list(failures)].")

--- a/code/modules/vore/smoleworld/smoleworld_vr.dm
+++ b/code/modules/vore/smoleworld/smoleworld_vr.dm
@@ -73,6 +73,7 @@
 	destruction_desc = "smashed"
 	sheet_singular_name = "bag"
 	sheet_plural_name = "bags"
+	supply_conversion_value = 1 // The value of smollbricks are only going up! Buy now! Fill your house! THE PLASTIC BRICKS ARE WORTH YOUR CHILD'S COLLEGE MONEY!
 
 //the actual materials
 


### PR DESCRIPTION

<img width="494" height="724" alt="pointsink" src="https://github.com/user-attachments/assets/ad3a28f0-ba1b-4ac5-8828-d6dbeb7d3bb1" />


## About The Pull Request
I was requested to upport this. I was concerned about mining gameplay, but mining can also mine whatever they want with this and sell it to buy what the station is asking for without being screwed over by mining ore rng. Adds supply packs for all major materials at 50 sheet stacks for an almost price-gouging price to avoid invalidating mining.

## Changelog
Tweaks many material prices
Adds material prices to mats missing them
Adds unit test to enforce material prices
Fixed a bug with non-material stacks runtiming the supply shuttle when sold.

:cl: Will
add: Cargo can now order most materials at a markup and only in full stacks
balance: Many material stacks have had their sell prices changed
fix: Attempting to sell non-material stacks on the supply shuttle no longer runtime
/:cl:

