### PR TITLE
Fixes gripper sheet interactions

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -170,7 +170,7 @@
 		if(material_belt.selected_item == O)
 			return TRUE
 	for(var/obj/item/gripper/gripper in contents)
-		if(gripper.current_pocket == O)
+		if(gripper.current_pocket == O || (O in gripper.current_pocket.contents))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION

## About The Pull Request
Fixes grippers to be able to use material sheets they are holding.
## Changelog
:cl: Diana
fix: Borgs can use material sheets in their grippers once again.
/:cl:
