### PR TITLE
Gripper fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -108,11 +108,11 @@ avoid code duplication. This includes items that may sometimes act as a standard
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
 /obj/item/proc/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!force || (flags & NOBLUDGEON))
-		return NONE
+		return ITEM_INTERACT_FAILURE
 	if(M == user && user.a_intent != I_HURT)
-		return NONE
+		return ITEM_INTERACT_FAILURE
 	if(M.is_incorporeal()) // No attacking phased entities :)
-		return NONE
+		return ITEM_INTERACT_FAILURE
 
 	/////////////////////////
 	M.lastattacker = user

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -106,16 +106,15 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
-/obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone, var/attack_modifier)
+/obj/item/proc/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!force || (flags & NOBLUDGEON))
-		return 0
+		return NONE
 	if(M == user && user.a_intent != I_HURT)
-		return 0
+		return NONE
 	if(M.is_incorporeal()) // No attacking phased entities :)
-		return 0
+		return NONE
 
 	/////////////////////////
-	user.lastattacked = M
 	M.lastattacker = user
 
 	if(!no_attack_log)
@@ -129,7 +128,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(hit_zone)
 		apply_hit_effect(M, user, hit_zone, attack_modifier)
 
-	return 1
+	return ITEM_INTERACT_SUCCESS
 
 //Called when a weapon is used to make a successful melee attack on a mob. Returns the blocked result
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone, var/attack_modifier)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -138,8 +138,8 @@
 					qdel(src) // Drop TK
 	return
 
-/obj/item/tk_grab/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
-	return
+/obj/item/tk_grab/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	return NONE
 
 
 /obj/item/tk_grab/proc/focus_object(var/obj/target, var/mob/living/user)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -139,7 +139,7 @@
 	return
 
 /obj/item/tk_grab/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return NONE
+	return ITEM_INTERACT_FAILURE
 
 
 /obj/item/tk_grab/proc/focus_object(var/obj/target, var/mob/living/user)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -38,7 +38,7 @@
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')
 	playsound(src, spooky, 50, 1)
 
-	return 1
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/melee/cultblade/pickup(mob/living/user as mob)
 	if(!iscultist(user) && !istype(user, /mob/living/simple_mob/construct))

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -15,7 +15,7 @@
 /obj/item/melee/cultblade/cultify()
 	return
 
-/obj/item/melee/cultblade/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/melee/cultblade/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(iscultist(user) && !istype(user, /mob/living/simple_mob/construct))
 		return ..()
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -299,17 +299,18 @@ ADMIN_VERB(check_words, R_ADMIN|R_EVENT, "Check Rune Words", "Check the rune-wor
 	if(isobserver(M))
 		var/mob/observer/dead/D = M
 		D.manifest(user)
-		return
+		return ITEM_INTERACT_SUCCESS
 	if(!istype(M))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(!iscultist(user))
 		return ..()
 	if(iscultist(M))
-		return
+		return ITEM_INTERACT_FAILURE
 	M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit
 	for(var/mob/O in viewers(M, null))
 		O.show_message(span_warning("\The [user] beats \the [M] with \the [src]!"), 1)
 	to_chat(M, span_danger("You feel searing heat inside!"))
+	return ITEM_INTERACT_SUCCESS
 
 
 /obj/item/book/tome/attack_self(mob/living/user)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -293,7 +293,7 @@ ADMIN_VERB(check_words, R_ADMIN|R_EVENT, "Check Rune Words", "Check the rune-wor
 	for(var/V in GLOB.cultwords)
 		words[GLOB.cultwords[V]] = V
 
-/obj/item/book/tome/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/book/tome/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	add_attack_logs(user,M,"Hit with [name]")
 
 	if(isobserver(M))

--- a/code/game/gamemodes/cult/soulstone.dm
+++ b/code/game/gamemodes/cult/soulstone.dm
@@ -18,7 +18,7 @@
 
 //////////////////////////////Capturing////////////////////////////////////////////////////////
 
-/obj/item/soulstone/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/soulstone/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!ishuman(M))//If target is not a human.
 		return ..()
 	if(istype(M, /mob/living/carbon/human/dummy))

--- a/code/game/gamemodes/cult/soulstone.dm
+++ b/code/game/gamemodes/cult/soulstone.dm
@@ -22,18 +22,18 @@
 	if(!ishuman(M))//If target is not a human.
 		return ..()
 	if(istype(M, /mob/living/carbon/human/dummy))
-		return..()
+		return ..()
 	if(jobban_isbanned(M, JOB_CULTIST))
 		to_chat(user, span_warning("This person's soul is too corrupt and cannot be captured!"))
-		return..()
+		return ..()
 
 	if(M.has_brain_worms()) //Borer stuff - RR
 		to_chat(user, span_warning("This being is corrupted by an alien intelligence and cannot be soul trapped."))
-		return..()
+		return ..()
 
 	add_attack_logs(user,M,"Soulstone'd with [src.name]")
 	transfer_soul("VICTIM", M, user)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 
 ///////////////////Options for using captured souls///////////////////////////////////////

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -46,11 +46,11 @@
 		return
 
 
-/obj/item/paper/talisman/attack(mob/living/carbon/T as mob, mob/living/user as mob)
+/obj/item/paper/talisman/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(iscultist(user))
 		if(imbue == "runestun")
 			user.take_organ_damage(5, 0)
-			call(/obj/effect/rune/proc/runestun)(T)
+			call(/obj/effect/rune/proc/runestun)(M)
 			qdel(src)
 		else
 			..()   ///If its some other talisman, use the generic attack code, is this supposed to work this way?

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -52,6 +52,7 @@
 			user.take_organ_damage(5, 0)
 			call(/obj/effect/rune/proc/runestun)(M)
 			qdel(src)
+			return ITEM_INTERACT_SUCCESS
 		else
 			..()   ///If its some other talisman, use the generic attack code, is this supposed to work this way?
 	else

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -23,7 +23,7 @@
 	desc = "Directions for use: Requires two people, one to pull each end."
 	var/cracked = 0
 
-/obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
+/obj/item/toy/xmas_cracker/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if( !cracked && (issilicon(target) || (ishuman(target) && !target.get_active_hand())) && target.stat == CONSCIOUS)
 		target.visible_message(span_notice("[user] and [target] pop \an [src]! *pop*"), span_notice("You pull \an [src] with [target]! *pop*"), span_notice("You hear a *pop*."))
 		var/obj/item/paper/Joke = new /obj/item/paper(user.loc)

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -47,7 +47,7 @@
 		other_half.icon_state = "cracker2"
 		target.put_in_active_hand(other_half)
 		playsound(src, 'sound/effects/snap.ogg', 50, 1)
-		return 1
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 /obj/item/clothing/head/festive

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -33,8 +33,9 @@
 		return attack_hand(user) //Process as if we're a normal person touching the object.
 	return ..() //Otherwise, treat this as an AI click like usual.
 
-/atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
+/atom/movable/MouseDrop_T(atom/dropping, mob/user, src_location, over_location, src_control, over_control, params)
 	. = ..()
+	var/mob/living/M = dropping
 	if(can_buckle && istype(M))
 		if(user_buckle_mob(M, user))
 			return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -715,11 +715,11 @@ GLOBAL_LIST_INIT(slot_flags_enumeration, list(
 			if(protection && (protection.body_parts_covered & EYES))
 				// you can't stab someone in the eyes wearing a mask!
 				to_chat(user, span_warning("You're going to need to remove the eye covering first."))
-				return
+				return ITEM_INTERACT_FAILURE
 
 	if(!M.has_eyes())
 		to_chat(user, span_warning("You cannot locate any eyes on [M]!"))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	//this should absolutely trigger even if not aim-impaired in some way
 	var/hit_zone = get_zone_with_miss_chance(U.zone_sel.selecting, M, U.get_accuracy_penalty(U))
@@ -727,7 +727,7 @@ GLOBAL_LIST_INIT(slot_flags_enumeration, list(
 		U.do_attack_animation(M)
 		playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message(span_danger("\The [U] attempts to stab \the [M] in the eyes, but misses!"))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	add_attack_logs(user,M,"Attack eyes with [name]")
 
@@ -780,7 +780,7 @@ GLOBAL_LIST_INIT(slot_flags_enumeration, list(
 	else
 		M.take_organ_damage(7)
 	M.eye_blurry += rand(3,4)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/reveal_blood()
 	if(was_bloodied && !fluorescent)

--- a/code/game/objects/items/bells.dm
+++ b/code/game/objects/items/bells.dm
@@ -18,7 +18,7 @@
 	if(broken)
 		. += span_bold("It looks damaged, the ringer is stuck firmly inside.")
 
-/obj/item/deskbell/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/deskbell/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!broken)
 		playsound(src, 'sound/effects/deskbell.ogg', 50, 1)
 	..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -144,6 +144,7 @@
 			if(uses <= 0)
 				to_chat(user, span_warning("You ate your crayon!"))
 				qdel(src)
+		return ITEM_INTERACT_SUCCESS
 	else
 		..()
 
@@ -244,5 +245,6 @@
 			if(uses <= 0)
 				to_chat(user, span_warning("You ate the marker!"))
 				qdel(src)
+		return ITEM_INTERACT_SUCCESS
 	else
 		..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -130,7 +130,7 @@
 					qdel(src)
 	return
 
-/obj/item/pen/crayon/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/pen/crayon/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M == user)
 		to_chat(user, "You take a bite of the crayon and swallow it.")
 		user.nutrition += 1
@@ -230,7 +230,7 @@
 		shadeColour = new_colour
 	return
 
-/obj/item/pen/crayon/marker/attack(mob/living/M, mob/living/user)
+/obj/item/pen/crayon/marker/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M == user)
 		to_chat(user, "You take a bite of the marker and swallow it.")
 		user.nutrition += 1

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -13,11 +13,12 @@
 
 	var/mob/living/silicon/ai/carded_ai
 
-/obj/item/aicard/attack(mob/living/silicon/decoy/M as mob, mob/user as mob)
-	if (!istype (M, /mob/living/silicon/decoy))
+/obj/item/aicard/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/silicon/decoy))
 		return ..()
 	else
-		M.death()
+		var/mob/living/silicon/decoy/decoy = M
+		decoy.death()
 		to_chat(user, span_infoplain(span_bold("ERROR ERROR ERROR")))
 
 /obj/item/aicard/attack_self(mob/user)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -20,6 +20,7 @@
 		var/mob/living/silicon/decoy/decoy = M
 		decoy.death()
 		to_chat(user, span_infoplain(span_bold("ERROR ERROR ERROR")))
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/aicard/attack_self(mob/user)
 	. = ..(user)

--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -12,7 +12,7 @@
 	drop_sound = 'sound/items/drop/device.ogg'
 	flags = NOBLUDGEON
 
-/obj/item/bodysnatcher/attack(mob/living/M, mob/living/user)
+/obj/item/bodysnatcher/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(ishuman(M) || issilicon(M)) //Allows body swapping with humans, synths, and pAI's/borgs since they all have a mind.
 		if(user == M)

--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -17,25 +17,25 @@
 	if(ishuman(M) || issilicon(M)) //Allows body swapping with humans, synths, and pAI's/borgs since they all have a mind.
 		if(user == M)
 			to_chat(user,span_warning("A message pops up on the LED display, informing you that the mind transfer to yourself was successful... Wait, did that even do anything?"))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		if(!M.mind) //Do they have a mind?
 			to_chat(user,span_warning("A warning pops up on the device, informing you that [M] appears braindead."))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		if(!M.allow_mind_transfer)
 			to_chat(user,span_danger("The target's mind is too complex to be affected!"))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.resleeve_lock && user.ckey != H.resleeve_lock)
 				to_chat(src, span_danger("[H] cannot be impersonated!"))
-				return
+				return ITEM_INTERACT_FAILURE
 
 		if(M.stat == DEAD) //Are they dead?
 			to_chat(user,span_warning("A warning pops up on the device, informing you that [M] is dead, and, as such, the mind transfer can not be done."))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		var/choice = tgui_alert(user,"This will swap your mind with the target's mind. This will result in them controlling your body, and you controlling their body. Continue?","Confirmation",list("Continue","Cancel"))
 		if(choice == "Continue" && user.get_active_hand() == src && user.Adjacent(M))
@@ -99,9 +99,12 @@
 						M.SetSleeping(10)
 						M.eye_blurry = 30
 						M.slurring = 50
+					return ITEM_INTERACT_SUCCESS
+				return ITEM_INTERACT_BLOCKING
 
 	else
 		to_chat(user,span_warning(" A warning pops up on the LED display on the side of the device, informing you that the target is not able to have their mind swapped with!"))
+		return ITEM_INTERACT_FAILURE
 
 /obj/item/bodysnatcher/attack_self(mob/user)
 	. = ..(user)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -318,15 +318,15 @@
 		return ..() //Do a regular attack. Harm intent shocking happens as a hit effect
 
 	if(can_use(user, H))
-		busy = 1
+		busy = TRUE
 		update_icon()
 
 		do_revive(H, user)
 
-		busy = 0
+		busy = FALSE
 		update_icon()
 
-	return 1
+	return ITEM_INTERACT_SUCCESS
 
 //Since harm-intent now skips the delay for deliberate placement, you have to be able to hit them in combat in order to shock people.
 /obj/item/shockpaddles/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -312,7 +312,7 @@
 /obj/item/shockpaddles/proc/checked_use(var/charge_amt)
 	return 0
 
-/obj/item/shockpaddles/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/shockpaddles/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/mob/living/carbon/human/H = M
 	if(!istype(H) || user.a_intent == I_HURT)
 		return ..() //Do a regular attack. Harm intent shocking happens as a hit effect

--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -219,7 +219,7 @@
 
 
 
-/obj/item/denecrotizer/attack(mob/living/simple_mob/target, mob/living/user)
+/obj/item/denecrotizer/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(check_target(target, user))
 		if(advanced)
 			ghostjoin_rez(target, user)

--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -225,6 +225,7 @@
 			ghostjoin_rez(target, user)
 		else
 			basic_rez(target, user)
+		return ITEM_INTERACT_SUCCESS
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/extrapolator.dm
+++ b/code/game/objects/items/devices/extrapolator.dm
@@ -93,7 +93,7 @@
 	// maximum_stealth = scanner.rating + 2
 	maximum_level = scanner.rating + 5
 
-/obj/item/extrapolator/attack(atom/AM, mob/living/user)
+/obj/item/extrapolator/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/extrapolator/afterattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/game/objects/items/devices/extrapolator.dm
+++ b/code/game/objects/items/devices/extrapolator.dm
@@ -94,7 +94,7 @@
 	maximum_level = scanner.rating + 5
 
 /obj/item/extrapolator/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/extrapolator/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -162,22 +162,23 @@
 //attack_as_weapon
 /obj/item/flash/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!user || !target || target.is_incorporeal())
-		return //sanity
+		return ITEM_INTERACT_FAILURE //sanity
 
 	add_attack_logs(user,target,"Flashed (attempt) with [src]")
 
 	user.setClickCooldown(user.get_attack_speed(src))
 	user.do_attack_animation(target)
 
-	if(!clown_check(user))	return
+	if(!clown_check(user))
+		return ITEM_INTERACT_FAILURE
 	if(broken)
 		to_chat(user, span_warning("\The [src] is broken."))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	flash_recharge()
 
 	if(!check_capacitor(user))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	playsound(src, 'sound/weapons/flash.ogg', 100, 1)
 
@@ -196,10 +197,10 @@
 			user.visible_message(span_notice("[user] overloads [target]'s sensors with the flash!"))
 		else
 			user.visible_message(span_disarm("[user] blinds [target] with the flash!"))
-		return
+		return ITEM_INTERACT_SUCCESS
 	//fail message
 	user.visible_message(span_notice("[user] fails to blind [target] with the flash!"))
-	return
+	return ITEM_INTERACT_FAILURE
 
 /// Sees if we can flash the target and if so, does the effects of it.
 /// Returns TRUE if the flash went through, FALSE otherwise.

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -160,7 +160,7 @@
 		return TRUE
 
 //attack_as_weapon
-/obj/item/flash/attack(mob/living/target, mob/living/user, var/target_zone)
+/obj/item/flash/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!user || !target || target.is_incorporeal())
 		return //sanity
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -121,7 +121,7 @@
 	user.update_mob_action_buttons()
 	return CAN_USE
 
-/obj/item/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/flashlight/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	add_fingerprint(user)
 	if(on && user.zone_sel.selecting == O_EYES)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -133,7 +133,7 @@
 			for(var/obj/item/clothing/C in list(H.head,H.wear_mask,H.glasses))
 				if(istype(C) && (C.body_parts_covered & EYES))
 					to_chat(user, span_warning("You're going to need to remove [C.name] first."))
-					return
+					return ITEM_INTERACT_FAILURE
 
 			var/obj/item/organ/vision
 			if(H.species.vision_organ)
@@ -143,14 +143,14 @@
 										span_notice("You direct [src] at [M]'s face."))
 				to_chat(user, span_warning("You can't find any [H.species.vision_organ ? H.species.vision_organ : "eyes"] on [H]!"))
 				user.setClickCooldown(user.get_attack_speed(src))
-				return
+				return ITEM_INTERACT_FAILURE
 
 			user.visible_message(span_infoplain(span_bold("\The [user]") + " directs [src] to [M]'s eyes."), \
 									span_notice("You direct [src] to [M]'s eyes."))
 			if(H != user)	//can't look into your own eyes buster
 				if(M.stat == DEAD || M.blinded)	//mob is dead or fully blind
 					to_chat(user, span_warning("\The [M]'s pupils do not react to the light!"))
-					return
+					return ITEM_INTERACT_SUCCESS
 				if(XRAY in M.mutations)
 					to_chat(user, span_notice("\The [M] pupils give an eerie glow!"))
 				if(vision.is_bruised())
@@ -171,6 +171,7 @@
 
 			user.setClickCooldown(user.get_attack_speed(src)) //can be used offensively
 			M.flash_eyes()
+			return ITEM_INTERACT_SUCCESS
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -57,7 +57,7 @@
 	..()
 
 //hit other people with it
-/obj/item/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/holowarrant/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	user.visible_message(span_notice("You show the warrant to [M]."), \
 			span_notice("[user] holds up a warrant projector and shows the contents to [M]."))
 	M.examinate(src)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -61,6 +61,7 @@
 	user.visible_message(span_notice("You show the warrant to [M]."), \
 			span_notice("[user] holds up a warrant projector and shows the contents to [M]."))
 	M.examinate(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/holowarrant/update_icon()
 	if(active)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -45,7 +45,7 @@
 /obj/item/laser_pointer/ultimate/Initialize(mapload)
 	. = ..(mapload, /obj/item/stock_parts/micro_laser/omni)
 
-/obj/item/laser_pointer/attack(mob/living/M, mob/user)
+/obj/item/laser_pointer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	laser_act(M, user)
 
 /obj/item/laser_pointer/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -47,6 +47,7 @@
 
 /obj/item/laser_pointer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	laser_act(M, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/laser_pointer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stock_parts/micro_laser))

--- a/code/game/objects/items/devices/scanners/halogen.dm
+++ b/code/game/objects/items/devices/scanners/halogen.dm
@@ -10,7 +10,7 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 
-/obj/item/halogen_counter/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/halogen_counter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!iscarbon(M))
 		to_chat(user, span_warning("This device can only scan organic beings!"))
 		return

--- a/code/game/objects/items/devices/scanners/halogen.dm
+++ b/code/game/objects/items/devices/scanners/halogen.dm
@@ -13,10 +13,10 @@
 /obj/item/halogen_counter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!iscarbon(M))
 		to_chat(user, span_warning("This device can only scan organic beings!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	user.visible_message(span_warning("\The [user] has analyzed [M]'s radiation levels!"), span_notice("Analyzing Results for [M]:"))
 	if(M.radiation)
 		to_chat(user, span_notice("Radiation Level: [M.radiation]"))
 	else
 		to_chat(user, span_notice("No radiation detected."))
-	return
+	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -38,7 +38,7 @@
 	scan_mob(M, user) //default surgery behaviour is just to scan as usual
 	return 1
 
-/obj/item/healthanalyzer/attack(mob/living/M, mob/living/user)
+/obj/item/healthanalyzer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	scan_mob(M, user)
 
 /obj/item/healthanalyzer/proc/scan_mob(mob/living/M, mob/living/user)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -40,6 +40,7 @@
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	scan_mob(M, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/healthanalyzer/proc/scan_mob(mob/living/M, mob/living/user)
 	var/dat = ""

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -72,7 +72,7 @@ GLOBAL_DATUM(sleevemate_mob, /mob/living/carbon/human/dummy/mannequin)
 
 
 
-/obj/item/sleevemate/attack(mob/living/M, mob/living/user)
+/obj/item/sleevemate/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	// Gather potential subtargets
 	var/list/choices = list(M)
 	if(istype(M))

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -83,7 +83,7 @@ GLOBAL_DATUM(sleevemate_mob, /mob/living/carbon/human/dummy/mannequin)
 	if(choices.len > 1)
 		var/mob/living/new_M = tgui_input_list(user, "Ambiguous target. Please validate target:", "Target Validation", choices, M)
 		if(!new_M || !M.Adjacent(user))
-			return
+			return ITEM_INTERACT_FAILURE
 		M = new_M
 
 	if(isrobot(M))
@@ -91,12 +91,14 @@ GLOBAL_DATUM(sleevemate_mob, /mob/living/carbon/human/dummy/mannequin)
 		var/obj/item/dogborg/sleeper/S = locate() in R.module.modules
 		if(S && S.patient)
 			scan_mob(S.patient, user)
-			return
+			return ITEM_INTERACT_SUCCESS
 
 	if(ishuman(M))
 		scan_mob(M, user)
+		return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user,span_warning("Not a compatible subject to work with!"))
+		return ITEM_INTERACT_FAILURE
 
 /obj/item/sleevemate/attack_self(mob/living/user)
 	. = ..(user)

--- a/code/game/objects/items/devices/scanners/slime.dm
+++ b/code/game/objects/items/devices/scanners/slime.dm
@@ -14,7 +14,7 @@
 /obj/item/slime_scanner/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
 		to_chat(user, span_infoplain(span_bold("This device can only scan lab-grown slimes!")))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/mob/living/simple_mob/slime/xenobio/S = M
 	user.show_message("Slime scan results:<br>[S.slime_color] [S.is_adult ? "adult" : "baby"] slime<br>Health: [S.health]<br>Mutation Probability: [S.mutation_chance]")
 
@@ -42,3 +42,4 @@
 		user.show_message("Subject is friendly to other slime colors.")
 
 	user.show_message("Growth progress: [S.amount_grown]/10")
+	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/devices/scanners/slime.dm
+++ b/code/game/objects/items/devices/scanners/slime.dm
@@ -11,7 +11,7 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 
-/obj/item/slime_scanner/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/slime_scanner/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
 		to_chat(user, span_infoplain(span_bold("This device can only scan lab-grown slimes!")))
 		return

--- a/code/game/objects/items/leash.dm
+++ b/code/game/objects/items/leash.dm
@@ -72,17 +72,18 @@
 		// If they re-click, remove the leash
 		if (C == leash_pet && user == leash_master)
 			unleash()
+			return ITEM_INTERACT_SUCCESS
 		else
 			// Dear god not the double leashing
 			to_chat(user, span_notice("[C] has already been leashed."))
-		return
+			return ITEM_INTERACT_FAILURE
 
 	if(!C.mind)
-		return
+		return ITEM_INTERACT_FAILURE
 
-	if (C == user)
+	if(C == user)
 		to_chat(user, span_notice("You cannot leash yourself!"))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	var/leashtime = 35
 
@@ -90,16 +91,16 @@
 		var/mob/living/carbon/human/humantarget = C
 		if (!is_wearing_collar(humantarget))
 			to_chat(user, span_notice("[humantarget] needs a collar before you can attach a leash to it."))
-			return
+			return ITEM_INTERACT_FAILURE
 		if(humantarget.handcuffed)
 			leashtime = 5
 
 	C.visible_message(span_danger("\The [user] is attempting to put the leash on \the [C]!"), span_danger("\The [user] tries to put a leash on you"))
 	add_attack_logs(user,C,"Leashed (attempt)")
 	if(!do_after(user, leashtime, C)) //do_mob adds a progress bar, but then we also check to see if they have a collar
-		return
+		return ITEM_INTERACT_FAILURE
 	if(tgui_alert(C, "Would you like to be leased by [user]? You can OOC escape to escape", "Become Leashed",list("No","Yes")) != "Yes")
-		return
+		return ITEM_INTERACT_FAILURE
 
 	C.visible_message(span_danger("\The [user] puts a leash on \the [C]!"), span_danger("The leash clicks onto your collar!"))
 
@@ -114,6 +115,7 @@
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_master_move))
 
 	START_PROCESSING(SSobj, src)
+	return ITEM_INTERACT_SUCCESS
 
 //Called when the leash is used in hand
 //Tugs the pet closer

--- a/code/game/objects/items/leash.dm
+++ b/code/game/objects/items/leash.dm
@@ -65,7 +65,7 @@
 		return
 
 //Called when someone is clicked with the leash
-/obj/item/leash/attack(mob/living/C, mob/living/user, attackchain_flags, damage_multiplier) //C is the target, user is the one with the leash
+/obj/item/leash/attack(mob/living/C, mob/living/user, target_zone, attack_modifier) //C is the target, user is the one with the leash
 	var/mob/living/leash_pet = leash_pet_ref?.resolve()
 	var/mob/living/leash_master = leash_master_ref?.resolve()
 	if(C.alerts && C.alerts["leashed"]) //If the pet is already leashed, do not leash them. For the love of god.

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -15,8 +15,8 @@
 
 	var/upgrade_to	// The type path this stack can be upgraded to.
 
-/obj/item/stack/medical/attack(mob/living/carbon/M as mob, mob/user as mob)
-	if (!istype(M))
+/obj/item/stack/medical/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!iscarbon(M))
 		balloon_alert(user, "\the [src] cannot be applied to [M]!")
 		return 1
 
@@ -89,7 +89,7 @@
 
 	upgrade_to = /obj/item/stack/medical/bruise_pack
 
-/obj/item/stack/medical/crude_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/crude_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
@@ -157,7 +157,7 @@
 
 	upgrade_to = /obj/item/stack/medical/advanced/bruise_pack
 
-/obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/bruise_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
@@ -230,7 +230,7 @@
 	drop_sound = 'sound/items/drop/herb.ogg'
 	pickup_sound = 'sound/items/pickup/herb.ogg'
 
-/obj/item/stack/medical/ointment/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/ointment/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
@@ -274,7 +274,7 @@
 	heal_brute = 7
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 
-/obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
@@ -343,7 +343,7 @@
 	heal_burn = 7
 	apply_sounds = list('sound/effects/ointment.ogg')
 
-/obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/stack/medical/advanced/ointment/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
@@ -386,7 +386,7 @@
 
 	var/list/splintable_organs = list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO)	//List of organs you can splint, natch.
 
-/obj/item/stack/medical/splint/attack(mob/living/carbon/M as mob, mob/living/user as mob)
+/obj/item/stack/medical/splint/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -18,55 +18,56 @@
 /obj/item/stack/medical/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!iscarbon(M))
 		balloon_alert(user, "\the [src] cannot be applied to [M]!")
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if (!user.IsAdvancedToolUser())
 		balloon_alert(user, "you don't have the dexterity to do this!")
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	var/available = get_amount()
 	if(!available)
 		balloon_alert(user, "not enough [uses_charge ? "charge" : "items"] left to use that!")
-		return 1
+		return ITEM_INTERACT_FAILURE
 
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(!affecting)
 			balloon_alert(user, "no body part there to work on!")
-			return 1
+			return ITEM_INTERACT_FAILURE
 
 		if(affecting.organ_tag == BP_HEAD)
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
 				balloon_alert(user, "you can't apply [src] through [H.head]!")
-				return 1
+				return ITEM_INTERACT_FAILURE
 		else
 			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
 				balloon_alert(user, "you can't apply [src] through [H.wear_suit]!")
-				return 1
+				return ITEM_INTERACT_FAILURE
 
 		if(affecting.robotic == ORGAN_ROBOT)
 			balloon_alert(user, "this isn't useful at all on a robotic limb.")
-			return 1
+			return ITEM_INTERACT_FAILURE
 
 		if(affecting.robotic >= ORGAN_LIFELIKE)
 			balloon_alert(user, "you apply the [src], but it seems to have no effect...")
 			use(1)
-			return 1
+			return ITEM_INTERACT_FAILURE
 
 		H.UpdateDamageIcon()
 
 	else
-
 		M.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
 		user.balloon_alert_visible( \
 			"[M] has been applied with [src] by [user].", \
 			"you apply \the [src] to [M]." \
 		)
 		use(1)
+		return ITEM_INTERACT_SUCCESS
 
 	M.updatehealth()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/medical/proc/upgrade_stack(var/upgrade_amount)
 	. = FALSE
@@ -91,7 +92,7 @@
 
 /obj/item/stack/medical/crude_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -103,7 +104,7 @@
 
 		if(affecting.is_bandaged())
 			balloon_alert(user, "[M]'s [affecting.name] is already bandaged.")
-			return 1
+			return ITEM_INTERACT_FAILURE
 		else
 			var/available = get_amount()
 			user.balloon_alert_visible("\the [user] starts bandaging [M]'s [affecting.name].", \
@@ -122,7 +123,7 @@
 
 				if(affecting.is_bandaged()) // We do a second check after the delay, in case it was bandaged after the first check.
 					balloon_alert(user, "[M]'s [affecting.name] is already bandaged.")
-					return 1
+					return ITEM_INTERACT_FAILURE
 
 				if(used >= available)
 					balloon_alert(user, "you run out of [src]!")
@@ -144,6 +145,7 @@
 				else
 					balloon_alert(user, "\the [src] is used up, but there are more wounds to treat on \the [affecting.name].")
 			use(used)
+			return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/medical/bruise_pack
 	name = "roll of gauze"
@@ -159,7 +161,7 @@
 
 /obj/item/stack/medical/bruise_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -171,7 +173,7 @@
 
 		if(affecting.is_bandaged())
 			balloon_alert(user, "[M]'s [affecting.name] is already bandaged.")
-			return 1
+			return ITEM_INTERACT_FAILURE
 		else
 			var/available = get_amount()
 			user.balloon_alert_visible("\the [user] starts treating [M]'s [affecting.name].", \
@@ -217,6 +219,7 @@
 				else
 					user.balloon_alert(user, "\the [src] is used up, but there are more wounds to treat on \the [affecting.name].")
 			use(used)
+			return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
@@ -232,7 +235,7 @@
 
 /obj/item/stack/medical/ointment/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -244,21 +247,22 @@
 
 		if(affecting.is_salved())
 			user.balloon_alert(user, "the wounds on [M]'s [affecting.name] have already been salved.")
-			return 1
+			return ITEM_INTERACT_FAILURE
 		else
 			user.balloon_alert_visible("\the [user] starts salving wounds on [M]'s [affecting.name].", \
 										"salving the wounds on [M]'s [affecting.name]." )
 			if(!do_after(user, 1 SECOND, affecting))
 				user.balloon_alert(user, "stand still to salve wounds.")
-				return 1
+				return ITEM_INTERACT_FAILURE
 			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
 				user.balloon_alert(user, "[M]'s [affecting.name] have already been salved.")
-				return 1
+				return ITEM_INTERACT_FAILURE
 			user.balloon_alert_visible("[user] salved wounds on [M]'s [affecting.name].", \
 										"salved wounds on [M]'s [affecting.name]." )
 			use(1)
 			affecting.salve()
 			playsound(src, pick(apply_sounds), 25)
+			return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/medical/ointment/simple
 	name = "ointment paste"
@@ -275,10 +279,10 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(..())
-		return 1
+	if(..() == ITEM_INTERACT_FAILURE)
+		return ITEM_INTERACT_FAILURE
 
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
@@ -334,6 +338,8 @@
 				else
 					balloon_alert(user, "\the [src] is used up, but there are more wounds to treat on \the [affecting.name].")
 			use(used)
+			return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -344,10 +350,10 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 /obj/item/stack/medical/advanced/ointment/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(..())
-		return 1
+	if(..() == ITEM_INTERACT_FAILURE)
+		return ITEM_INTERACT_FAILURE
 
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
@@ -356,16 +362,16 @@
 
 		if(affecting.is_salved())
 			user.balloon_alert(user, "[M]'s [affecting.name] has already been salved.")
-			return 1
+			return ITEM_INTERACT_FAILURE
 		else
 			user.balloon_alert_visible("\the [user] starts salving wounds on [M]'s [affecting.name].", \
 										"salving the wounds on [M]'s [affecting.name]." )
 			if(!do_after(user, 1 SECOND, affecting))
 				user.balloon_alert(user, "stand still to salve wounds.")
-				return 1
+				return ITEM_INTERACT_FAILURE
 			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
 				user.balloon_alert(user, "[M]'s [affecting.name] have already been salved.")
-				return 1
+				return ITEM_INTERACT_FAILURE
 			user.balloon_alert_visible("[user] covers wounds on [M]'s [affecting.name] with regenerative membrane.", \
 									"covered wounds on [M]'s [affecting.name] with regenerative membrane." )
 			affecting.heal_damage(0,heal_burn)
@@ -373,6 +379,8 @@
 			affecting.salve()
 			playsound(src, pick(apply_sounds), 25)
 			update_icon()
+			return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/stack/medical/splint
 	name = "medical splints"
@@ -387,34 +395,34 @@
 	var/list/splintable_organs = list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO)	//List of organs you can splint, natch.
 
 /obj/item/stack/medical/splint/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(..())
-		return 1
+	if(..() == ITEM_INTERACT_FAILURE)
+		return ITEM_INTERACT_FAILURE
 
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 		var/limb = affecting.name
 		if(!(affecting.organ_tag in splintable_organs))
 			balloon_alert(user, "you can't use \the [src] to apply a splint there!")
-			return
+			return ITEM_INTERACT_FAILURE
 		if(affecting.splinted)
 			balloon_alert(user, "[M]'s [limb] is already splinted!")
-			return
+			return ITEM_INTERACT_FAILURE
 		if (M != user)
 			user.balloon_alert_visible("[user] starts to apply \the [src] to [M]'s [limb].", "applying \the [src] to [M]'s [limb].", "You hear something being wrapped.")
 		else
 			if(( !user.hand && (affecting.organ_tag in list(BP_R_ARM, BP_R_HAND)) || \
 				user.hand && (affecting.organ_tag in list(BP_L_ARM, BP_L_HAND)) ))
 				balloon_alert(user, "you can't apply a splint to the arm you're using!")
-				return
+				return ITEM_INTERACT_FAILURE
 			user.balloon_alert_visible("[user] starts to apply \the [src] to their [limb].", "applying \the [src] to your [limb].", "You hear something being wrapped.")
 		if(do_after(user, 5 SECONDS, affecting))
 			if(affecting.splinted)
 				balloon_alert(user, "[M]'s [limb] is already splinted!")
-				return
+				return ITEM_INTERACT_FAILURE
 			if(M == user && prob(75))
 				user.balloon_alert_visible("\the [user] fumbles [src].", "fumbling [src].", "You hear something being wrapped.")
-				return
+				return ITEM_INTERACT_FAILURE
 			if(ishuman(user))
 				var/obj/item/stack/medical/splint/S = split(1)
 				if(S)
@@ -424,7 +432,7 @@
 							user.balloon_alert_visible("\the [user] finishes applying [src] to [M]'s [limb].", "finished applying \the [src] to [M]'s [limb].", "You hear something being wrapped.")
 						else
 							user.balloon_alert_visible("\the [user] successfully applies [src] to their [limb].", "successfully applied \the [src] to your [limb].", "You hear something being wrapped.")
-						return
+						return ITEM_INTERACT_FAILURE
 					S.dropInto(src.loc) //didn't get applied, so just drop it
 			if(isrobot(user))
 				var/obj/item/stack/medical/splint/B = src
@@ -433,9 +441,9 @@
 						B.forceMove(affecting)
 						user.balloon_alert_visible("\the [user] finishes applying [src] to [M]'s [limb].", "finish applying \the [src] to [M]'s [limb].", "You hear something being wrapped.")
 						B.use(1)
-						return
+						return ITEM_INTERACT_SUCCESS
 			user.balloon_alert_visible("\the [user] fails to apply [src].", "failed to apply [src].", "You hear something being wrapped.")
-		return
+		return ITEM_INTERACT_FAILURE
 
 
 /obj/item/stack/medical/splint/ghetto

--- a/code/game/objects/items/stacks/medical_vr.dm
+++ b/code/game/objects/items/stacks/medical_vr.dm
@@ -32,12 +32,13 @@
 	amount = 5
 	max_amount = 5
 
-/obj/item/stack/medical/advanced/clotting/attack(mob/living/carbon/human/H, var/mob/user)
+/obj/item/stack/medical/advanced/clotting/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(..())
 		return 1
 
-	if(!istype(H))
+	if(!ishuman(M))
 		return
+	var/mob/living/carbon/human/H = M
 
 	var/clotted = 0
 	var/too_far_gone = 0

--- a/code/game/objects/items/stacks/medical_vr.dm
+++ b/code/game/objects/items/stacks/medical_vr.dm
@@ -33,11 +33,11 @@
 	max_amount = 5
 
 /obj/item/stack/medical/advanced/clotting/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(..())
-		return 1
+	if(..() == ITEM_INTERACT_FAILURE)
+		return ITEM_INTERACT_FAILURE
 
 	if(!ishuman(M))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/mob/living/carbon/human/H = M
 
 	var/clotted = 0
@@ -69,6 +69,7 @@
 	use(1)
 	playsound(src, pick(apply_sounds), 25)
 	update_icon()
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/stack/medical/advanced/clotting/update_icon()
 	icon_state = "[initial(icon_state)]_[amount]"

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -10,7 +10,7 @@
 	w_class = ITEMSIZE_SMALL
 	no_variants = FALSE
 
-/obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/stack/nanopaste/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!istype(M) || !istype(user))
 		return 0
 	if (istype(M,/mob/living/silicon/robot) && can_use(1))	//Repairing cyborgs

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -11,9 +11,9 @@
 	no_variants = FALSE
 
 /obj/item/stack/nanopaste/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if (!istype(M) || !istype(user))
-		return 0
-	if (istype(M,/mob/living/silicon/robot) && can_use(1))	//Repairing cyborgs
+	if(!istype(M) || !istype(user))
+		return ITEM_INTERACT_FAILURE
+	if(istype(M,/mob/living/silicon/robot) && can_use(1))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss())
 			if(do_after(user, 7 * toolspeed, target = R))
@@ -23,30 +23,34 @@
 				use(1)
 				user.balloon_alert_visible("\the [user] applied some [src] on [R]'s damaged areas.",\
 				"you apply some [src] at [R]'s damaged areas.")
+				return ITEM_INTERACT_SUCCESS
 		else
 			balloon_alert(user, "all [R]'s systems are nominal.")
+			return ITEM_INTERACT_FAILURE
 
-	if (ishuman(M))		//Repairing robolimbs
+	if(ishuman(M))		//Repairing robolimbs
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 		if(!S)
 			balloon_alert(user, "no body part there to work on!")
-			return 1
+			return ITEM_INTERACT_FAILURE
 
 		if(S.organ_tag == BP_HEAD)
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
 				balloon_alert(user, "you can't apply [src] through [H.head]!")
-				return 1
+				return ITEM_INTERACT_FAILURE
 		else
 			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
 				balloon_alert(user, "you can't apply [src] through [H.wear_suit]!")
-				return 1
+				return ITEM_INTERACT_FAILURE
 
 		if (S && (S.robotic >= ORGAN_ROBOT))
 			if(!S.get_damage())
 				balloon_alert(user, "nothing to fix here.")
+				return ITEM_INTERACT_FAILURE
 			else if((S.open < 2) && (S.brute_dam + S.burn_dam >= S.min_broken_damage) && !repair_external)
 				balloon_alert(user, "the damage is too extensive for this nanite swarm to handle.")
+				return ITEM_INTERACT_FAILURE
 			else if(can_use(1))
 				user.setClickCooldown(user.get_attack_speed(src))
 				if(S.open >= 2)
@@ -58,3 +62,4 @@
 				use(1)
 				user.balloon_alert_visible("\the [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].",\
 				"you apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].")
+				return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/toys/mech_toys.dm
+++ b/code/game/objects/items/toys/mech_toys.dm
@@ -143,7 +143,7 @@
 /**
  * Attack is called from the user's toy, aimed at target(another human), checking for target's toy.
  */
-/obj/item/toy/mecha/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
+/obj/item/toy/mecha/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(target == user)
 		to_chat(user, span_notice("Target another toy mech if you want to start a battle with yourself."))
 		return

--- a/code/game/objects/items/toys/mech_toys.dm
+++ b/code/game/objects/items/toys/mech_toys.dm
@@ -146,13 +146,13 @@
 /obj/item/toy/mecha/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(target == user)
 		to_chat(user, span_notice("Target another toy mech if you want to start a battle with yourself."))
-		return
+		return ITEM_INTERACT_FAILURE
 	else if(user.a_intent != I_HURT)
 		if(wants_to_battle) //prevent spamming someone with offers
 			to_chat(user, span_notice("You already are offering battle to someone!"))
-			return
+			return ITEM_INTERACT_FAILURE
 		if(!check_battle_start(user)) //if the user's mech isn't ready, don't bother checking
-			return
+			return ITEM_INTERACT_FAILURE
 
 		for(var/obj/item/I in target.get_all_held_items())
 			if(istype(I, /obj/item/toy/mecha)) //if you attack someone with a mech who's also holding a mech, offer to battle them
@@ -164,14 +164,14 @@
 				if(M.wants_to_battle) //if the target mech wants to battle, initiate the battle from their POV
 					mecha_brawl(M, target, user) //P = defender's mech / SRC = attacker's mech / target = defender / user = attacker
 					M.wants_to_battle = FALSE
-					return
+					return ITEM_INTERACT_SUCCESS
 
 		//extend the offer of battle to the other mech
 		to_chat(user, span_notice("You offer battle to [target.name]!"))
 		to_chat(target, span_notice(span_bold("[user.name] wants to battle with [user.p_their()] [name]!") + " " + span_italics("Attack them with a toy mech to initiate combat.")))
 		wants_to_battle = TRUE
 		addtimer(CALLBACK(src, PROC_REF(withdraw_offer), user), 6 SECONDS)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	..()
 

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -42,7 +42,7 @@
 	reagents = R
 	R.my_atom = src
 
-/obj/item/toy/balloon/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/toy/balloon/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/toy/balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
@@ -642,7 +642,7 @@
 	cooldown_length = 1 SECOND
 
 // Attack mob
-/obj/item/toy/plushie/carp/attack(mob/M as mob, mob/user as mob)
+/obj/item/toy/plushie/carp/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	playsound(src, squeeze_sound, 20, 1)	// Play bite sound in local area
 	return ..()
 

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -43,7 +43,7 @@
 	R.my_atom = src
 
 /obj/item/toy/balloon/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/toy/balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/toys/toys_vr.dm
+++ b/code/game/objects/items/toys/toys_vr.dm
@@ -694,7 +694,7 @@
 		spin_cylinder()
 
 /obj/item/toy/russian_revolver/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/toy/russian_revolver/afterattack(atom/target, mob/user, flag, params)
 	if(flag)
@@ -875,6 +875,9 @@
 			var/datum/effect/effect/system/confetti_spread/s = new /datum/effect/effect/system/confetti_spread
 			s.set_up(5, 1, src)
 			s.start()
+			return ITEM_INTERACT_SUCCESS
+		return ITEM_INTERACT_FAILURE
+	return NONE
 
 /obj/item/toy/snake_popper/emag_act(remaining_charges, mob/user)
 	if(real != 2)

--- a/code/game/objects/items/toys/toys_vr.dm
+++ b/code/game/objects/items/toys/toys_vr.dm
@@ -440,7 +440,7 @@
 		slot_r_hand_str = 'icons/mob/items/righthand.dmi',
 		)
 
-/obj/item/toy/flash/attack(mob/living/M, mob/user)
+/obj/item/toy/flash/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!cooldown)
 		playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 		flick("[initial(icon_state)]2", src)
@@ -693,7 +693,7 @@
 		playsound(src, 'sound/weapons/revolver_spin.ogg', 100, 1)
 		spin_cylinder()
 
-/obj/item/toy/russian_revolver/attack(mob/M, mob/living/user)
+/obj/item/toy/russian_revolver/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/toy/russian_revolver/afterattack(atom/target, mob/user, flag, params)
@@ -851,7 +851,7 @@
 			popped = 0
 			icon_state = "tastybread"
 
-/obj/item/toy/snake_popper/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/toy/snake_popper/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(ishuman(M))
 		if(!popped)
 			to_chat(user, span_warning("A snake popped out of [src]!"))

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -237,7 +237,7 @@
 	slot_flags = SLOT_EARS | SLOT_MASK
 
 /obj/item/trash/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 
 /obj/item/trash/beef

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -236,7 +236,7 @@
 	pickup_sound = 'sound/items/pickup/flesh.ogg'
 	slot_flags = SLOT_EARS | SLOT_MASK
 
-/obj/item/trash/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/trash/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 

--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -68,7 +68,7 @@
 	desc = "A white cane. They are commonly used by the blind or visually impaired as a mobility tool or as a courtesy to others."
 	icon_state = "whitecane"
 
-/obj/item/cane/white/attack(mob/M as mob, mob/user as mob)
+/obj/item/cane/white/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)
 		user.visible_message(span_notice("\The [user] has lightly tapped [M] on the ankle with their white cane!"))
 		return TRUE

--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -71,7 +71,7 @@
 /obj/item/cane/white/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)
 		user.visible_message(span_notice("\The [user] has lightly tapped [M] on the ankle with their white cane!"))
-		return TRUE
+		return ITEM_INTERACT_SUCCESS
 	else
 		. = ..()
 

--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -210,7 +210,7 @@
 		return FALSE
 	else return TRUE
 
-/obj/item/capture_crystal/attack(mob/living/M, mob/living/user)
+/obj/item/capture_crystal/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(bound_mob)
 		if(!bound_mob.devourable)	//Don't eat if prefs are bad
 			return
@@ -879,7 +879,7 @@
 	active = TRUE
 	loadout = TRUE
 
-/obj/item/capture_crystal/loadout/attack(mob/living/M, mob/living/user)
+/obj/item/capture_crystal/loadout/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!bound_mob && M != user)
 		to_chat(user, span_notice("\The [src] emits an unpleasant tone..."))
 		playsound(src, 'sound/effects/capture-crystal-negative.ogg', 75, 1, -1)

--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -213,19 +213,23 @@
 /obj/item/capture_crystal/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(bound_mob)
 		if(!bound_mob.devourable)	//Don't eat if prefs are bad
-			return
+			return ITEM_INTERACT_FAILURE
 		if(user.zone_sel.selecting == "mouth")	//Click while targetting the mouth and you eat/feed the stored mob to whoever you clicked on
 			if(bound_mob in contents)
 				user.visible_message("\The [user] moves \the [src] to [M]'s [M.vore_selected]...")
 				M.perform_the_nom(M, bound_mob, M, M.vore_selected)
+				return ITEM_INTERACT_SUCCESS
 	else if(M == user)		//You don't have a mob, you ponder the orb instead of trying to capture yourself
 		user.visible_message("\The [user] ponders \the [src]...", "You ponder \the [src]...")
+		return ITEM_INTERACT_FAILURE
 	else if (cooldown_check())	//Try to capture someone without throwing
 		user.visible_message("\The [user] taps \the [M] with \the [src].")
 		activate(user, M)
+		return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_notice("\The [src] emits an unpleasant tone... It is not ready yet."))
 		playsound(src, 'sound/effects/capture-crystal-negative.ogg', 75, 1, -1)
+		return ITEM_INTERACT_FAILURE
 
 //Tries to unleash or recall your stored mob
 /obj/item/capture_crystal/attack_self(mob/living/user)
@@ -883,7 +887,7 @@
 	if(!bound_mob && M != user)
 		to_chat(user, span_notice("\The [src] emits an unpleasant tone..."))
 		playsound(src, 'sound/effects/capture-crystal-negative.ogg', 75, 1, -1)
-		return
+		return ITEM_INTERACT_FAILURE
 	. = ..()
 
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -232,11 +232,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if(blocked)
 			to_chat(H, span_warning("\The [blocked] is in the way!"))
-			return 1
+			return ITEM_INTERACT_FAILURE
 		to_chat(H, span_notice("You take a drag on your [name]."))
 		playsound(src, 'sound/items/cigs_lighters/inhale.ogg', 50, 0, -1)
 		smoke(5)
-		return 1
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W as obj, mob/user as mob)
@@ -664,16 +664,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == O_MOUTH && lit)
 		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
 		if(M == user)
 			cig.attackby(src, user)
+			return ITEM_INTERACT_SUCCESS
+
 		else
 			if(istype(src, /obj/item/flame/lighter/zippo))
 				cig.light(span_notice(span_rose("[user] whips the [name] out and holds it for [M].")))
 			else
 				cig.light(span_notice("[user] holds the [name] out for [M], and lights the [cig.name]."))
+			return ITEM_INTERACT_SUCCESS
 	else
 		..()
 
@@ -870,13 +874,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 		set_light(0)
 		STOP_PROCESSING(SSobj, src)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 
 /obj/item/flame/lighter/supermatter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == O_MOUTH && lit)
 		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
@@ -887,6 +892,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				cig.light(span_notice(span_rose("[user] whips the [name] out and holds it for [M].")))
 			else
 				cig.light(span_notice("[user] holds the [name] out for [M], and lights the [cig.name]."))
+		return ITEM_INTERACT_SUCCESS
 	else
 		..()
 
@@ -941,23 +947,26 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 		set_light(0)
 		STOP_PROCESSING(SSobj, src)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 
 /obj/item/flame/lighter/supermatter/syndismzippo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == O_MOUTH && lit)
 		var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
 		if(M == user)
 			cig.attackby(src, user)
+			return ITEM_INTERACT_SUCCESS
 		else
 			if(istype(src, /obj/item/flame/lighter/supermatter/syndismzippo))
 				cig.light(span_notice(span_rose("[user] whips the [name] out and holds it for [M].")))
 			else
 				cig.light(span_notice("[user] holds the [name] out for [M], and lights the [cig.name]."))
+			return ITEM_INTERACT_SUCCESS
 	else
 		..()
 
@@ -1113,6 +1122,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 		set_light(0)
 		STOP_PROCESSING(SSobj, src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/flame/lighter/supermatter/expsmzippo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (lit == 1)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -227,8 +227,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	STOP_PROCESSING(SSobj, src)
 	update_icon()
 
-/obj/item/clothing/mask/smokable/attack(mob/living/carbon/human/H, mob/user, def_zone)
-	if(lit && H == user && istype(H))
+/obj/item/clothing/mask/smokable/attack(mob/living/carbon/human/H, mob/living/user, target_zone, attack_modifier)
+	if(lit && H == user && ishuman(H))
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if(blocked)
 			to_chat(H, span_warning("\The [blocked] is in the way!"))
@@ -660,10 +660,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		update_icon()
 	return
 
-/obj/item/flame/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
-		return
-
+/obj/item/flame/lighter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
@@ -876,10 +873,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return
 
 
-/obj/item/flame/lighter/supermatter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
-		return
-
+/obj/item/flame/lighter/supermatter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
@@ -950,10 +944,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return
 
 
-/obj/item/flame/lighter/supermatter/syndismzippo/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
-		return
-
+/obj/item/flame/lighter/supermatter/syndismzippo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user,M,"Lit on fire with [src]")
@@ -1123,10 +1114,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		set_light(0)
 		STOP_PROCESSING(SSobj, src)
 
-/obj/item/flame/lighter/supermatter/expsmzippo/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if (!istype(M, /mob))
-		return
-
+/obj/item/flame/lighter/supermatter/expsmzippo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (lit == 1)
 		M.ignite_mob()
 		add_attack_logs(user, M, "Lit on fire with [src]")

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -44,18 +44,19 @@
 
 /obj/item/lipstick/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!open)
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.lip_style)	//if they already have lipstick on
 			to_chat(user, span_notice("You need to wipe off the old lipstick first!"))
-			return
+			return ITEM_INTERACT_FAILURE
 		if(H == user)
 			user.visible_message(span_notice("[user] does their lips with \the [src]."), \
 									span_notice("You take a moment to apply \the [src]. Perfect!"))
 			H.lip_style = colour
 			H.update_icons_body()
+			return ITEM_INTERACT_SUCCESS
 		else
 			user.visible_message(span_warning("[user] begins to do [H]'s lips with \the [src]."), \
 									span_notice("You begin to apply \the [src]."))
@@ -64,8 +65,10 @@
 										span_notice("You apply \the [src]."))
 				H.lip_style = colour
 				H.update_icons_body()
+				return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_notice("Where are the lips on that?"))
+		return ITEM_INTERACT_FAILURE
 
 //you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/attack()
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -42,10 +42,9 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/lipstick/attack(mob/M as mob, mob/user as mob)
-	if(!open)	return
-
-	if(!istype(M, /mob))	return
+/obj/item/lipstick/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!open)
+		return
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -118,9 +118,9 @@
 
 /obj/item/dnainjector/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!user.IsAdvancedToolUser())
-		return
+		return ITEM_INTERACT_FAILURE
 	if (in_use)
-		return
+		return ITEM_INTERACT_FAILURE
 
 	user.visible_message(span_danger("\The [user] is trying to inject \the [M] with \the [src]!"))
 	in_use = TRUE
@@ -129,7 +129,7 @@
 
 	if(!do_after(user, 5 SECONDS, target = src))
 		in_use = FALSE
-		return
+		return ITEM_INTERACT_FAILURE
 
 
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
@@ -140,10 +140,10 @@
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
 		to_chat(user, span_warning("Apparently it didn't work..."))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	inject(M, user)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 
 // Traitgenes Injectors are randomized now due to no hardcoded genes. Split into good or bad, and then versions that specify what they do on the label.

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -116,9 +116,7 @@
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), src)
 	return uses
 
-/obj/item/dnainjector/attack(mob/M as mob, mob/user as mob)
-	if (!istype(M, /mob))
-		return
+/obj/item/dnainjector/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!user.IsAdvancedToolUser())
 		return
 	if (in_use)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -92,7 +92,7 @@
 	qdel(src)
 
 /obj/item/plastique/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/plastique/seismic
 	name = "seismic charge"

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -91,7 +91,7 @@
 		target.cut_overlay(image_overlay)
 	qdel(src)
 
-/obj/item/plastique/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/plastique/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/plastique/seismic

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -177,8 +177,9 @@
 	if(Adjacent(user))
 		. += "There is about [src.amount] square units of paper left!"
 
-/obj/item/wrapping_paper/attack(mob/target as mob, mob/user as mob)
-	if(!ishuman(target)) return
+/obj/item/wrapping_paper/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
+	if(!ishuman(target))
+		return
 	var/mob/living/carbon/human/H = target
 
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket) || istype(H.wear_suit, /obj/item/clothing/suit/shibari) || H.stat)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -179,7 +179,7 @@
 
 /obj/item/wrapping_paper/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!ishuman(target))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/mob/living/carbon/human/H = target
 
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket) || istype(H.wear_suit, /obj/item/clothing/suit/shibari) || H.stat)
@@ -190,10 +190,13 @@
 			H.forceMove(present)
 
 			add_attack_logs(user,H,"Wrapped with [src]")
+			return ITEM_INTERACT_SUCCESS
 		else
 			to_chat(user, span_warning("You need more paper."))
+			return ITEM_INTERACT_FAILURE
 	else
 		to_chat(user, "They are moving around too much. A straightjacket would help.")
+		return ITEM_INTERACT_FAILURE
 
 
 /obj/item/a_gift/advanced

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -28,26 +28,28 @@
 
 /obj/item/handcuffs/attack(mob/living/carbon/C, mob/living/user, target_zone, attack_modifier)
 	if(!istype(C))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(!user.IsAdvancedToolUser())
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if (CLUMSY_FAIL_CHANCE(user))
 		to_chat(user, span_warning("Uh ... how do those things work?!"))
 		attempt_to_cuff(user, user)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	if(!C.handcuffed)
 		if (C == user)
 			attempt_to_cuff(user, user)
-			return
+			return ITEM_INTERACT_SUCCESS
 
 		//check for an aggressive grab (or robutts)
 		if(can_place(C, user))
 			attempt_to_cuff(C, user)
+			return ITEM_INTERACT_SUCCESS
 		else
 			to_chat(user, span_danger("You need to have a firm grip on [C] before you can put \the [src] on!"))
+			return ITEM_INTERACT_FAILURE
 
 /obj/item/handcuffs/proc/can_place(var/mob/target, var/mob/user)
 	if(user == target)
@@ -218,26 +220,28 @@
 
 /obj/item/handcuffs/legcuffs/attack(mob/living/carbon/C, mob/living/user, target_zone, attack_modifier)
 	if(!istype(C))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(!user.IsAdvancedToolUser())
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if (CLUMSY_FAIL_CHANCE(user))
 		to_chat(user, span_warning("Uh ... how do those things work?!"))
 		place_legcuffs(user, user)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	if(!C.legcuffed)
 		if (C == user)
 			place_legcuffs(user, user)
-			return
+			return ITEM_INTERACT_SUCCESS
 
 		//check for an aggressive grab (or robutts)
 		if(can_place(C, user))
 			place_legcuffs(C, user)
+			return ITEM_INTERACT_SUCCESS
 		else
 			to_chat(user, span_danger("You need to have a firm grip on [C] before you can put \the [src] on!"))
+			return ITEM_INTERACT_FAILURE
 
 /obj/item/handcuffs/legcuffs/proc/place_legcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src, cuff_sound, 30, 1, -2)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -26,7 +26,7 @@
 
 	return ..()
 
-/obj/item/handcuffs/attack(var/mob/living/carbon/C, var/mob/living/user)
+/obj/item/handcuffs/attack(mob/living/carbon/C, mob/living/user, target_zone, attack_modifier)
 	if(!istype(C))
 		return
 
@@ -216,7 +216,7 @@
 
 	return ..()
 
-/obj/item/handcuffs/legcuffs/attack(var/mob/living/carbon/C, var/mob/living/user)
+/obj/item/handcuffs/legcuffs/attack(mob/living/carbon/C, mob/living/user, target_zone, attack_modifier)
 	if(!istype(C))
 		return
 

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -50,7 +50,7 @@
 	src.icon_state += "_[active]"
 	return
 
-/obj/item/implanter/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!istype(M, /mob/living/carbon))
 		return
 	if(active)
@@ -125,7 +125,7 @@
 		icon_state = "cimplanter0"
 	return
 
-/obj/item/implanter/compressed/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/compressed/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/obj/item/implant/compressed/c = imp
 	if (!c)	return
 	if (c.scanned == null)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -52,9 +52,9 @@
 
 /obj/item/implanter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!istype(M, /mob/living/carbon))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(active)
-		if (imp)
+		if(imp)
 			M.visible_message(span_warning("[user] is attempting to implant [M]."))
 
 			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
@@ -75,11 +75,12 @@
 							BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 							BITSET(H.hud_updateflag, BACKUP_HUD) //VOREStation Add - Backup HUD updates
 
-					src.imp = null
+					imp = null
 					update()
+					return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_warning("You need to activate \the [src.name] first."))
-	return
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/implanter/loyalty
 	name = "implanter-loyalty"
@@ -127,10 +128,11 @@
 
 /obj/item/implanter/compressed/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/obj/item/implant/compressed/c = imp
-	if (!c)	return
-	if (c.scanned == null)
+	if(!c)
+		return ITEM_INTERACT_FAILURE
+	if(c.scanned == null)
 		to_chat(user, "Please scan an object with the implanter first.")
-		return
+		return ITEM_INTERACT_FAILURE
 	..()
 
 /obj/item/implanter/compressed/afterattack(atom/A, mob/user as mob, proximity)

--- a/code/game/objects/items/weapons/inducer_vr.dm
+++ b/code/game/objects/items/weapons/inducer_vr.dm
@@ -38,7 +38,7 @@
 /obj/item/inducer/get_cell()
 	return cell
 
-/obj/item/inducer/attack(mob/living/M, mob/living/user)
+/obj/item/inducer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HURT)
 		return ..()
 	else

--- a/code/game/objects/items/weapons/inducer_vr.dm
+++ b/code/game/objects/items/weapons/inducer_vr.dm
@@ -42,7 +42,7 @@
 	if(user.a_intent == I_HURT)
 		return ..()
 	else
-		return 0 //No accidental bludgeons!
+		return ITEM_INTERACT_FAILURE //No accidental bludgeons!
 
 /obj/item/inducer/afterattack(atom/A, mob/living/carbon/user, proximity)
 	if(user.a_intent == I_HURT)

--- a/code/game/objects/items/weapons/joke.dm
+++ b/code/game/objects/items/weapons/joke.dm
@@ -8,7 +8,7 @@
 	throwforce = 0
 
 // Attack mob
-/obj/item/squishhammer/attack(mob/M as mob, mob/user as mob)
+/obj/item/squishhammer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/is_squished = M.tf_scale_x || M.tf_scale_y
 	playsound(src, 'sound/items/hooh.ogg', 50, 1)
 	if(!is_squished)
@@ -28,7 +28,7 @@
 	force = 0
 	throwforce = 0
 
-/obj/item/squishhammer/dark/attack(mob/M as mob, mob/user as mob)
+/obj/item/squishhammer/dark/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	..()
 	var/mob/living/carbon/human/H = M
 	if(istype(H))

--- a/code/game/objects/items/weapons/joke.dm
+++ b/code/game/objects/items/weapons/joke.dm
@@ -16,7 +16,7 @@
 	else
 		M.ClearTransform()
 		M.update_transform()
-	return ..()
+	return ITEM_INTERACT_SUCCESS
 
 // Do not ever just leave this laying about, it will go horribly wrong!
 /obj/item/squishhammer/dark
@@ -37,3 +37,4 @@
 	var/turf/T = M.loc
 	if(isturf(T))
 		new /obj/effect/gibspawner/generic(T)
+	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -83,7 +83,7 @@
 		qdel(loading)
 	update_icon()
 
-/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M))
 		return ..()
 
@@ -210,7 +210,7 @@
 	drop_sound = 'sound/items/drop/wooden.ogg'
 	pickup_sound = 'sound/items/pickup/wooden.ogg'
 
-/obj/item/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/material/kitchen/rollingpin/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (CLUMSY_HARM_CHANCE(user))
 		to_chat(user, span_warning("\The [src] slips out of your hand and hits your head."))
 		user.take_organ_damage(10)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -106,20 +106,20 @@
 					M.vore_selected.nom_atom(F)
 		if(M == user)
 			if(!M.can_eat(loaded))
-				return
+				return ITEM_INTERACT_FAILURE
 			M.visible_message(span_bold("\The [user]") + " eats some of [loaded] with \the [src].")
 		else
 			user.visible_message(span_warning("\The [user] begins to feed \the [M]!"))
 			if(!(M.can_force_feed(user, loaded) && do_after(user, 5 SECONDS, M)))
-				return
+				return ITEM_INTERACT_FAILURE
 			M.visible_message(span_bold("\The [user]") + " feeds some of [loaded] to \the [M] with \the [src].")
 		playsound(src,'sound/items/eatfood.ogg', rand(10,40), 1)
 		loaded = null
 		update_icon()
-		return
+		return ITEM_INTERACT_SUCCESS
 	else
 		to_chat(user, span_warning("You don't have anything on \the [src]."))	//if we have help intent and no food scooped up DON'T STAB OURSELVES WITH THE FORK
-		return
+		return ITEM_INTERACT_FAILURE
 
 /obj/item/material/kitchen/utensil/on_rag_wipe()
 	. = ..()
@@ -211,9 +211,9 @@
 	pickup_sound = 'sound/items/pickup/wooden.ogg'
 
 /obj/item/material/kitchen/rollingpin/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if (CLUMSY_HARM_CHANCE(user))
+	if(CLUMSY_HARM_CHANCE(user))
 		to_chat(user, span_warning("\The [src] slips out of your hand and hits your head."))
 		user.take_organ_damage(10)
 		user.Paralyse(2)
-		return
+		return ITEM_INTERACT_SUCCESS
 	return ..()

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -45,7 +45,7 @@
 	can_cleave = FALSE
 	var/hits = 0
 
-/obj/item/material/knife/machete/hatchet/unathiknife/attack(mob/M as mob, mob/user as mob)
+/obj/item/material/knife/machete/hatchet/unathiknife/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(hits > 0)
 		return
 	var/obj/item/I = user.get_inactive_hand()
@@ -56,7 +56,7 @@
 		W.afterattack(M, user)
 	..()
 
-/obj/item/material/knife/machete/hatchet/unathiknife/afterattack(mob/M as mob, mob/user as mob)
+/obj/item/material/knife/machete/hatchet/unathiknife/afterattack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	hits = initial(hits)
 	..()
 

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -43,22 +43,6 @@
 	icon_state = "unathiknife"
 	attack_verb = list("ripped", "torn", "cut")
 	can_cleave = FALSE
-	var/hits = 0
-
-/obj/item/material/knife/machete/hatchet/unathiknife/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(hits > 0)
-		return
-	var/obj/item/I = user.get_inactive_hand()
-	if(istype(I, /obj/item/material/knife/machete/hatchet/unathiknife))
-		hits ++
-		var/obj/item/W = I
-		W.attack(M, user)
-		W.afterattack(M, user)
-	..()
-
-/obj/item/material/knife/machete/hatchet/unathiknife/afterattack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	hits = initial(hits)
-	..()
 
 /obj/item/material/minihoe // -- Numbers
 	name = "mini hoe"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -126,7 +126,7 @@
 	add_fingerprint(user)
 	return
 
-/obj/item/melee/energy/attack(mob/M, mob/user)
+/obj/item/melee/energy/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(active && use_cell)
 		if(!use_charge(hitcost))
 			deactivate(user)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -131,6 +131,7 @@
 		if(!use_charge(hitcost))
 			deactivate(user)
 			visible_message(span_notice("\The [src]'s blade flickers, before deactivating."))
+			return ITEM_INTERACT_FAILURE
 	return ..()
 
 /obj/item/melee/energy/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/weapons/paiwire.dm
+++ b/code/game/objects/items/weapons/paiwire.dm
@@ -14,4 +14,4 @@
 		user.visible_message("[user] fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
 
 /obj/item/pai_cable/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE

--- a/code/game/objects/items/weapons/paiwire.dm
+++ b/code/game/objects/items/weapons/paiwire.dm
@@ -1,12 +1,10 @@
-/obj/item/pai_cable/proc/plugin(obj/machinery/M as obj, mob/user as mob)
+/obj/item/pai_cable/proc/plugin(obj/machinery/M, mob/user)
 	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
-		//VOREStation Add - Can't hack secured_wires doors (vault, etc)
 		if(istype(M, /obj/machinery/door/airlock))
 			var/obj/machinery/door/airlock/A = M
 			if(A.secured_wires)
 				to_chat(user,span_warning("\The [M] doesn't have any acessible data ports for \the [src]!"))
 				return
-		//VOREStation Add End
 		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
 		playsound(src, 'sound/machines/click.ogg', 50, 1)
 		user.drop_item()
@@ -15,5 +13,5 @@
 	else
 		user.visible_message("[user] fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
 
-/obj/item/pai_cable/attack(obj/machinery/M as obj, mob/user as mob)
-	src.plugin(M, user)
+/obj/item/pai_cable/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	return

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -304,10 +304,7 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 	return ..()
 
-/obj/item/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
-		return
-
+/obj/item/storage/fancy/cigarettes/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M == user && user.zone_sel.selecting == O_MOUTH)
 		// Find ourselves a cig. Note that we could be full of lighters.
 		var/obj/item/clothing/mask/smokable/cigarette/cig = locate() in src

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -311,12 +311,12 @@
 
 		if(cig == null)
 			to_chat(user, span_notice("Looks like the packet is out of cigarettes."))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		// Instead of running equip_to_slot_if_possible() we check here first,
 		// to avoid dousing cig with reagents if we're not going to equip it
 		if(!cig.mob_can_equip(user, slot_wear_mask))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		// We call remove_from_storage first to manage the reagent transfer and
 		// UI updates.
@@ -326,6 +326,7 @@
 		reagents.maximum_volume = 15 * contents.len
 		to_chat(user, span_notice("You take a cigarette out of the pack."))
 		update_icon()
+		return ITEM_INTERACT_SUCCESS
 	else
 		..()
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -178,7 +178,7 @@
 		to_chat(user, span_danger("You accidentally hit yourself with the [src]!"))
 		user.Weaken(30)
 		deductcharge(hitcost)
-		return
+		return ITEM_INTERACT_SUCCESS
 	deductcharge(hitcost)
 	return ..()
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -173,7 +173,7 @@
 			to_chat(user, span_warning("[src] is out of charge."))
 	add_fingerprint(user)
 
-/obj/item/melee/baton/attack(mob/M, mob/user)
+/obj/item/melee/baton/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(status && CLUMSY_FAIL_CHANCE(user))
 		to_chat(user, span_danger("You accidentally hit yourself with the [src]!"))
 		user.Weaken(30)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -24,7 +24,7 @@
 
 /obj/item/surgical/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
-		return 0
+		return NONE
 	..()
 
 /*

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -22,7 +22,7 @@
 	pickup_sound = 'sound/items/pickup/weldingtool.ogg'
 	var/helpforce = 0	//For help intent things
 
-/obj/item/surgical/attack(mob/M, mob/user)
+/obj/item/surgical/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		return 0
 	..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -29,7 +29,7 @@
 	drop_sound = 'sound/items/drop/crowbar.ogg'
 	pickup_sound = 'sound/items/pickup/crowbar.ogg'
 
-/obj/item/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/melee/classic_baton/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (CLUMSY_FAIL_CHANCE(user))
 		to_chat(user, span_warning("You club yourself over the head."))
 		user.Weaken(3 * force)
@@ -99,7 +99,7 @@
 
 	return
 
-/obj/item/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/melee/telebaton/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(on)
 		if (CLUMSY_FAIL_CHANCE(user))
 			to_chat(user, span_warning("You club yourself over the head."))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -38,7 +38,7 @@
 			H.apply_damage(2*force, BRUTE, BP_HEAD)
 		else
 			user.take_organ_damage(2*force)
-		return
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 //Telescopic baton
@@ -101,7 +101,7 @@
 
 /obj/item/melee/telebaton/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(on)
-		if (CLUMSY_FAIL_CHANCE(user))
+		if(CLUMSY_FAIL_CHANCE(user))
 			to_chat(user, span_warning("You club yourself over the head."))
 			user.Weaken(3 * force)
 			if(ishuman(user))
@@ -109,9 +109,5 @@
 				H.apply_damage(2*force, BRUTE, BP_HEAD)
 			else
 				user.take_organ_damage(2*force)
-			return
-		if(..())
-			//playsound(src, "swing_hit", 50, 1, -1)
-			return
-	else
-		return ..()
+			return ITEM_INTERACT_SUCCESS
+	return ..()

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -19,8 +19,9 @@
 
 	return FALSE
 
-/obj/item/tape_roll/attack(var/mob/living/carbon/human/H, var/mob/user)
-	if(istype(H))
+/obj/item/tape_roll/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
 		if(user.a_intent == I_HELP)
 			return
 		if(!can_place(H, user))

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -23,35 +23,35 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(user.a_intent == I_HELP)
-			return
+			return ITEM_INTERACT_FAILURE
 		if(!can_place(H, user))
 			to_chat(user, span_danger("You need to have a firm grip on [H] before you can use \the [src]!"))
-			return
+			return ITEM_INTERACT_FAILURE
 		else
 			if(user.zone_sel.selecting == O_EYES)
 
 				if(!H.organs_by_name[BP_HEAD])
 					to_chat(user, span_warning("\The [H] doesn't have a head."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(!H.has_eyes())
 					to_chat(user, span_warning("\The [H] doesn't have any eyes."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(H.glasses)
 					to_chat(user, span_warning("\The [H] is already wearing something on their eyes."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(H.head && (H.head.body_parts_covered & FACE))
 					to_chat(user, span_warning("Remove their [H.head] first."))
-					return
+					return ITEM_INTERACT_FAILURE
 				user.visible_message(span_danger("\The [user] begins taping over \the [H]'s eyes!"))
 
 				if(!do_after(user, 3 SECONDS, target = src))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(!can_place(H, user))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(!H || !src || !H.organs_by_name[BP_HEAD] || !H.has_eyes() || H.glasses || (H.head && (H.head.body_parts_covered & FACE)))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				user.visible_message(span_danger("\The [user] has taped up \the [H]'s eyes!"))
 				H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses/blindfold/tape(H), slot_glasses, ignore_obstructions = FALSE)
@@ -61,26 +61,26 @@
 			else if(user.zone_sel.selecting == O_MOUTH || user.zone_sel.selecting == BP_HEAD)
 				if(!H.organs_by_name[BP_HEAD])
 					to_chat(user, span_warning("\The [H] doesn't have a head."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(!H.check_has_mouth())
 					to_chat(user, span_warning("\The [H] doesn't have a mouth."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(H.wear_mask)
 					to_chat(user, span_warning("\The [H] is already wearing a mask."))
-					return
+					return ITEM_INTERACT_FAILURE
 				if(H.head && (H.head.body_parts_covered & FACE))
 					to_chat(user, span_warning("Remove their [H.head] first."))
-					return
+					return ITEM_INTERACT_FAILURE
 				user.visible_message(span_danger("\The [user] begins taping up \the [H]'s mouth!"))
 
 				if(!do_after(user, 3 SECONDS, target = src))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(!can_place(H, user))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(!H || !src || !H.organs_by_name[BP_HEAD] || !H.check_has_mouth() || (H.head && (H.head.body_parts_covered & FACE)))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				user.visible_message(span_danger("\The [user] has taped up \the [H]'s mouth!"))
 
@@ -90,7 +90,7 @@
 
 			else if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 				if(!can_place(H, user))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				var/obj/item/handcuffs/cable/tape/T = new(user)
 				playsound(src, 'sound/effects/tape.ogg',25)
@@ -100,7 +100,7 @@
 					qdel(T)
 			else
 				return ..()
-			return 1
+			return ITEM_INTERACT_SUCCESS
 
 /obj/item/tape_roll/proc/stick(var/obj/item/W, mob/user)
 	if(!istype(W, /obj/item/paper) || istype(W, /obj/item/paper/sticky) || !user.unEquip(W))

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -55,7 +55,7 @@
 	if (prob(75))
 		pixel_y = rand(0, 16)
 
-/obj/item/tool/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/tool/screwdriver/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M) || user.a_intent == I_HELP)
 		return ..()
 	if(user.zone_sel.selecting != O_EYES && user.zone_sel.selecting != BP_HEAD)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -83,21 +83,21 @@
 		if(S.organ_tag == BP_HEAD)
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
 				to_chat(user, span_warning("You can't apply [src] through [H.head]!"))
-				return TRUE
+				return ITEM_INTERACT_FAILURE
 		else
 			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
 				to_chat(user, span_warning("You can't apply [src] through [H.wear_suit]!"))
-				return TRUE
+				return ITEM_INTERACT_FAILURE
 
 		if(!welding)
 			to_chat(user, span_warning("You'll need to turn [src] on to patch the damage on [H]'s [S.name]!"))
-			return TRUE
+			return ITEM_INTERACT_FAILURE
 
 		if(S.robo_repair(15, BRUTE, "some dents", src, user))
 			remove_fuel(1, user)
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 		else
-			return TRUE //Stops you from accidentally harming someone while on help intent.
+			return ITEM_INTERACT_FAILURE //Stops you from accidentally harming someone while on help intent.
 
 	return ..()
 

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -67,9 +67,9 @@
 	if(max_fuel && loc == user)
 		. += "It contains [get_fuel()]/[src.max_fuel] units of fuel!"
 
-/obj/item/weldingtool/attack(atom/A, mob/living/user, def_zone)
-	if(ishuman(A) && user.a_intent == I_HELP)
-		var/mob/living/carbon/human/H = A
+/obj/item/weldingtool/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(ishuman(M) && user.a_intent == I_HELP)
+		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
 
 		if(!S || S.robotic < ORGAN_ROBOT || S.open == 3)

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -56,7 +56,7 @@
 		if(C.buckled && C.buckled.buckle_require_restraints)
 			C.buckled.unbuckle_mob()
 		C.update_handcuffed()
-		return
+		return ITEM_INTERACT_SUCCESS
 	else
 		..()
 

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -44,7 +44,10 @@
 	if (prob(75))
 		pixel_y = rand(0, 16)
 
-/obj/item/tool/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
+/obj/item/tool/wirecutters/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!iscarbon(M))
+		return ..()
+	var/mob/living/carbon/C = M
 	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		user.visible_message("\The [user] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -19,7 +19,7 @@
 	COOLDOWN_DECLARE(shield_bash)
 	drop_sound = 'sound/items/trayhit1.ogg'
 
-/obj/item/tray/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/tray/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/tray_sound = pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg')
 	//var/attack_area = user.zone_sel.selecting
 	user.setClickCooldown(user.get_attack_speed(src))

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -41,7 +41,7 @@
 		M.Weaken(1)
 		user.take_organ_damage(2)
 		playsound(src, tray_sound, 50, 1)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	var/face_hit = FALSE
 
@@ -91,7 +91,7 @@
 	user.visible_message(span_danger("[user] slams [M] [face_hit ? "in the face " : ""]with the tray!"), runemessage = "CLANG!")
 	//user.apply_damage(rand(min_bonus_damage, max_bonus_damage), BRUTE, attack_area)
 	M.take_organ_damage(rand(min_bonus_damage, max_bonus_damage))
-	return
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/tray/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/material/kitchen/rollingpin))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -21,19 +21,19 @@
 
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, span_danger("You don't have the dexterity to do this!"))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(CLUMSY_HARM_CHANCE(user))
 		to_chat(user, span_danger("The rod slips out of your hand and hits your head."))
 		user.take_organ_damage(10)
 		user.Paralyse(20)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	if(M.stat != DEAD)
 		if(user?.mind?.assigned_role != JOB_CHAPLAIN)
 			to_chat(user, span_danger("You feel that only a chaplain can wield the null rod's true power!"))
 			..()
-			return
+			return ITEM_INTERACT_FAILURE
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/infected = M
@@ -60,7 +60,7 @@
 		else
 			to_chat(user, span_danger("The rod appears to do nothing."))
 			M.visible_message(span_danger("\The [user] waves \the [src] over \the [M]'s head."))
-			return
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/nullrod/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -12,7 +12,7 @@
 	drop_sound = 'sound/items/drop/sword.ogg'
 	pickup_sound = 'sound/items/pickup/sword.ogg'
 
-/obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/nullrod/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	add_attack_logs(user,M,"Hit with [src] (nullrod)")
 

--- a/code/game/objects/mail.dm
+++ b/code/game/objects/mail.dm
@@ -406,7 +406,7 @@ ADMIN_VERB(spawn_mail, R_SPAWN, "Spawn Mail", "Spawn mail for a specific player,
 	. += span_notice("Scan a letter to log it into the active database, then scan the person you wish to hand the letter to. Correctly scanning the recipient of the letter logged into the active database will add points to the supply budget.")
 
 /obj/item/mail_scanner/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/mail_scanner/afterattack(atom/A, mob/user)
 	if(istype(A, /obj/item/mail))

--- a/code/game/objects/mail.dm
+++ b/code/game/objects/mail.dm
@@ -405,7 +405,7 @@ ADMIN_VERB(spawn_mail, R_SPAWN, "Spawn Mail", "Spawn mail for a specific player,
 	. = ..()
 	. += span_notice("Scan a letter to log it into the active database, then scan the person you wish to hand the letter to. Correctly scanning the recipient of the letter logged into the active database will add points to the supply budget.")
 
-/obj/item/mail_scanner/attack()
+/obj/item/mail_scanner/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/mail_scanner/afterattack(atom/A, mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -85,7 +85,7 @@
 		var/mob/living/T = M
 		T.Weaken(10)
 		T.apply_damage(20)
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/stool/ex_act(severity)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -71,7 +71,7 @@
 		padding_material = null
 	update_icon()
 
-/obj/item/stool/attack(mob/M as mob, mob/user as mob)
+/obj/item/stool/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (prob(5) && isliving(M))
 		user.visible_message(span_danger("[user] breaks [src] over [M]'s back!"))
 		user.setClickCooldown(user.get_attack_speed())

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -1,5 +1,4 @@
 /atom/var/lastattacker = null
-/mob/var/lastattacked = null
 
 /proc/log_and_message_admins(var/message as text, var/mob/user = usr)
 	log_admin(user ? "[key_name(user)] [message]" : "EVENT [message]")

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -316,7 +316,7 @@
 							sound = "anything"
 
 				user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "You place [src] against [their] [body_part]. You [sound_strength] [sound].")
-				return
+				return ITEM_INTERACT_SUCCESS
 	return ..(M,user)
 
 //Medals

--- a/code/modules/clothing/accessories/badges.dm
+++ b/code/modules/clothing/accessories/badges.dm
@@ -49,7 +49,7 @@
 		else
 			user.visible_message(span_notice("[user] displays their [src.name].\nIt reads: [badge_string]."),span_notice("You display your [src.name]. It reads: [badge_string]."))
 
-/obj/item/clothing/accessory/badge/attack(mob/living/carbon/human/M, mob/living/user)
+/obj/item/clothing/accessory/badge/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(isliving(user))
 		user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_danger("You invade [M]'s personal space, thrusting [src] into their face insistently."))
 		user.do_attack_animation(M)
@@ -210,7 +210,7 @@
 	user.visible_message("[user] shows their sheriff badge. There's a new sheriff in town!",\
 		"You flash the sheriff badge to everyone around you!")
 
-/obj/item/clothing/accessory/badge/sheriff/attack(mob/living/carbon/human/M, mob/living/user)
+/obj/item/clothing/accessory/badge/sheriff/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(isliving(user))
 		user.visible_message(span_danger("[user] invades [M]'s personal space, the sheriff badge into their face!."),span_danger("You invade [M]'s personal space, thrusting the sheriff badge into their face insistently."))
 		user.do_attack_animation(M)

--- a/code/modules/clothing/accessories/badges.dm
+++ b/code/modules/clothing/accessories/badges.dm
@@ -50,10 +50,10 @@
 			user.visible_message(span_notice("[user] displays their [src.name].\nIt reads: [badge_string]."),span_notice("You display your [src.name]. It reads: [badge_string]."))
 
 /obj/item/clothing/accessory/badge/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(isliving(user))
-		user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_danger("You invade [M]'s personal space, thrusting [src] into their face insistently."))
-		user.do_attack_animation(M)
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //NO SPAM
+	user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_danger("You invade [M]'s personal space, thrusting [src] into their face insistently."))
+	user.do_attack_animation(M)
+	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //NO SPAM
+	return ITEM_INTERACT_SUCCESS
 
 // General Badges
 /obj/item/clothing/accessory/badge/old
@@ -211,10 +211,10 @@
 		"You flash the sheriff badge to everyone around you!")
 
 /obj/item/clothing/accessory/badge/sheriff/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	if(isliving(user))
-		user.visible_message(span_danger("[user] invades [M]'s personal space, the sheriff badge into their face!."),span_danger("You invade [M]'s personal space, thrusting the sheriff badge into their face insistently."))
-		user.do_attack_animation(M)
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //NO SPAM
+	user.visible_message(span_danger("[user] invades [M]'s personal space, the sheriff badge into their face!."),span_danger("You invade [M]'s personal space, thrusting the sheriff badge into their face insistently."))
+	user.do_attack_animation(M)
+	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //NO SPAM
+	return ITEM_INTERACT_SUCCESS
 
 // Synthmorph bag / Corporation badges. Primarily used on the robobag, but can be worn. Default is NT.
 /obj/item/clothing/accessory/badge/corporate_tag

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -118,7 +118,7 @@
 				var/mob/living/carbon/human/H = target
 				if(H.head && (H.head.body_parts_covered & FACE)) //Check human head coverage.
 					to_chat(user, span_warning("Remove their [H.head] first."))
-					return
+					return ITEM_INTERACT_FAILURE
 				else if(reagents.total_volume) //Final check. If the rag is not on fire and their face is uncovered, smother target.
 					user.do_attack_animation(src)
 					user.visible_message(
@@ -131,13 +131,15 @@
 					update_name()
 				else
 					to_chat(user, span_warning("You can't smother this creature."))
+					return ITEM_INTERACT_FAILURE
 			else
 				to_chat(user, span_warning("You can't smother this creature."))
+				return ITEM_INTERACT_FAILURE
 		else
 			wipe_down(target, user)
 	else
 		wipe_down(target, user)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -106,7 +106,7 @@
 			user.visible_message("[user] finishes wiping [A]!")
 			A.on_rag_wipe(src)
 
-/obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
+/obj/item/reagent_containers/glass/rag/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(isliving(target)) //Leaving this as isliving.
 		var/mob/living/M = target
 		if(on_fire) //Check if rag is on fire, if so igniting them and stopping.

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -86,17 +86,17 @@
 		return ..()
 
 	if(evidence && evidence.len)
-		return 0
+		return ITEM_INTERACT_FAILURE
 
 	var/mob/living/carbon/human/H = M
 
 	if(H.gloves)
 		to_chat(user, span_warning("\The [H] is wearing gloves."))
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if(user != H && H.a_intent != I_HELP && !H.lying)
 		user.visible_message(span_danger("\The [user] tries to take prints from \the [H], but they move away."))
-		return 1
+		return ITEM_INTERACT_FAILURE
 
 	if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 		var/has_hand
@@ -109,15 +109,15 @@
 				has_hand = 1
 		if(!has_hand)
 			to_chat(user, span_warning("They don't have any hands."))
-			return 1
+			return ITEM_INTERACT_FAILURE
 		user.visible_message("[user] takes a copy of \the [H]'s fingerprints.")
 		var/fullprint = H.get_full_print()
 		evidence[fullprint] = fullprint
 		copy_evidence(src)
 		name = "[initial(name)] (\the [H])"
 		icon_state = "fingerprint1"
-		return 1
-	return 0
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/sample/print/copy_evidence(var/atom/supplied)
 	var/list/print_data = supplied.forensic_data.get_prints()

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -80,7 +80,7 @@
 	name = "[initial(name)] (\the [H])"
 	icon_state = "fingerprint1"
 
-/obj/item/sample/print/attack(var/mob/living/M, var/mob/user)
+/obj/item/sample/print/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(!ishuman(M))
 		return ..()

--- a/code/modules/detectivework/tools/scanner.dm
+++ b/code/modules/detectivework/tools/scanner.dm
@@ -21,14 +21,14 @@
 	if (!ishuman(M))
 		to_chat(user, span_warning("\The [M] does not seem to be compatible with this device."))
 		flick("[icon_state]0",src)
-		return 0
+		return ITEM_INTERACT_FAILURE
 	var/mob/living/carbon/human/target = M
 
 	if(reveal_fingerprints)
 		if((!( istype(target.dna, /datum/dna) ) || target.gloves))
 			to_chat(user, span_notice("No fingerprints found on [target]"))
 			flick("[icon_state]0",src)
-			return 0
+			return ITEM_INTERACT_FAILURE
 		else if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 			var/obj/item/sample/print/P = new /obj/item/sample/print(user.loc)
 			P.attack(target, user)
@@ -41,7 +41,7 @@
 			var/list/blooddna = target.forensic_data.get_blooddna()
 			for(var/blood in blooddna)
 				to_chat(user, span_notice("Blood type: [blooddna[blood]]\nDNA: [blood]"))
-	return
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/detective_scanner/afterattack(atom/A as obj|turf, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/detectivework/tools/scanner.dm
+++ b/code/modules/detectivework/tools/scanner.dm
@@ -17,27 +17,28 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 
-/obj/item/detective_scanner/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/detective_scanner/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!ishuman(M))
 		to_chat(user, span_warning("\The [M] does not seem to be compatible with this device."))
 		flick("[icon_state]0",src)
 		return 0
+	var/mob/living/carbon/human/target = M
 
 	if(reveal_fingerprints)
-		if((!( istype(M.dna, /datum/dna) ) || M.gloves))
-			to_chat(user, span_notice("No fingerprints found on [M]"))
+		if((!( istype(target.dna, /datum/dna) ) || target.gloves))
+			to_chat(user, span_notice("No fingerprints found on [target]"))
 			flick("[icon_state]0",src)
 			return 0
 		else if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 			var/obj/item/sample/print/P = new /obj/item/sample/print(user.loc)
-			P.attack(M, user)
+			P.attack(target, user)
 			to_chat(user, span_notice("Done printing."))
 	//		to_chat(user, span_notice("[M]'s Fingerprints: [md5(M.dna.uni_identity)]"))
 
-	if(reveal_blood && M.forensic_data?.has_blooddna())
-		to_chat(user, span_notice("Blood found on [M]. Analysing..."))
+	if(reveal_blood && target.forensic_data?.has_blooddna())
+		to_chat(user, span_notice("Blood found on [target]. Analysing..."))
 		spawn(15)
-			var/list/blooddna = M.forensic_data.get_blooddna()
+			var/list/blooddna = target.forensic_data.get_blooddna()
 			for(var/blood in blooddna)
 				to_chat(user, span_notice("Blood type: [blooddna[blood]]\nDNA: [blood]"))
 	return

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -11,7 +11,7 @@
 /obj/item/forensics/swab/proc/is_used()
 	return used
 
-/obj/item/forensics/swab/attack(var/mob/living/M, var/mob/user)
+/obj/item/forensics/swab/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(!ishuman(M))
 		return ..()

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -17,30 +17,30 @@
 		return ..()
 
 	if(is_used())
-		return
+		return ITEM_INTERACT_FAILURE
 
 	var/mob/living/carbon/human/H = M
 	var/sample_type
 
 	if(H.wear_mask)
 		to_chat(user, span_warning("\The [H] is wearing a mask."))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(!H.dna || !H.dna.unique_enzymes)
 		to_chat(user, span_warning("They don't seem to have DNA!"))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(user != H && H.a_intent != I_HELP && !H.lying)
 		user.visible_message(span_danger("\The [user] tries to take a swab sample from \the [H], but they move away."))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(user.zone_sel.selecting == O_MOUTH)
 		if(!H.organs_by_name[BP_HEAD])
 			to_chat(user, span_warning("They don't have a head."))
-			return
+			return ITEM_INTERACT_FAILURE
 		if(!H.check_has_mouth())
 			to_chat(user, span_warning("They don't have a mouth."))
-			return
+			return ITEM_INTERACT_FAILURE
 		user.visible_message("[user] swabs \the [H]'s mouth for a saliva sample.")
 		dna = list(H.dna.unique_enzymes)
 		sample_type = "DNA"
@@ -61,12 +61,12 @@
 		sample_type = "GSR"
 		gsr = H.forensic_data?.get_gunshotresidue()
 	else
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(sample_type)
 		set_used(sample_type, H)
-		return
-	return 1
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/forensics/swab/afterattack(var/atom/A, var/mob/user, var/proximity)
 

--- a/code/modules/entrepreneur/entrepreneur_items.dm
+++ b/code/modules/entrepreneur/entrepreneur_items.dm
@@ -226,7 +226,7 @@
 	desc = "A small mirror at the end of a short, stainless steel rod."
 	w_class = ITEMSIZE_TINY
 
-/obj/item/entrepreneur/dentist_mirror/attack(mob/M, mob/user)
+/obj/item/entrepreneur/dentist_mirror/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You use the mirror to get a good look inside of [M]'s mouth."))
 		to_chat(M, span_notice("[user] uses a small mirror to look inside of your mouth."))
@@ -240,7 +240,7 @@
 	desc = "A short stainless steel rod that ends with a narrow pointy bit for poking."
 	w_class = ITEMSIZE_TINY
 
-/obj/item/entrepreneur/dentist_probe/attack(mob/M, mob/user)
+/obj/item/entrepreneur/dentist_probe/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You use the probe to poke about inside of [M]'s mouth."))
 		to_chat(M, span_notice("[user] examines the inside of your mouth with a sharp probe, it hurts a little being prodded."))
@@ -254,7 +254,7 @@
 	desc = "A narrow, sharp hook at the end of a short, stainless steel rod."
 	w_class = ITEMSIZE_TINY
 
-/obj/item/entrepreneur/dentist_sickle/attack(mob/M, mob/user)
+/obj/item/entrepreneur/dentist_sickle/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You loosen some stuck debris from [M]'s mouth with the hook."))
 		to_chat(M, span_notice("[user] uses a hook to scrape out something stuck in your mouth, it's pretty uncomfortable."))
@@ -268,7 +268,7 @@
 	desc = "A flat and thin scraper at the end of a short, stainless steel rod."
 	w_class = ITEMSIZE_TINY
 
-/obj/item/entrepreneur/dentist_scaler/attack(mob/M, mob/user)
+/obj/item/entrepreneur/dentist_scaler/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You scrape debris out from [M]'s mouth."))
 		to_chat(M, span_notice("[user] scrapes debris from out of your mouth."))

--- a/code/modules/entrepreneur/entrepreneur_items.dm
+++ b/code/modules/entrepreneur/entrepreneur_items.dm
@@ -230,7 +230,7 @@
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You use the mirror to get a good look inside of [M]'s mouth."))
 		to_chat(M, span_notice("[user] uses a small mirror to look inside of your mouth."))
-		return 0
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/entrepreneur/dentist_probe
@@ -244,7 +244,7 @@
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You use the probe to poke about inside of [M]'s mouth."))
 		to_chat(M, span_notice("[user] examines the inside of your mouth with a sharp probe, it hurts a little being prodded."))
-		return 0
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/entrepreneur/dentist_sickle
@@ -258,7 +258,7 @@
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You loosen some stuck debris from [M]'s mouth with the hook."))
 		to_chat(M, span_notice("[user] uses a hook to scrape out something stuck in your mouth, it's pretty uncomfortable."))
-		return 0
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/entrepreneur/dentist_scaler
@@ -272,7 +272,7 @@
 	if(user.a_intent == I_HELP)	//A tad messy, but this should stop people from smacking their patients in surgery
 		to_chat(user, span_notice("You scrape debris out from [M]'s mouth."))
 		to_chat(M, span_notice("[user] scrapes debris from out of your mouth."))
-		return 0
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 ////// Exercise mat, yoga and trainer stuff

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -105,7 +105,7 @@
 /obj/item/material/fishing_rod/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(cast)
 		to_chat(user, span_notice("You cannot cast \the [src] when it is already in use!"))
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 	update_bait()
 	return ..()
 

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -102,7 +102,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item/material/fishing_rod/attack(var/mob/M as mob, var/mob/user as mob, var/def_zone)
+/obj/item/material/fishing_rod/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(cast)
 		to_chat(user, span_notice("You cannot cast \the [src] when it is already in use!"))
 		return FALSE

--- a/code/modules/food/food/condiment.dm
+++ b/code/modules/food/food/condiment.dm
@@ -21,7 +21,7 @@
 /obj/item/reagent_containers/food/condiment/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	return
 
-/obj/item/reagent_containers/food/condiment/attack(var/mob/M as mob, var/mob/user as mob, var/def_zone)
+/obj/item/reagent_containers/food/condiment/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(standard_feed_mob(user, M))
 		return
 

--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -148,7 +148,7 @@
 		to_chat(user, span_warning("...wait a second, this one doesn't have a ring pull. It's not a <b>can</b>, it's a <b>can't!</b>"))
 		name = "\improper can't of [initial(name)]"	//don't update the name until they try to open it
 
-/obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/drinks/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(force && !(flags & NOBLUDGEON) && user.a_intent == I_HURT)
 		return ..()
 

--- a/code/modules/food/food/drinks.dm
+++ b/code/modules/food/food/drinks.dm
@@ -153,9 +153,9 @@
 		return ..()
 
 	if(standard_feed_mob(user, M))
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	return FALSE
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/food/food/drinks/bottle.dm
+++ b/code/modules/food/food/drinks/bottle.dm
@@ -224,7 +224,7 @@
 	edge = FALSE
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 
-/obj/item/broken_bottle/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/broken_bottle/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 	return ..()
 

--- a/code/modules/food/food/sandwich.dm
+++ b/code/modules/food/food/sandwich.dm
@@ -84,7 +84,7 @@
 		var/obj/item/O = pick(contents)
 		. += span_blue("You think you can see [O.name] in there.")
 
-/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	var/obj/item/shard
 	for(var/obj/item/O in contents)

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -102,7 +102,7 @@
 	if(canned && !user.incapacitated())
 		uncan(user)
 
-/obj/item/reagent_containers/food/snacks/attack(mob/living/eater as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/attack(mob/living/eater, mob/living/user, target_zone, attack_modifier)
 	if(reagents && !reagents.total_volume)
 		balloon_alert(user, "none of \the [src] left!")
 		user.drop_from_inventory(src)

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -107,15 +107,15 @@
 		balloon_alert(user, "none of \the [src] left!")
 		user.drop_from_inventory(src)
 		qdel(src)
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
 	if(package)
 		balloon_alert(user, "the package is in the way!")
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
 	if(canned)
 		balloon_alert(user, "the can is closed!")
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
 	if(istype(eater, /mob/living/carbon))
 		//TODO: replace with standard_feed_mob() call.
@@ -123,7 +123,7 @@
 		if(!eater.consume_liquid_belly)
 			if(liquid_belly_check())
 				to_chat(user, span_infoplain("[user == eater ? "You can't" : "\The [eater] can't"] consume that, it contains something produced from a belly!"))
-				return FALSE
+				return ITEM_INTERACT_FAILURE
 		var/swallow_whole = FALSE
 		var/obj/belly/belly_target				// These are surprise tools that will help us later
 
@@ -133,7 +133,7 @@
 				var/mob/living/carbon/human/human_eater = eater
 				if(!human_eater.check_has_mouth())
 					balloon_alert(user, "you don't have a mouth!")
-					return
+					return ITEM_INTERACT_FAILURE
 				var/obj/item/blocked = null
 				if(survivalfood)
 					blocked = human_eater.check_mouth_coverage_survival()
@@ -141,7 +141,7 @@
 					blocked = human_eater.check_mouth_coverage()
 				if(blocked)
 					balloon_alert(user, "\the [blocked] is in the way!")
-					return
+					return ITEM_INTERACT_FAILURE
 
 			user.setClickCooldown(user.get_attack_speed(src)) //puts a limit on how fast people can eat/drink things
 			if (fullness <= 50)
@@ -164,7 +164,7 @@
 				to_chat(eater, span_danger("You glug down the bite of [src], you are reaching the very limits of what you can eat, but maybe a few more bites could be managed..."))
 			if (fullness > 6000) // There has to be a limit eventually.
 				to_chat(eater, span_danger("Nope. That's it. You literally cannot force any more of [src] to go down your throat. It's fair to say you're full."))
-				return FALSE
+				return ITEM_INTERACT_FAILURE
 
 		else if(user.a_intent == I_HURT)
 			return ..()
@@ -174,7 +174,7 @@
 				var/mob/living/carbon/human/human_eater = eater
 				if(!human_eater.check_has_mouth())
 					balloon_alert(user, "\the [human_eater] doesn't have a mouth!")
-					return
+					return ITEM_INTERACT_FAILURE
 				var/obj/item/blocked = null
 				var/unconcious = FALSE
 				blocked = human_eater.check_mouth_coverage()
@@ -192,20 +192,20 @@
 
 				if(unconcious)
 					to_chat(user, span_warning("You can't feed [human_eater] through \the [blocked] while they are unconcious!"))
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(blocked)
 					// to_chat(user, span_warning("\The [blocked] is in the way!"))
 					balloon_alert(user, "\the [blocked] is in the way!")
-					return
+					return ITEM_INTERACT_FAILURE
 
 				if(swallow_whole)
 					if(!(human_eater.feeding))
 						balloon_alert(user, "you can't feed [human_eater] a whole [src] as they refuse to be fed whole things!")
-						return
+						return ITEM_INTERACT_FAILURE
 					if(!belly_target)
 						balloon_alert(user, "you can't feed [human_eater] a whole [src] as they don't appear to have a belly to fit it!")
-						return
+						return ITEM_INTERACT_FAILURE
 
 				if(swallow_whole)
 					user.balloon_alert_visible("[user] attempts to make [human_eater] consume [src] whole into their [belly_target].")
@@ -217,10 +217,13 @@
 					feed_duration = 5 SECONDS
 
 				user.setClickCooldown(user.get_attack_speed(src))
-				if(!do_after(user, feed_duration, human_eater)) return
-				if(!reagents || (reagents && !reagents.total_volume)) return
+				if(!do_after(user, feed_duration, human_eater))
+					return ITEM_INTERACT_FAILURE
+				if(!reagents || (reagents && !reagents.total_volume))
+					return ITEM_INTERACT_FAILURE
 
-				if(swallow_whole && !belly_target) return			// Just in case we lost belly mid-feed
+				if(swallow_whole && !belly_target)
+					return ITEM_INTERACT_FAILURE			// Just in case we lost belly mid-feed
 
 				if(swallow_whole)
 					add_attack_logs(user, human_eater,"Whole-fed with [src.name] containing [reagentlist(src)] into [belly_target]", admin_notify = FALSE)
@@ -233,12 +236,12 @@
 
 			else
 				balloon_alert(user, "this creature does not seem to have a mouth!")
-				return
+				return ITEM_INTERACT_FAILURE
 
 		if(swallow_whole)
 			user.drop_item()
 			forceMove(belly_target)
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 		else if(reagents)								//Handle ingestion of the reagent.
 			playsound(eater, eating_sound, rand(10,50), 1)
 			if(reagents.total_volume)
@@ -252,9 +255,9 @@
 					reagents.trans_to_mob(eater, reagents.total_volume, CHEM_INGEST)
 				bitecount++
 				On_Consume(eater, user)
-			return TRUE
+			return ITEM_INTERACT_SUCCESS
 
-	return FALSE
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/reagent_containers/food/snacks/examine(mob/user)
 	. = ..()

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -121,7 +121,7 @@
 	. = ..()
 	AddComponent(/datum/component/spooky)
 */
-/obj/item/instrument/trumpet/spectral/attack(mob/living/carbon/C, mob/user)
+/obj/item/instrument/trumpet/spectral/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	playsound (src, 'sound/runtime/instruments/trombone/En4.mid', 100,1,-1)
 	..()
 
@@ -144,7 +144,7 @@
 	AddComponent(/datum/component/spooky)
 */
 
-/obj/item/instrument/saxophone/spectral/attack(mob/living/carbon/C, mob/user)
+/obj/item/instrument/saxophone/spectral/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	playsound (src, 'sound/runtime/instruments/saxophone/En4.mid', 100,1,-1)
 	..()
 
@@ -167,7 +167,7 @@
 	AddComponent(/datum/component/spooky)
 */
 
-/obj/item/instrument/trombone/spectral/attack(mob/living/carbon/C, mob/user)
+/obj/item/instrument/trombone/spectral/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	playsound (src, 'sound/runtime/instruments/trombone/Cn4.mid', 100,1,-1)
 	..()
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -306,7 +306,7 @@ Book Cart End
 	else
 		..()
 
-/obj/item/book/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/book/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.zone_sel.selecting == O_EYES)
 		user.visible_message(span_notice("You open up the book and show it to [M]."), \
 			span_notice(" [user] opens up a book and shows it to [M]."))

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -312,6 +312,8 @@ Book Cart End
 			span_notice(" [user] opens up a book and shows it to [M]."))
 		display_content(M)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /*
 * Book Bundle (Multi-page book)

--- a/code/modules/makeup/nailpolish.dm
+++ b/code/modules/makeup/nailpolish.dm
@@ -61,7 +61,7 @@
 		icostate = organ_tag
 	return new /datum/nail_polish(ico, icostate, colour)
 
-/obj/item/nailpolish/attack(var/mob/user, var/mob/living/carbon/human/target)
+/obj/item/nailpolish/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!open)
 		return
 
@@ -115,7 +115,7 @@
 	. = ..()
 	icon_state = "[initial(icon_state)][open ? "-open" : ""]"
 
-/obj/item/nailpolish_remover/attack(var/mob/user, var/mob/living/carbon/human/target)
+/obj/item/nailpolish_remover/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!open)
 		return
 

--- a/code/modules/makeup/nailpolish.dm
+++ b/code/modules/makeup/nailpolish.dm
@@ -63,23 +63,23 @@
 
 /obj/item/nailpolish/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!open)
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(!istype(target))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	var/bp = user.zone_sel.selecting
 	var/obj/item/organ/external/body_part = target.get_organ(bp)
 	if(!body_part)
 		to_chat(user, span_warning("[target] is missing that limb!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(body_part.nail_polish)
 		to_chat(user, span_notice("[target]'s [body_part.name] already has nail polish on!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/datum/nail_polish/polish = body_part.get_polish(colour)
 	if(!polish)
 		to_chat(user, span_notice("You can't find any nails on [body_part] to paint."))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(user == target)
 		user.visible_message(span_infoplain(span_bold("\The [user]") + " paints their nails with \the [src]."), span_infoplain("You paint your nails with \the [src]."))
 	else
@@ -87,8 +87,9 @@
 			user.visible_message(span_infoplain(span_bold("\The [user]") + " paints \the [target]'s nails with \the [src]."), span_infoplain("You paint \the [target]'s nails with \the [src]."))
 		else
 			to_chat(user, span_notice("Both you and [target] must stay still!"))
-			return
+			return ITEM_INTERACT_FAILURE
 	body_part.set_polish(polish)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/organ/external/proc/set_polish(var/datum/nail_polish/polish)
 	nail_polish = polish
@@ -117,19 +118,19 @@
 
 /obj/item/nailpolish_remover/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!open)
-		return
+		return ITEM_INTERACT_FAILURE
 
 	if(!istype(target))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	var/bp = user.zone_sel.selecting
 	var/obj/item/organ/external/body_part = target.get_organ(bp)
 	if(!body_part)
 		to_chat(user, span_warning("[target] is missing that limb!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(!body_part.nail_polish)
 		to_chat(user, span_notice("[target]'s [body_part.name] has no nail polish to remove!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(user == target)
 		user.visible_message(span_infoplain(span_bold("\The [user]") + " removes their nail polish with \the [src]."), span_infoplain("You remove your nail polish with \the [src]."))
 	else
@@ -137,8 +138,9 @@
 			user.visible_message(span_infoplain(span_bold("\The [user]") + " removes \the [target]'s nail polish with \the [src]."), span_infoplain("You remove \the [target]'s nail polish with \the [src]."))
 		else
 			to_chat(user, span_notice("Both you and [target] must stay still!"))
-			return
+			return ITEM_INTERACT_FAILURE
 	body_part.set_polish(null)
+	return ITEM_INTERACT_SUCCESS
 
 /datum/nail_polish
 	var/icon = 'icons/obj/nailpolish_vr.dmi'

--- a/code/modules/materials/materials/_materials_vr.dm
+++ b/code/modules/materials/materials/_materials_vr.dm
@@ -1,4 +1,4 @@
-/obj/item/stack/material/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/stack/material/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M.handle_eat_minerals(src, user))
 		return
 	..()

--- a/code/modules/materials/materials/_materials_vr.dm
+++ b/code/modules/materials/materials/_materials_vr.dm
@@ -1,9 +1,9 @@
 /obj/item/stack/material/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M.handle_eat_minerals(src, user))
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/stack/material/attack_generic(var/mob/living/user) //Allow adminbussed mobs to eat ore if they click it while NOT on help intent.
 	if(user.handle_eat_minerals(src))
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -90,7 +90,7 @@
 	. += span_notice("Mark a[emagged ? "nything": " creature"] with the destabilizing force, then hit them in melee to do <b>[force + detonation_damage]</b> damage.")
 	. += span_notice("Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.")
 
-/obj/item/kinetic_crusher/attack(mob/living/target, mob/living/carbon/user)
+/obj/item/kinetic_crusher/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!wielded && requires_wield)
 		to_chat(user, span_warning("[src] is too heavy to use with one hand."))
 		return

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -93,7 +93,7 @@
 /obj/item/kinetic_crusher/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(!wielded && requires_wield)
 		to_chat(user, span_warning("[src] is too heavy to use with one hand."))
-		return
+		return ITEM_INTERACT_FAILURE
 	..()
 
 /obj/item/kinetic_crusher/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -154,12 +154,12 @@
 
 /obj/item/ore/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M.handle_eat_minerals(src, user))
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/ore/attack_generic(var/mob/living/user) //Allow adminbussed mobs to eat ore if they click it while NOT on help intent.
 	if(user.handle_eat_minerals(src))
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/ore_chunk

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -152,7 +152,7 @@
 	else
 		return ..()
 
-/obj/item/ore/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/ore/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M.handle_eat_minerals(src, user))
 		return
 	..()

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -18,14 +18,14 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 
-/obj/item/robotanalyzer/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/robotanalyzer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	do_scan(M, user)
 
 /obj/item/robotanalyzer/click_alt(mob/user)
 	mode = !mode
 	user.show_message(span_blue("[mode ? "Toggled to cyborg analyzing mode." : "Toggled to cyborg upgrade scan mode."]"), 1)
 
-/obj/item/robotanalyzer/proc/do_scan(mob/living/M as mob, mob/living/user as mob)
+/obj/item/robotanalyzer/proc/do_scan(mob/living/M, mob/living/user)
 	if(CLUMSY_FAIL_CHANCE(user))
 		to_chat(user, span_red("You try to analyze the floor's vitals!"))
 		for(var/mob/O in viewers(M, null))

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -20,6 +20,7 @@
 
 /obj/item/robotanalyzer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	do_scan(M, user)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/robotanalyzer/click_alt(mob/user)
 	mode = !mode

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -13,7 +13,7 @@
 	var/datum/matter_synth/plastic/plastic = null
 
 /obj/item/matter_decompiler/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -12,7 +12,7 @@
 	var/datum/matter_synth/wood/wood = null
 	var/datum/matter_synth/plastic/plastic = null
 
-/obj/item/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/matter_decompiler/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)

--- a/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
+++ b/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
@@ -366,7 +366,7 @@
 	clear_and_select_pocket()
 	generate_icons()
 
-/obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/gripper/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(is_in_use(user))
 		return FALSE
 

--- a/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
+++ b/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
@@ -381,13 +381,13 @@
 		return ITEM_INTERACT_FAILURE
 
 	//First, we call the item's /attack on the MOB TARGET we are clicking on.
-	if(!(wrapped.attack(M, user, target_zone, attack_modifier) == ITEM_INTERACT_SUCCESS))
-		//If we don't get a return value of success, that means we didn't hit them with it/do a successful special interaction with it.
+	if(!(wrapped.attack(M, user, target_zone, attack_modifier) == (ITEM_INTERACT_SUCCESS || ITEM_INTERACT_BLOCKING)))
+		//If we don't get a return value of success/failure, that means we didn't hit them with it/do a special interaction with it.
 		if(item_left_gripper(wrapped))
 			update_ref(null)
-		else
-			//Attackby is procced when an object (non living entity) is clicked on by the user.
-			M.attackby(wrapped, user, target_zone, attack_modifier)
+			return ITEM_INTERACT_SUCCESS
+		//Attackby is procced when an object (non living entity) is clicked on by the user.
+		M.attackby(wrapped, user, target_zone, attack_modifier)
 
 	//If our wrapper was deleted OR it's no longer in our internal gripper storage
 	if(item_left_gripper(wrapped))

--- a/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
+++ b/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
@@ -368,27 +368,32 @@
 
 /obj/item/gripper/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(is_in_use(user))
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
 	var/obj/item/wrapped = get_wrapped_item()
 	//The force of the wrapped obj gets set to zero during the attack() and afterattack().
 	if(!wrapped)
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
 	//If our wrapper was deleted OR it's no longer in our internal gripper storage
 	if(item_left_gripper(wrapped))
 		update_ref(null)
-		return FALSE
+		return ITEM_INTERACT_FAILURE
 
-	wrapped.attack(M, user)
-	//attackby reportedly gets procced by being clicked on, at least according to Anewbe.
-	M.attackby(wrapped, user)
+	//First, we call the item's /attack on the MOB TARGET we are clicking on.
+	if(!(wrapped.attack(M, user, target_zone, attack_modifier) == ITEM_INTERACT_SUCCESS))
+		//If we don't get a return value of success, that means we didn't hit them with it/do a successful special interaction with it.
+		if(item_left_gripper(wrapped))
+			update_ref(null)
+		else
+			//Attackby is procced when an object (non living entity) is clicked on by the user.
+			M.attackby(wrapped, user, target_zone, attack_modifier)
 
 	//If our wrapper was deleted OR it's no longer in our internal gripper storage
 	if(item_left_gripper(wrapped))
 		update_ref(null)
 
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/gripper/update_icon()
 	cut_overlays()

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -205,7 +205,7 @@
 			)
 	item_state = "sheet-metal"
 
-/obj/item/form_printer/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/form_printer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/form_printer/afterattack(atom/target, mob/living/user, flag, params)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -206,7 +206,7 @@
 	item_state = "sheet-metal"
 
 /obj/item/form_printer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/form_printer/afterattack(atom/target, mob/living/user, flag, params)
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -301,11 +301,11 @@
 
 /obj/item/grab/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(QDELETED(src))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(!affecting)
-		return
+		return ITEM_INTERACT_FAILURE
 	if(world.time < (last_action + 20))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	last_action = world.time
 	reset_kill_state() //using special grab moves will interrupt choking them
@@ -321,7 +321,6 @@
 					if(force_down)
 						to_chat(assailant, span_warning("You are no longer pinning [affecting] to the ground."))
 						force_down = 0
-						return
 					if(state >= GRAB_AGGRESSIVE)
 						H.apply_pressure(assailant, hit_zone)
 					else
@@ -340,6 +339,8 @@
 
 				if(I_DISARM)
 					pin_down(affecting, assailant)
+			return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/grab/proc/reset_kill_state()
 	if(state == GRAB_KILL)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -299,7 +299,7 @@
 
 	return 1
 
-/obj/item/grab/attack(mob/M, mob/living/user)
+/obj/item/grab/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(QDELETED(src))
 		return
 	if(!affecting)

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -675,7 +675,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 ////////////////////////////////
 // Special Promethean """surgery"""
-/obj/item/nif/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/nif/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!ishuman(M) || !ishuman(user) || (M == user))
 		return ..()
 

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -685,11 +685,11 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	if(istype(T.species,/datum/species/shapeshifter/promethean) && target_zone == BP_TORSO)
 		if(T.w_uniform || T.wear_suit)
 			to_chat(user,span_warning("Remove any clothing they have on, as it might interfere!"))
-			return
+			return ITEM_INTERACT_FAILURE
 		var/obj/item/organ/external/eo = T.get_organ(BP_TORSO)
 		if(!T)
 			to_chat(user,span_warning("They should probably regrow their torso first."))
-			return
+			return ITEM_INTERACT_FAILURE
 		U.visible_message(span_notice("[U] begins installing [src] into [T]'s chest by just stuffing it in."),
 		span_notice("You begin installing [src] into [T]'s chest by just stuffing it in."),
 		"There's a wet SQUISH noise.")
@@ -699,6 +699,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			eo.implants |= src
 			implant(T)
 			playsound(T,'sound/effects/slime_squish.ogg',50,1)
+			return ITEM_INTERACT_SUCCESS
 	else
 		return ..()
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -10,7 +10,7 @@
 	pickup_sound = 'sound/items/pickup/device.ogg'
 
 /obj/item/hand_labeler/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/hand_labeler/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -9,7 +9,7 @@
 	drop_sound = 'sound/items/drop/device.ogg'
 	pickup_sound = 'sound/items/pickup/device.ogg'
 
-/obj/item/hand_labeler/attack()
+/obj/item/hand_labeler/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/hand_labeler/afterattack(atom/A, mob/user, proximity)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -223,6 +223,7 @@
 		user.visible_message(span_notice("You show the paper to [M]. "), \
 			span_notice(" [user] holds up a paper and shows it to [M]. "))
 		M.examinate(src)
+		return ITEM_INTERACT_SUCCESS
 
 	else if(user.zone_sel.selecting == O_MOUTH) // lipstick wiping
 		if(ishuman(M))
@@ -239,6 +240,8 @@
 											span_notice("You wipe off [H]'s lipstick."))
 					H.lip_style = null
 					H.update_icons_body()
+					return ITEM_INTERACT_SUCCESS
+				return ITEM_INTERACT_FAILURE
 
 /obj/item/paper/proc/set_content(text,title)
 	if(title)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -218,7 +218,7 @@
 		onclose(user, "[name]")
 	return
 
-/obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/paper/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(user.zone_sel.selecting == O_EYES)
 		user.visible_message(span_notice("You show the paper to [M]. "), \
 			span_notice(" [user] holds up a paper and shows it to [M]. "))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -150,7 +150,7 @@
 	. = ..()
 	create_reagents(30)
 
-/obj/item/pen/reagent/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/pen/reagent/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(!istype(M))
 		return

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -151,10 +151,6 @@
 	create_reagents(30)
 
 /obj/item/pen/reagent/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-
-	if(!istype(M))
-		return
-
 	. = ..()
 
 	if(M.can_inject(user,1))
@@ -163,6 +159,7 @@
 				var/contained = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
 				add_attack_logs(user,M,"Injected with [src.name] containing [contained], trasferred [trans] units")
+				return ITEM_INTERACT_SUCCESS
 
 /*
  * Blade Pens

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -149,7 +149,7 @@ GLOBAL_VAR_INIT(photo_count, 0)
 		size = nsize
 		to_chat(usr, span_notice("Camera will now take [size]x[size] photos."))
 
-/obj/item/camera/attack(mob/living/carbon/human/M as mob, mob/user as mob)
+/obj/item/camera/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/camera/attack_self(mob/user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -150,7 +150,7 @@ GLOBAL_VAR_INIT(photo_count, 0)
 		to_chat(usr, span_notice("Camera will now take [size]x[size] photos."))
 
 /obj/item/camera/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/camera/attack_self(mob/user)
 	. = ..(user)

--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -456,9 +456,9 @@
 			add_overlay("pda-pen")
 	return
 
-/obj/item/pda/attack(mob/living/C, mob/living/user)
-	if (istype(C, /mob/living/carbon) && scanmode)
-		scanmode.scan_mob(C, user)
+/obj/item/pda/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(istype(M, /mob/living/carbon) && scanmode)
+		scanmode.scan_mob(M, user)
 
 /obj/item/pda/afterattack(atom/A, mob/user, proximity)
 	if(proximity && scanmode)

--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -459,6 +459,7 @@
 /obj/item/pda/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(istype(M, /mob/living/carbon) && scanmode)
 		scanmode.scan_mob(M, user)
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/pda/afterattack(atom/A, mob/user, proximity)
 	if(proximity && scanmode)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -558,16 +558,18 @@ GLOBAL_LIST_INIT(possible_cable_coil_colours, list(
 		if(S.organ_tag == BP_HEAD)
 			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
 				to_chat(user, span_warning("You can't apply [src] through [H.head]!"))
-				return 1
+				return ITEM_INTERACT_FAILURE
 		else
 			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
 				to_chat(user, span_warning("You can't apply [src] through [H.wear_suit]!"))
-				return 1
+				return ITEM_INTERACT_FAILURE
 
 		var/use_amt = min(src.amount, CEILING(S.burn_dam/5, 1), 5)
 		if(can_use(use_amt))
 			if(S.robo_repair(5*use_amt, BURN, "some damaged wiring", src, user))
 				src.use(use_amt)
+				return ITEM_INTERACT_SUCCESS
+		return ITEM_INTERACT_FAILURE
 
 	else
 		return ..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -542,7 +542,7 @@ GLOBAL_LIST_INIT(possible_cable_coil_colours, list(
 ///////////////////////////////////
 
 //you can use wires to heal robotics
-/obj/item/stack/cable_coil/attack(var/atom/A, var/mob/living/user, var/def_zone)
+/obj/item/stack/cable_coil/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if(ishuman(A) && user.a_intent == I_HELP)
 		var/mob/living/carbon/human/H = A
 		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -178,7 +178,7 @@
 	if(isrobot(M))
 		var/mob/living/silicon/robot/target = M
 		if(target.opened)
-			return FALSE
+			return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/cell/attackby(obj/item/W, mob/user)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -174,7 +174,7 @@
 		. += "It has a power rating of [maxcharge]."
 		. += "The charge meter reads [round(src.percent() )]%."
 
-/obj/item/cell/attack(mob/living/M, mob/living/user, var/target_zone, var/attack_modifier)
+/obj/item/cell/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(isrobot(M))
 		var/mob/living/silicon/robot/target = M
 		if(target.opened)

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -226,12 +226,16 @@
 		if(H.isSynthetic())
 			if(H.nutrition <= amount)
 				use(user,H)
+				return ITEM_INTERACT_SUCCESS
 			else
 				to_chat(user,span_warning("The difference in potential is too great. [user == M ? "You have" : "[H] has"] too much charge to use such a small battery."))
+				return ITEM_INTERACT_FAILURE
 		else if(M == user)
 			to_chat(user,span_warning("You lick the cell, and your tongue tingles slightly."))
+			return ITEM_INTERACT_SUCCESS
 		else
 			to_chat(user,span_warning("This cell is meant for use on humanoid synthetics only."))
+			return ITEM_INTERACT_FAILURE
 
 	. = ..()
 

--- a/code/modules/power/cells/power_cells.dm
+++ b/code/modules/power/cells/power_cells.dm
@@ -220,7 +220,7 @@
 	. = ..()
 	add_overlay("[icon_state]_100")
 
-/obj/item/fbp_backup_cell/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/fbp_backup_cell/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!used && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.isSynthetic())

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -274,7 +274,7 @@
 	Fire(A,user,params) //Otherwise, fire normally.
 */
 
-/obj/item/gun/attack(atom/A, mob/living/user, def_zone)
+/obj/item/gun/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if (A == user && user.zone_sel.selecting == O_MOUTH && !mouthshoot)
 		handle_suicide(user)
 	else if(user.a_intent == I_HURT) //point blank shooting

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -277,12 +277,14 @@
 /obj/item/gun/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if (A == user && user.zone_sel.selecting == O_MOUTH && !mouthshoot)
 		handle_suicide(user)
+		return ITEM_INTERACT_SUCCESS
 	else if(user.a_intent == I_HURT) //point blank shooting
 		if(user && user.client && user.aiming && user.aiming.active && user.aiming.aiming_at != A && A != user)
 			PreFire(A,user) //They're using the new gun system, locate what they're aiming at.
-			return
+			return ITEM_INTERACT_SUCCESS
 		else
 			Fire(A, user, pointblank=1)
+			return ITEM_INTERACT_SUCCESS
 	else
 		return ..() //Pistolwhippin'
 

--- a/code/modules/projectiles/guns/energy/cyborg.dm
+++ b/code/modules/projectiles/guns/energy/cyborg.dm
@@ -245,7 +245,7 @@
 		return TRUE
 	return null
 
-/obj/item/melee/robotic/borg_combat_shocker/attack(mob/M, mob/user)
+/obj/item/melee/robotic/borg_combat_shocker/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	deductcharge(600)
 	return ..()
 
@@ -467,7 +467,7 @@
 		return TRUE
 	return null
 
-/obj/item/melee/robotic/baton/attack(mob/M, mob/user)
+/obj/item/melee/robotic/baton/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(status)
 		deductcharge(hitcost)
 	return ..()
@@ -543,7 +543,7 @@
 	hitcost = 48	//Less zap for less cost
 
 
-/obj/item/melee/robotic/baton/slime/attack(mob/living/L, mob/user, hit_zone)
+/obj/item/melee/robotic/baton/slime/attack(mob/living/L, mob/living/user, target_zone, attack_modifier)
 	if(!istype(L))
 		return ..()
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -275,7 +275,7 @@
 /obj/item/gun/energy/maghowitzer/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if(power_cycle)
 		to_chat(user, span_notice("\The [src] is already powering up!"))
-		return 0
+		return ITEM_INTERACT_FAILURE
 	var/turf/target_turf = get_turf(A)
 	var/beameffect = user.Beam(target_turf,icon_state="sat_beam",icon='icons/effects/beam.dmi',time=31, maxdistance=10,beam_type=/obj/effect/ebeam,beam_sleep_time=3)
 	if(beameffect)
@@ -291,6 +291,7 @@
 					..(rand_target, user, target_zone, attack_modifier)
 				else
 					..(target_turf, user, target_zone, attack_modifier)
+			return ITEM_INTERACT_SUCCESS
 		else
 			if(beameffect)
 				qdel(beameffect)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -272,7 +272,7 @@
 		return return_target
 	return FALSE
 
-/obj/item/gun/energy/maghowitzer/attack(atom/A, mob/living/user, def_zone)
+/obj/item/gun/energy/maghowitzer/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if(power_cycle)
 		to_chat(user, span_notice("\The [src] is already powering up!"))
 		return 0
@@ -284,19 +284,19 @@
 		power_cycle = TRUE
 		if(do_after(user, 3 SECONDS, target = src))
 			if(A.loc == target_turf)
-				..(A, user, def_zone)
+				..(A, user, target_zone, attack_modifier)
 			else
 				var/rand_target = pick_random_target(target_turf)
 				if(rand_target)
-					..(rand_target, user, def_zone)
+					..(rand_target, user, target_zone, attack_modifier)
 				else
-					..(target_turf, user, def_zone)
+					..(target_turf, user, target_zone, attack_modifier)
 		else
 			if(beameffect)
 				qdel(beameffect)
 		power_cycle = FALSE
 	else
-		..(A, user, def_zone) //If it can't fire, just bash with no delay.
+		..(A, user, target_zone, attack_modifier) //If it can't fire, just bash with no delay.
 
 /obj/item/gun/energy/maghowitzer/afterattack(atom/A, mob/living/user, adjacent, params)
 	if(power_cycle)

--- a/code/modules/projectiles/guns/lasertag.dm
+++ b/code/modules/projectiles/guns/lasertag.dm
@@ -128,7 +128,7 @@
 	allowed_suits = list(/obj/item/clothing/suit/lasertag/bluetag, /obj/item/clothing/suit/lasertag/omni)
 
 //We have to do this if(user) check all over the place because for some reason someone broke thrower code. Thanks.
-/obj/item/lasertagknife/attack(target, mob/user)
+/obj/item/lasertagknife/attack(mob/living/target, mob/living/user, target_zone, attack_modifier)
 	if(user)
 		user.setClickCooldown(user.get_attack_speed(src))
 		user.do_attack_animation(target)

--- a/code/modules/projectiles/guns/lasertag.dm
+++ b/code/modules/projectiles/guns/lasertag.dm
@@ -140,7 +140,7 @@
 	else
 		user.visible_message(span_danger("[target] has been harmlessly bonked with [src] by [user]!"))
 		playsound(src, 'sound/weapons/punchmiss.ogg', 75, 1)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 ///go my hack
 /obj/item/lasertagknife/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/reagents/machinery/injector_maker.dm
+++ b/code/modules/reagents/machinery/injector_maker.dm
@@ -1,6 +1,6 @@
 /obj/machinery/injector_maker
 	name = "Ready-to-Use Medicine 3000"
-	desc = "Fills plastic autoinjectors with chemicals! Molds new injectors if needed!  \n Add a beaker or a bottle filled with chemicals and an autoinjector of appropriate size or sheets of plastic to use!"
+	desc = "Fills plastic autoinjectors with chemicals! Molds new injectors if needed!  \n Add a beaker or a bottle filled with chemicals and an autoinjector of appropriate size or sheets of plastic to use! \n Plastic can be drag-dropped into the machine."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "injector"
 	use_power = USE_POWER_IDLE
@@ -111,6 +111,26 @@
 				src.count_plastic = src.count_plastic + plastic_input
 				update_icon()
 
+
+/obj/machinery/injector_maker/MouseDrop_T(atom/dropping, mob/user, src_location, over_location, src_control, over_control, params)
+	if(!isliving(user) || user.stat || !Adjacent(user) || !Adjacent(dropping))
+		return
+
+	if(istype(dropping, /obj/item/stack/material/plastic))
+		var/obj/item/stack/material/plastic/plastic_stack = dropping
+		var/input_amount = tgui_input_number(user, "How many sheets would you like to add?", "Add plastic", 0, plastic_stack.get_amount())
+		if(input_amount == 0)
+			return
+		if(!isliving(user) || user.stat || !Adjacent(user) || !Adjacent(dropping))
+			return
+		var/plastic_input = input_amount * value_plastic
+		var/free_space = capacity_plastic - count_plastic
+		if(plastic_input > free_space)
+			to_chat(user, span_warning("Storage is full! There is only [free_space] units worth of space left!"))
+		else
+			plastic_stack.use(input_amount)
+			src.count_plastic = src.count_plastic + plastic_input
+			update_icon()
 
 /obj/machinery/injector_maker/click_alt(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/bluespacecoffee.dm
+++ b/code/modules/reagents/reagent_containers/bluespacecoffee.dm
@@ -15,4 +15,5 @@
 	//Infinite Coffee
 /obj/item/reagent_containers/food/drinks/bluespace_coffee/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	..()
-	src.reagents.add_reagent(REAGENT_ID_COFFEE, 50)
+	reagents.add_reagent(REAGENT_ID_COFFEE, 50)
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/reagents/reagent_containers/bluespacecoffee.dm
+++ b/code/modules/reagents/reagent_containers/bluespacecoffee.dm
@@ -13,6 +13,6 @@
 	reagents.add_reagent(REAGENT_ID_COFFEE, 50)
 
 	//Infinite Coffee
-/obj/item/reagent_containers/food/drinks/bluespace_coffee/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/drinks/bluespace_coffee/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	..()
 	src.reagents.add_reagent(REAGENT_ID_COFFEE, 50)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -128,18 +128,18 @@
 
 /obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M))
-		return
+		return ITEM_INTERACT_FAILURE
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
 		if(!affected)
 			balloon_alert(user, "\the [H] is missing that limb!")
-			return
+			return ITEM_INTERACT_FAILURE
 		/* since synths have oil/coolant streams now, it only makes sense that you should be able to inject stuff. preserved for posterity.
 		else if(affected.robotic >= ORGAN_ROBOT)
 			to_chat(user, span_danger("You cannot inject a robotic limb."))
-			return
+			return ITEM_INTERACT_FAILURE
 		*/
 
 	if(M.can_inject(user, 1, ignore_thickness = bypass_protection))
@@ -160,7 +160,7 @@
 			switch(result)
 				if(BORGHYPO_STATUS_CONTAINERFULL)
 					balloon_alert(user, "\the [M] has too many reagents in [M.p_their()] system!")
-					return
+					return ITEM_INTERACT_FAILURE
 				if(BORGHYPO_STATUS_NOCHARGE)
 					if(is_dispensing_recipe)
 						balloon_alert(user, "not enough reagents to inject full recipe!")
@@ -168,10 +168,10 @@
 					else
 						var/datum/reagent/empty_reagent = SSchemistry.chemical_reagents[reagent_id]
 						balloon_alert(user, "\the [src] doesn't have enough [empty_reagent.name]!")
-					return
+					return ITEM_INTERACT_FAILURE
 				if(BORGHYPO_STATUS_NORECIPE)
 					balloon_alert(user, "recipe '[selected_recipe_id]' not found!")
-					return
+					return ITEM_INTERACT_FAILURE
 				else
 					if(is_dispensing_recipe)
 						balloon_alert(user, "recipe '[selected_recipe_id]' injected into \the [M].")
@@ -179,7 +179,8 @@
 					else
 						balloon_alert(user, "[amount_to_add] units injected into \the [M].")
 						balloon_alert(M, "you feel a tiny prick!")
-	return
+					return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user) //Change the mode
 	. = ..(user)
@@ -397,7 +398,7 @@
 		REAGENT_ID_WHISKEY)
 
 /obj/item/reagent_containers/borghypo/service/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
-	return
+	return NONE
 
 /obj/item/reagent_containers/borghypo/service/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -126,7 +126,7 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/reagent_containers/borghypo/attack(var/mob/living/M, var/mob/user)
+/obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!istype(M))
 		return
 
@@ -396,7 +396,7 @@
 		REAGENT_ID_WATERMELONJUICE,
 		REAGENT_ID_WHISKEY)
 
-/obj/item/reagent_containers/borghypo/service/attack(var/mob/M, var/mob/user)
+/obj/item/reagent_containers/borghypo/service/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	return
 
 /obj/item/reagent_containers/borghypo/service/afterattack(var/obj/target, var/mob/user, var/proximity)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -73,9 +73,9 @@
 		return attempt_snake_milking(user, M)
 
 	if(standard_feed_mob(user, M))
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	return 0
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/reagent_containers/glass/standard_feed_mob(var/mob/user, var/mob/target)
 	if(user.a_intent == I_HURT)
@@ -99,16 +99,16 @@
 
 	if(!reagent || !amount)
 		to_chat(user, span_warning("[target] does not have venom you can express. Open the beaker to drink from it."))
-		return TRUE
+		return ITEM_INTERACT_FAILURE
 
 	if(TIMER_COOLDOWN_RUNNING(target, COOLDOWN_VENOM_MILKING))
 		user.visible_message(span_warning("[user] attempts to express venom from [target], but nothing happens."), span_warning("[target] had their venom expressed too recently, try again later."))
-		return TRUE
+		return ITEM_INTERACT_FAILURE
 
 	TIMER_COOLDOWN_START(target, COOLDOWN_VENOM_MILKING, 30 SECONDS)
 	user.visible_message(span_notice("[user] expresses venom from [target]."))
 	reagents.add_reagent(reagent, amount)
-	return TRUE
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/reagent_containers/glass/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!proximity || !is_open_container()) //Is the container open & are they next to whatever they're clicking?

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -64,7 +64,7 @@
 		flags |= OPENCONTAINER
 	update_icon()
 
-/obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/glass/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(force && !(flags & NOBLUDGEON) && user.a_intent == I_HURT)
 		return	..()
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -29,7 +29,7 @@
 				reagents.add_reagent(r, filled_reagents[r])
 	update_icon()
 
-/obj/item/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!reagents.total_volume)
 		balloon_alert(user, "\the [src] is empty.")
 		return

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -32,43 +32,39 @@
 /obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!reagents.total_volume)
 		balloon_alert(user, "\the [src] is empty.")
-		return
-	if (!istype(M))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(!M.consume_liquid_belly)
 		if(liquid_belly_check())
 			to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] take that, it contains something produced from a belly!"))
-			return FALSE
+			return ITEM_INTERACT_FAILURE
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
 		if(!affected)
 			balloon_alert(user, "\the [H] is missing that limb!")
-			return
+			return ITEM_INTERACT_FAILURE
 		/* since synths have oil/coolant streams now, it only makes sense that you should be able to inject stuff. preserved for posterity.
 		else if(affected.robotic >= ORGAN_ROBOT)
 			to_chat(user, span_danger("You cannot inject a robotic limb."))
 			return
 		*/
 
-		//VOREStation Add Start - Adds Prototype Hypo functionality
 		if(H != user && prototype)
 			balloon_alert(user, "injecting [H] with \the [src]")
 			balloon_alert(H, "[user] is trying to inject you with \the [src]")
 			if(!do_after(user, 3 SECONDS, target = H))
-				return
-		//VOREstation Add End
+				return ITEM_INTERACT_FAILURE
 		else if(!H.stat && !prototype)
 			if(H != user)
 				if(H.a_intent != I_HELP)
 					balloon_alert(user, "[H] resists your attempt to inject them with \the [src].")
 					balloon_alert(H, "[user] is trying to inject you with \the [src]")
 					if(!do_after(user, 3 SECONDS, target = H))
-						return
+						return ITEM_INTERACT_FAILURE
 
 	do_injection(H, user)
-	return
+	return ITEM_INTERACT_SUCCESS
 
 // This does the actual injection and transfer.
 /obj/item/reagent_containers/hypospray/proc/do_injection(mob/living/carbon/human/H, mob/living/user)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -28,41 +28,41 @@
 			var/obj/item/organ/external/affecting = H.get_organ(check_zone(L.zone_sel.selecting))
 			if(!affecting)
 				to_chat(user, span_warning("The limb is missing!"))
-				return
+				return ITEM_INTERACT_FAILURE
 			if(affecting.status >= ORGAN_ROBOT)
 				to_chat(user, span_notice("\The [src] won't work on a robotic limb!"))
-				return
+				return ITEM_INTERACT_FAILURE
 
 			if(!H.can_inject(user, FALSE, L.zone_sel.selecting, pierce_material))
 				to_chat(user, span_notice("\The [src] can't be applied through such a thick material!"))
-				return
+				return ITEM_INTERACT_FAILURE
 
 			to_chat(H, span_notice("\The [src] is placed on your [affecting]."))
 			M.drop_from_inventory(src) //icon update
 			if(reagents.total_volume)
 				reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)
 			qdel(src)
-			return 1
+			return ITEM_INTERACT_SUCCESS
 
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(check_zone(L.zone_sel.selecting))
 		if(!affecting)
 			to_chat(user, span_warning("The limb is missing!"))
-			return
+			return ITEM_INTERACT_FAILURE
 		if(affecting.status >= ORGAN_ROBOT)
 			to_chat(user, span_notice("\The [src] won't work on a robotic limb!"))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		if(!H.can_inject(user, FALSE, L.zone_sel.selecting, pierce_material))
 			to_chat(user, span_notice("\The [src] can't be applied through such a thick material!"))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		user.visible_message(span_warning("[user] attempts to place \the [src] onto [H]`s [affecting]."))
 
 		user.setClickCooldown(user.get_attack_speed(src))
 		if(!do_after(user, 3 SECONDS, M))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		user.drop_from_inventory(src) //icon update
 		user.visible_message(span_warning("[user] applies \the [src] to [H]."))
@@ -77,6 +77,6 @@
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_TOUCH)	//CHEM_TOUCH
 		qdel(src)
 
-		return 1
+		return ITEM_INTERACT_SUCCESS
 
-	return 0
+	return ITEM_INTERACT_FAILURE

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -19,7 +19,7 @@
 
 	var/pierce_material = FALSE	// If true, the patch can be used through thick material.
 
-/obj/item/reagent_containers/pill/patch/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/pill/patch/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/mob/living/L = user
 
 	if(M == L)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -22,7 +22,7 @@
 	if(!icon_state)
 		icon_state = "[base_state][rand(1, 4)]" //preset pills only use colour changing or unique icons
 
-/obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/pill/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(!M.consume_liquid_belly)
 		if(liquid_belly_check())
 			to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!"))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -26,41 +26,41 @@
 	if(!M.consume_liquid_belly)
 		if(liquid_belly_check())
 			to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!"))
-			return FALSE
+			return ITEM_INTERACT_FAILURE
 	if(M == user)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(!H.check_has_mouth())
 				to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
-				return
+				return ITEM_INTERACT_FAILURE
 			var/obj/item/blocked = H.check_mouth_coverage()
 			if(blocked)
 				balloon_alert(user, "\the [blocked] is in the way!")
-				return
+				return ITEM_INTERACT_FAILURE
 
 			balloon_alert(user, "swallowed \the [src]")
 			M.drop_from_inventory(src) //icon update
 			if(reagents.total_volume)
 				reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 			qdel(src)
-			return 1
+			return ITEM_INTERACT_SUCCESS
 
 	else if(ishuman(M))
 
 		var/mob/living/carbon/human/H = M
 		if(!H.check_has_mouth())
 			balloon_alert(user, "\the [H] doesn't have a mouth.")
-			return
+			return ITEM_INTERACT_FAILURE
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if(blocked)
 			balloon_alert(user, "\the [blocked] is in the way!")
-			return
+			return ITEM_INTERACT_FAILURE
 
 		user.balloon_alert_visible("[user] attempts to force [M] to swallow \the [src].")
 
 		user.setClickCooldown(user.get_attack_speed(src))
 		if(!do_after(user, 3 SECONDS, M))
-			return
+			return ITEM_INTERACT_FAILURE
 
 		user.drop_from_inventory(src) //icon update
 		user.balloon_alert_visible("[user] forces [M] to swallow \the [src].")
@@ -72,9 +72,9 @@
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
 
-		return 1
+		return ITEM_INTERACT_SUCCESS
 
-	return 0
+	return ITEM_INTERACT_FAILURE
 
 /obj/item/reagent_containers/pill/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/resleeving/implant.dm
+++ b/code/modules/resleeving/implant.dm
@@ -109,7 +109,7 @@
 		else
 			to_chat(user, span_warning("\The [src] is already full!"))
 
-/obj/item/backup_implanter/attack(mob/M as mob, mob/user as mob)
+/obj/item/backup_implanter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!istype(M, /mob/living/carbon))
 		return
 	if (user && imps.len)

--- a/code/modules/resleeving/implant.dm
+++ b/code/modules/resleeving/implant.dm
@@ -111,8 +111,8 @@
 
 /obj/item/backup_implanter/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if (!istype(M, /mob/living/carbon))
-		return
-	if (user && imps.len)
+		return ITEM_INTERACT_FAILURE
+	if(user && imps.len)
 		M.visible_message(span_notice("[user] is injecting a backup implant into [M]."))
 
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
@@ -130,6 +130,7 @@
 					add_attack_logs(user,M,"Implanted backup implant")
 
 				update()
+		return ITEM_INTERACT_SUCCESS
 
 //The glass case for the implant
 /obj/item/implantcase/backup

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -261,13 +261,12 @@
 	if(active)
 		var/list/covered_turfs = get_shielded_turfs()
 		var/turf/T = get_turf(src)
-		var/obj/effect/energy_field/E
 		if(T in covered_turfs)
 			covered_turfs.Remove(T)
 		for(var/turf/O in covered_turfs)
 			if(locate(/obj/effect/energy_field, O) || locate(/obj/machinery/pointdefense, orange(2, O)))
 				continue
-			E = new(O, src)
+			new /obj/effect/energy_field(O, src)
 
 /obj/machinery/shield_gen/update_icon()
 	if(stat & BROKEN)

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -228,6 +228,7 @@
 
 /obj/item/card/id/centcom/station/fluff/joanbadge/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
+	return ITEM_INTERACT_SUCCESS
 
 //JoanRisu:Joan Risu
 /obj/item/pda/heads/hos/joanpda
@@ -298,7 +299,7 @@
 
 /obj/item/flag/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
-
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/flag/federation
 	name = "Federation Banner"
@@ -868,6 +869,7 @@
 	user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face with an insistent huff."),span_danger("You invade [M]'s personal space, thrusting [src] into their face with an insistent huff."))
 	user.do_attack_animation(M)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/clothing/accessory/badge/holo/detective/ruda/attack_self(mob/user)
 	. = ..(user)
@@ -912,8 +914,10 @@
 			var/mob/living/carbon/human/H = user
 			H.monkeyize()
 			qdel(src) //One time use.
+			return ITEM_INTERACT_SUCCESS
 	else //If not, do nothing.
 		to_chat(user, span_warning("You are unable to inject other people."))
+		return ITEM_INTERACT_FAILURE
 
 /obj/item/fluff/injector/numb_bite
 	name = "Numbing Venom Injector"
@@ -926,8 +930,10 @@
 			var/mob/living/carbon/human/H = user
 			H.species.give_numbing_bite() //This was annoying, but this is the easiest way of performing it.
 			qdel(src) //One time use.
+			return ITEM_INTERACT_SUCCESS
 	else //If not, do nothing.
 		to_chat(user, span_warning("You are unable to inject other people."))
+		return ITEM_INTERACT_FAILURE
 
 //For 2 handed fluff weapons.
 /obj/item/material/twohanded/fluff //Twohanded fluff items.

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -226,9 +226,8 @@
 	if(isliving(user))
 		user.visible_message(span_warning("[user] flashes their golden security badge.\nIt reads:NT Security."),span_warning("You display the faded badge.\nIt reads: NT Security."))
 
-/obj/item/card/id/centcom/station/fluff/joanbadge/attack(mob/living/carbon/human/M, mob/living/user)
-	if(isliving(user))
-		user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
+/obj/item/card/id/centcom/station/fluff/joanbadge/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
 
 //JoanRisu:Joan Risu
 /obj/item/pda/heads/hos/joanpda
@@ -297,9 +296,8 @@
 	if(isliving(user))
 		user.visible_message(span_warning("[user] waves their Banner around!"),span_warning("You wave your Banner around."))
 
-/obj/item/flag/attack(mob/living/carbon/human/M, mob/living/user)
-	if(isliving(user))
-		user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
+/obj/item/flag/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	user.visible_message(span_warning("[user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning("You invade [M]'s personal space, thrusting [src] into their face insistently."))
 
 
 /obj/item/flag/federation
@@ -866,11 +864,10 @@
 	//slot_flags = SLOT_TIE | SLOT_BELT
 	fluff_badge = TRUE
 
-/obj/item/clothing/accessory/badge/holo/detective/ruda/attack(mob/living/carbon/human/M, mob/living/user)
-	if(isliving(user))
-		user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face with an insistent huff."),span_danger("You invade [M]'s personal space, thrusting [src] into their face with an insistent huff."))
-		user.do_attack_animation(M)
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
+/obj/item/clothing/accessory/badge/holo/detective/ruda/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	user.visible_message(span_danger("[user] invades [M]'s personal space, thrusting [src] into their face with an insistent huff."),span_danger("You invade [M]'s personal space, thrusting [src] into their face with an insistent huff."))
+	user.do_attack_animation(M)
+	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
 
 /obj/item/clothing/accessory/badge/holo/detective/ruda/attack_self(mob/user)
 	. = ..(user)
@@ -908,7 +905,7 @@
 	name = "Lesser Form Injector"
 	desc = "Turn the user into their lesser, more primal form."
 
-/obj/item/fluff/injector/monkey/attack(mob/living/M, mob/living/user)
+/obj/item/fluff/injector/monkey/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(user == M) //Is the person using it on theirself?
 		if(ishuman(M)) //If so, monkify them.
@@ -922,7 +919,7 @@
 	name = "Numbing Venom Injector"
 	desc = "Injects the user with a high dose of some type of chemical, causing any chemical glands they have to kick into overdrive and create the production of a numbing enzyme that is injected via bites.."
 
-/obj/item/fluff/injector/numb_bite/attack(mob/living/M, mob/living/user)
+/obj/item/fluff/injector/numb_bite/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(user == M) //Is the person using it on theirself?
 		if(ishuman(M)) //Give them numbing bites.

--- a/code/modules/vore/resizing/crackers.dm
+++ b/code/modules/vore/resizing/crackers.dm
@@ -51,8 +51,8 @@
 					"What do you call a cow with no legs? Ground Beef.",
 					"Why'd the scarecrow win the Nobel prize? He was outstanding in his field.")
 
-/obj/item/cracker/attack(atom/A, mob/living/user, adjacent, params)
-	var/mob/living/carbon/human/target = A
+/obj/item/cracker/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	var/mob/living/carbon/human/target = M
 	if(!istype(target))
 		return
 	if(target.stat)
@@ -64,9 +64,6 @@
 	var/check_pull = tgui_alert(target, "\The [user] is offering to pull \the [src] with you, do you want to pull it?", "Pull Cracker", list("Yes", "No"))
 	if(!check_pull || check_pull == "No")
 		to_chat(user, span_notice("\The [target] chose not to pull \the [src]!"))
-		return
-	if(!adjacent)
-		to_chat(user, span_notice("\The [target] is not standing close enough to pull \the [src]!"))
 		return
 	var/obj/item/check_hand = user.get_active_hand()
 	if(check_hand != src)

--- a/code/modules/vore/resizing/crackers.dm
+++ b/code/modules/vore/resizing/crackers.dm
@@ -54,22 +54,22 @@
 /obj/item/cracker/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	var/mob/living/carbon/human/target = M
 	if(!istype(target))
-		return
+		return ITEM_INTERACT_FAILURE
 	if(target.stat)
-		return
+		return ITEM_INTERACT_FAILURE
 	if(target == user)
 		to_chat(user, span_notice("You can't pull \the [src] by yourself, that would just be sad!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	to_chat(user, span_notice("You offer \the [src] to \the [target] to pull and wait to see how whether they do."))
 	var/check_pull = tgui_alert(target, "\The [user] is offering to pull \the [src] with you, do you want to pull it?", "Pull Cracker", list("Yes", "No"))
 	if(!check_pull || check_pull == "No")
 		to_chat(user, span_notice("\The [target] chose not to pull \the [src]!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/obj/item/check_hand = user.get_active_hand()
 	if(check_hand != src)
 		to_chat(user, span_notice("\The [src] is no longer in-hand!"))
 		to_chat(target, span_notice("\The [src] is no longer in-hand!"))
-		return
+		return ITEM_INTERACT_FAILURE
 	var/mob/living/carbon/human/winner
 	var/mob/living/carbon/human/loser
 	if(!rigged)
@@ -139,6 +139,7 @@
 	var/obj/item/paper/cracker_joke/J = new(spawnloc)
 	J.info = joke
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/cracker/shrinking
 	name = "shrinking bluespace cracker"

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -160,7 +160,7 @@
 			var/mob/living/M = loc // TGMC Ammo HUD
 			if(istype(M)) // TGMC Ammo HUD
 				M?.hud_used.update_ammo_hud(M, src)
-			return
+			return ITEM_INTERACT_SUCCESS
 		else
 			return ..()
 	else

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -151,7 +151,7 @@
 	else
 		return ..()
 
-/obj/item/gun/energy/sizegun/attack(atom/A, mob/living/user, adjacent, params)
+/obj/item/gun/energy/sizegun/attack(mob/living/A, mob/living/user, target_zone, attack_modifier)
 	if(backfire)
 		if(prob(50))
 			to_chat(user, span_notice("\The [src] backfires and consumes its entire charge!"))

--- a/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
+++ b/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
@@ -106,7 +106,7 @@
 		user.Weaken(5)
 		throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,10),5)
 		user.apply_damage(rand(force/2, force), BURN, zone, FALSE)
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	..() //We hit them!
 
@@ -150,7 +150,7 @@
 		playsound(src, spooky, 50, 1)
 
 	force = prior_force //Return our force back.
-	return 1
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/melee/artifact_blade/pickup(mob/living/user as mob)
 	// We check to see if the person picking us up isn't our owner, not a cultist, and they're human.

--- a/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
+++ b/code/modules/xenoarcheaology/finds/Weapons/archeo_melee.dm
@@ -86,7 +86,7 @@
 /obj/item/melee/artifact_blade/cultify()
 	return
 
-/obj/item/melee/artifact_blade/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/melee/artifact_blade/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(M == user) //No accidentally hitting yourself and exploding.
 		return
 	var/zone = (user.hand ? BP_L_ARM:BP_R_ARM) //Which arm we're in!

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -255,3 +255,4 @@
 
 	if(inserted_battery?.battery_effect)
 		add_attack_logs(user,M,"Anobattery tap ([inserted_battery?.battery_effect?.name])")
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -241,9 +241,7 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
-	if (!istype(M))
-		return
+/obj/item/anodevice/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 
 	if(activated && inserted_battery?.battery_effect?.effect == EFFECT_TOUCH && !isnull(inserted_battery))
 		inserted_battery?.battery_effect?.DoEffectTouch(M)
@@ -253,7 +251,6 @@
 		user.visible_message(span_blue("[user] taps [M] with [src], but nothing happens."))
 
 	//admin logging
-	user.lastattacked = M
 	M.lastattacker = user
 
 	if(inserted_battery?.battery_effect)

--- a/code/modules/xenobio/items/slimepotions.dm
+++ b/code/modules/xenobio/items/slimepotions.dm
@@ -37,6 +37,7 @@
 	xenobio_slime.mutation_chance = between(0, xenobio_slime.mutation_chance - 15, 100)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // The opposite, makes the slime more likely to mutate.
@@ -63,6 +64,7 @@
 	xenobio_slime.mutation_chance = between(0, xenobio_slime.mutation_chance + 12, 100)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // Makes the slime friendly forever.
@@ -85,7 +87,7 @@
 		return
 	if(currently_using)
 		to_chat(user, span_warning("This agent has already been used!")) // Possibly trying to cheese the dialogue box and use same potion on multiple targets.
-		return
+		return ITEM_INTERACT_FAILURE
 
 	currently_using = TRUE
 	var/datum/ai_holder/AI = M.ai_holder
@@ -127,6 +129,7 @@
 		M.name = newname
 		M.real_name = newname
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // Makes slimes make more extracts.
@@ -157,6 +160,7 @@
 	xenobio_slime.cores++
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // Makes slimes not try to murder other slime colors.
@@ -186,6 +190,7 @@
 	xenobio_slime.unify()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 // Makes slimes not kill (most) humanoids but still fight spiders/carp/bears/etc.
 /obj/item/slimepotion/loyalty
@@ -224,6 +229,7 @@
 		slime.update_mood() //Makes them drop-nomable.
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // User befriends the slime with this.
@@ -261,6 +267,7 @@
 	AI.remove_target() // So hostile things stop attacking people even if not hostile anymore.
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 
 // Feeds the slime instantly.
@@ -287,3 +294,4 @@
 	xenobio_slime.reproduce()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/xenobio/items/slimepotions.dm
+++ b/code/modules/xenobio/items/slimepotions.dm
@@ -20,19 +20,21 @@
 	icon_state = "potcyan"
 	description_info = "The slime needs to be alive for this to work.  It will reduce the chances of mutation by 15%."
 
-/obj/item/slimepotion/stabilizer/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
+/obj/item/slimepotion/stabilizer/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
 		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.mutation_chance == 0)
+	if(xenobio_slime.mutation_chance == 0)
 		to_chat(user, span_warning("The slime already has no chance of mutating!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the stabilizer. It is now less likely to mutate."))
-	M.mutation_chance = between(0, M.mutation_chance - 15, 100)
+	xenobio_slime.mutation_chance = between(0, xenobio_slime.mutation_chance - 15, 100)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -44,19 +46,21 @@
 	description_info = "The slime needs to be alive for this to work.  It will increase the chances of mutation by 12%."
 	icon_state = "potred"
 
-/obj/item/slimepotion/mutator/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The mutator only works on slimes!"))
+/obj/item/slimepotion/mutator/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.mutation_chance == 100)
+	if(xenobio_slime.mutation_chance == 100)
 		to_chat(user, span_warning("The slime is already guaranteed to mutate!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the mutator. It is now more likely to mutate."))
-	M.mutation_chance = between(0, M.mutation_chance + 12, 100)
+	xenobio_slime.mutation_chance = between(0, xenobio_slime.mutation_chance + 12, 100)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -69,8 +73,8 @@
 	description_info = "The target needs to be alive, not already passive, and be an animal or slime type entity."
 	var/currently_using = FALSE						// To avoid same potion being usable multiple times
 
-/obj/item/slimepotion/docility/attack(mob/living/simple_mob/M, mob/user)
-	if(!istype(M))
+/obj/item/slimepotion/docility/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob))
 		to_chat(user, span_warning("The agent only works on creatures!"))
 		return ..()
 	if(M.stat == DEAD)
@@ -133,22 +137,24 @@
 	Extra extracts are not passed down to offspring when reproducing."
 	icon_state = "potpurple"
 
-/obj/item/slimepotion/steroid/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The steroid only works on slimes!"))
+/obj/item/slimepotion/steroid/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.is_adult) //Can't steroidify adults
+	if(xenobio_slime.is_adult) //Can't steroidify adults
 		to_chat(user, span_warning("Only baby slimes can use the steroid!"))
 		return ..()
-	if(M.cores >= 5)
+	if(xenobio_slime.cores >= 5)
 		to_chat(user, span_warning("The slime already has the maximum amount of extract!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the steroid. It will now produce one more extract."))
-	M.cores++
+	xenobio_slime.cores++
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -161,21 +167,23 @@
 	carry over to offspring when reproducing."
 	icon_state = "potpink"
 
-/obj/item/slimepotion/unity/attack(mob/living/simple_mob/slime/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/unity/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.unity == TRUE)
+	if(xenobio_slime.unity == TRUE)
 		to_chat(user, span_warning("The slime is already unified!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the agent. It will now be friendly to all other slimes."))
-	to_chat(M, span_notice("\The [user] feeds you \the [src], and you suspect that all the other slimes will be \
+	to_chat(xenobio_slime, span_notice("\The [user] feeds you \the [src], and you suspect that all the other slimes will be \
 	your friends, at least if you don't attack them first."))
-	M.unify()
+	xenobio_slime.unify()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -187,10 +195,11 @@
 	the user's faction, which means the slime will attack things that are hostile to the user's faction, such as carp, spiders, and other slimes."
 	icon_state = "potlightpink"
 
-/obj/item/slimepotion/loyalty/attack(mob/living/simple_mob/M, mob/user)
-	if(!istype(M))
+/obj/item/slimepotion/loyalty/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob))
 		to_chat(user, span_warning("The agent only works on creatures!"))
 		return ..()
+
 	if(!(M.mob_class & (MOB_CLASS_SLIME|MOB_CLASS_ANIMAL))) // So you can't use this on Russians/syndies/hivebots/etc.
 		to_chat(user, span_warning("\The [M] only works on slimes and animals."))
 		return ..()
@@ -225,28 +234,30 @@
 	their 'friend', and will never attack them.  This might also work on other things besides slimes."
 	icon_state = "potlightpink"
 
-/obj/item/slimepotion/friendship/attack(mob/living/simple_mob/M, mob/user)
-	if(!istype(M))
+/obj/item/slimepotion/friendship/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob))
 		to_chat(user, span_warning("The agent only works on creatures!"))
 		return ..()
-	if(!(M.mob_class & (MOB_CLASS_SLIME|MOB_CLASS_ANIMAL))) // So you can't use this on Russians/syndies/hivebots/etc.
+	var/mob/living/simple_mob/SM = M
+
+	if(!(SM.mob_class & (MOB_CLASS_SLIME|MOB_CLASS_ANIMAL))) // So you can't use this on Russians/syndies/hivebots/etc.
 		to_chat(user, span_warning("\The [M] only works on slimes and animals."))
 		return ..()
-	if(M.stat == DEAD)
+	if(SM.stat == DEAD)
 		to_chat(user, span_warning("\The [M] is dead!"))
 		return ..()
-	if(user in M.friends)
+	if(user in SM.friends)
 		to_chat(user, span_warning("\The [M] is already loyal to you!"))
 		return ..()
-	if(!M.has_AI())
+	if(!SM.has_AI())
 		to_chat(user, span_warning("\The [M] is too strong-willed for this to affect them."))
 		return ..()
 
-	var/datum/ai_holder/AI = M.ai_holder
+	var/datum/ai_holder/AI = SM.ai_holder
 
-	to_chat(user, span_notice("You feed \the [M] the agent. It will now be your best friend."))
-	to_chat(M, span_notice("\The [user] feeds you \the [src], and feel that \the [user] wants to be best friends with you."))
-	M.friends.Add(user)
+	to_chat(user, span_notice("You feed \the [SM] the agent. It will now be your best friend."))
+	to_chat(SM, span_notice("\The [user] feeds you \the [src], and feel that \the [user] wants to be best friends with you."))
+	SM.friends.Add(user)
 	AI.remove_target() // So hostile things stop attacking people even if not hostile anymore.
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
@@ -259,18 +270,20 @@
 	description_info = "The slime needs to be alive for this to work.  It will instantly grow the slime enough to reproduce."
 	icon_state = "potorange"
 
-/obj/item/slimepotion/feeding/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The feeding agent only works on slimes!"))
+/obj/item/slimepotion/feeding/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the feeding agent. It will now instantly reproduce."))
-	M.amount_grown = 10
-	M.make_adult()
-	M.amount_grown = 10
-	M.reproduce()
+	xenobio_slime.amount_grown = 10
+	xenobio_slime.make_adult()
+	xenobio_slime.amount_grown = 10
+	xenobio_slime.reproduce()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)

--- a/code/modules/xenobio/items/slimepotions_vr.dm
+++ b/code/modules/xenobio/items/slimepotions_vr.dm
@@ -31,6 +31,7 @@
 	xenobio_slime.split_amount = between(2, xenobio_slime.split_amount - 2, 6)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/fertility
 	name = "slime fertility agent"
@@ -55,6 +56,7 @@
 	xenobio_slime.split_amount = between(2, xenobio_slime.split_amount + 2, 6)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/shrink
 	name = "slime shrinking agent"
@@ -79,6 +81,7 @@
 	xenobio_slime.make_baby()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/death
 	name = "slime death agent"
@@ -100,6 +103,7 @@
 	xenobio_slime.adjustToxLoss(500)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/ferality
 	name = "slime ferality agent"
@@ -125,6 +129,7 @@
 	xenobio_slime.untamable_inheirit = TRUE
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/reinvigoration
 	name = "extract reinvigoration agent"
@@ -148,7 +153,7 @@
 		s.start()
 		qdel(M)
 		qdel(src)
-		return
+		return ITEM_INTERACT_SUCCESS
 	..()
 
 /obj/item/slimepotion/sapience
@@ -182,6 +187,7 @@
 	log_and_message_admins("used a sapience potion on a simple mob: [xenobio_slime]. [ADMIN_FLW(src)]", user)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/slimepotion/obedience
 	name = "slime obedience agent"
@@ -207,3 +213,4 @@
 		AI.obedience = 10
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/xenobio/items/slimepotions_vr.dm
+++ b/code/modules/xenobio/items/slimepotions_vr.dm
@@ -14,19 +14,21 @@
 	icon_state = "potpurple"
 	description_info = "The slime needs to be alive for this to work. It will reduce the amount of slime babies by 2 (to minimum of 2)."
 
-/obj/item/slimepotion/infertility/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/infertility/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.split_amount <= 2)
+	if(xenobio_slime.split_amount <= 2)
 		to_chat(user, span_warning("The slime cannot get any less fertile!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the infertility agent. It will now have less offspring."))
-	M.split_amount = between(2, M.split_amount - 2, 6)
+	xenobio_slime.split_amount = between(2, xenobio_slime.split_amount - 2, 6)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -36,19 +38,21 @@
 	icon_state = "potpurple"
 	description_info = "The slime needs to be alive for this to work. It will increase the amount of slime babies by 2 (to maximum of 6)."
 
-/obj/item/slimepotion/fertility/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/fertility/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(M.split_amount >= 6)
+	if(xenobio_slime.split_amount >= 6)
 		to_chat(user, span_warning("The slime cannot get any more fertile!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the fertility agent. It will now have more offspring."))
-	M.split_amount = between(2, M.split_amount + 2, 6)
+	xenobio_slime.split_amount = between(2, xenobio_slime.split_amount + 2, 6)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -58,19 +62,21 @@
 	icon_state = "potpurple"
 	description_info = "The slime needs to be alive for this to work."
 
-/obj/item/slimepotion/shrink/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/shrink/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
-	if(!(M.is_adult))
+	if(!(xenobio_slime.is_adult))
 		to_chat(user, span_warning("The slime is already a baby!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the shrinking agent. It is now back to being a baby."))
-	M.make_baby()
+	xenobio_slime.make_baby()
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -80,16 +86,18 @@
 	icon_state = "potblue"
 	description_info = "The slime needs to be alive for this to work."
 
-/obj/item/slimepotion/death/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/death/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is already dead!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the death agent. Its face flashes pain of betrayal before it goes still."))
-	M.adjustToxLoss(500)
+	xenobio_slime.adjustToxLoss(500)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -99,20 +107,22 @@
 	icon_state = "potred"
 	description_info = "The slime needs to be alive for this to work."
 
-/obj/item/slimepotion/ferality/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/ferality/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is already dead!"))
 		return ..()
-	if(M.untamable && M.untamable_inheirit)
+	if(xenobio_slime.untamable && xenobio_slime.untamable_inheirit)
 		to_chat(user, span_warning("The slime is already untamable!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the death agent. It will now only get angrier at taming attempts."))
-	M.untamable = TRUE
-	M.untamable_inheirit = TRUE
+	xenobio_slime.untamable = TRUE
+	xenobio_slime.untamable_inheirit = TRUE
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -128,15 +138,15 @@
 	icon_state = "potsilver"
 	description_info = "Warning: avoid combining multiple doses of mimic agent."
 
-/obj/item/slimepotion/mimic/attackby(obj/item/O, mob/user)
-	if(istype(O, /obj/item/slimepotion/mimic))
+/obj/item/slimepotion/mimic/attackby(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(istype(M, /obj/item/slimepotion/mimic))
 		to_chat(user, span_warning("You apply the mimic to the mimic, resulting a mimic that copies a mimic that copies a mimic that copies a mimic that-"))
 		var/location = get_turf(src)
 		playsound(location, 'sound/weapons/gauss_shoot.ogg', 50, 1)
 		var/datum/effect/effect/system/grav_pull/s = new /datum/effect/effect/system/grav_pull
 		s.set_up(3, 3, location)
 		s.start()
-		qdel(O)
+		qdel(M)
 		qdel(src)
 		return
 	..()
@@ -147,27 +157,29 @@
 	description_info = "The slime or other animal needs to be alive for this to work. The development is not always immedeate and may take indeterminate time before effects show."
 	icon_state = "potblue"
 
-/obj/item/slimepotion/sapience/attack(mob/living/simple_mob/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on creatures!"))
+/obj/item/slimepotion/sapience/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The creature is dead!"))
 		return ..()
-	if(M.ghostjoin)
+	if(xenobio_slime.ghostjoin)
 		to_chat(user, span_warning("The creature is already developing sapience."))
 		return ..()
-	if(M.ckey)
+	if(xenobio_slime.ckey)
 		to_chat(user, span_warning("The creature is already sapient!"))
 		return ..()
 
-	to_chat(user, span_notice("You feed \the [M] the agent. It may now eventually develop proper sapience."))
-	M.ghostjoin = 1
-	GLOB.active_ghost_pods |= M
-	if(!M.vore_active)
-		add_verb(M, /mob/living/simple_mob/proc/animal_nom)
-	M.ghostjoin_icon()
-	log_and_message_admins("used a sapience potion on a simple mob: [M]. [ADMIN_FLW(src)]", user)
+	to_chat(user, span_notice("You feed \the [xenobio_slime] the agent. It may now eventually develop proper sapience."))
+	xenobio_slime.ghostjoin = 1
+	GLOB.active_ghost_pods |= xenobio_slime
+	if(!xenobio_slime.vore_active)
+		add_verb(xenobio_slime, /mob/living/simple_mob/proc/animal_nom)
+	xenobio_slime.ghostjoin_icon()
+	log_and_message_admins("used a sapience potion on a simple mob: [xenobio_slime]. [ADMIN_FLW(src)]", user)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 	qdel(src)
 
@@ -177,18 +189,20 @@
 	icon_state = "potlightpink"
 	description_info = "The target needs to be alive and currently misbehaving. Effect is equivalent to very strong discipline."
 
-/obj/item/slimepotion/obedience/attack(mob/living/simple_mob/slime/xenobio/M, mob/user)
-	if(!istype(M))
-		to_chat(user, span_warning("The agent only works on slimes!"))
+/obj/item/slimepotion/obedience/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(!istype(M, /mob/living/simple_mob/slime/xenobio))
+		to_chat(user, span_warning("The stabilizer only works on slimes!"))
 		return ..()
-	if(M.stat == DEAD)
+	var/mob/living/simple_mob/slime/xenobio/xenobio_slime = M
+
+	if(xenobio_slime.stat == DEAD)
 		to_chat(user, span_warning("The slime is dead!"))
 		return ..()
 
 	to_chat(user, span_notice("You feed the slime the agent. It has been disciplined, for better or worse..."))
-	var/justified = M.is_justified_to_discipline()
-	M.adjust_discipline(10)
-	var/datum/ai_holder/simple_mob/xenobio_slime/AI = M.ai_holder
+	var/justified = xenobio_slime.is_justified_to_discipline()
+	xenobio_slime.adjust_discipline(10)
+	var/datum/ai_holder/simple_mob/xenobio_slime/AI = xenobio_slime.ai_holder
 	if(istype(AI) && justified)
 		AI.obedience = 10
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)

--- a/code/modules/xenobio/items/weapons.dm
+++ b/code/modules/xenobio/items/weapons.dm
@@ -10,18 +10,18 @@
 	hitcost = 48	//Less zap for less cost
 	description_info = "This baton will stun a slime or other slime-based lifeform for about five seconds, if hit with it while on."
 
-/obj/item/melee/baton/slime/attack(mob/living/L, mob/user, hit_zone)
-	if(istype(L) && status) // Is it on?
-		if(L.mob_class & MOB_CLASS_SLIME) // Are they some kind of slime? (Prommies might pass this check someday).
-			if(isslime(L))
-				var/mob/living/simple_mob/slime/S = L
+/obj/item/melee/baton/slime/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
+	if(istype(M) && status) // Is it on?
+		if(M.mob_class & MOB_CLASS_SLIME) // Are they some kind of slime? (Prommies might pass this check someday).
+			if(isslime(M))
+				var/mob/living/simple_mob/slime/S = M
 				S.slimebatoned(user, 5) // Feral and xenobio slimes will react differently to this.
 			else
-				L.Weaken(5)
+				M.Weaken(5)
 
 		// Now for prommies.
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
 			if(H.species && H.species.name == SPECIES_PROMETHEAN)
 				var/agony_to_apply = 60 - agonyforce
 				H.apply_damage(agony_to_apply, HALLOSS)

--- a/code/modules/xenobio/items/weapons_vr.dm
+++ b/code/modules/xenobio/items/weapons_vr.dm
@@ -152,11 +152,11 @@
 
 /obj/item/slime_grinder/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(processing)
-		return
+		return ITEM_INTERACT_FAILURE
 	if(!can_insert(M))
 		to_chat(user, span_warning("\The [src] cannot process \the [M] at this time."))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-		return
+		return ITEM_INTERACT_FAILURE
 
 	extract(M, user)
 	return ..()

--- a/code/modules/xenobio/items/weapons_vr.dm
+++ b/code/modules/xenobio/items/weapons_vr.dm
@@ -150,7 +150,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item/slime_grinder/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/slime_grinder/attack(mob/living/M, mob/living/user, target_zone, attack_modifier)
 	if(processing)
 		return
 	if(!can_insert(M))


### PR DESCRIPTION

## About The Pull Request
Makes /attack return legal return values AND fixing the /attack proc to use sane args and not do weird shit (like PAI cable did)

Allows plastic to be drag-dropped into the autoinjector printer. This allows borgs to use it.

Fixes https://github.com/VOREStation/VOREStation/issues/19372
## Changelog
:cl: Diana
fix: Borg grippers work again
qol: You can drag-drop plastic into the autoinjector printer.
/:cl:
