### PR TITLE
Some bugfixes

### DIFF
--- a/code/game/machinery/partslathe_vr.dm
+++ b/code/game/machinery/partslathe_vr.dm
@@ -344,10 +344,10 @@
 /obj/machinery/partslathe/proc/update_recipe_list()
 	if(!partslathe_recipies)
 		partslathe_recipies = list()
-		var/list/paths = subtypesof(/obj/item/stock_parts)
+		var/list/paths = subtypesof(/obj/item/stock_parts) - subtypesof(/obj/item/stock_parts/subspace)
 		for(var/type in paths)
 			var/obj/item/stock_parts/I = new type()
-			if(!I.matter)
+			if(!I.matter || I.rating > 1)
 				qdel(I)
 				continue // Ignore parts we can't build
 

--- a/code/game/machinery/partslathe_vr.dm
+++ b/code/game/machinery/partslathe_vr.dm
@@ -344,7 +344,7 @@
 /obj/machinery/partslathe/proc/update_recipe_list()
 	if(!partslathe_recipies)
 		partslathe_recipies = list()
-		var/list/paths = subtypesof(/obj/item/stock_parts) - subtypesof(/obj/item/stock_parts/subspace)
+		var/list/paths = subtypesof(/obj/item/stock_parts) - typesof(/obj/item/stock_parts/subspace)
 		for(var/type in paths)
 			var/obj/item/stock_parts/I = new type()
 			if(!I.matter || I.rating > 1)

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_BOILERPLATE(all_mops, /obj/item/mop)
 
 		user.visible_message(span_warning("[user] begins to clean \the [get_turf(A)]."))
 
-		if(do_after(user, mop_time, target = src, max_interact_count = 9))
+		if(do_after(user, mop_time, target = A))
 			var/turf/T = get_turf(A)
 			if(T)
 				T.wash(CLEAN_SCRUB)

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_BOILERPLATE(all_mops, /obj/item/mop)
 
 		user.visible_message(span_warning("[user] begins to clean \the [get_turf(A)]."))
 
-		if(do_after(user, mop_time, target = A))
+		if(do_after(user, mop_time, target = get_turf(A)))
 			var/turf/T = get_turf(A)
 			if(T)
 				T.wash(CLEAN_SCRUB)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -71,7 +71,7 @@
 
 /obj/item/clothing/click_alt(mob/user)
 	if(Adjacent(user) || user == src.loc)
-		removetie_verb(user)
+		removetie_proc(user)
 
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(mob/M, slot, disable_warning = FALSE, ignore_obstruction, go_over_slot)

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -115,13 +115,14 @@
 	for(var/obj/item/clothing/accessory/A in accessories)
 		slowdown += A.slowdown
 
-/obj/item/clothing/proc/removetie_verb(mob/user)
+/obj/item/clothing/proc/removetie_verb()
 	set name = "Remove Accessory"
 	set category = "Object"
 	set src in usr
 
-	if(!user)
-		user = usr
+	removetie_proc(usr)
+
+/obj/item/clothing/proc/removetie_proc(mob/living/user)
 
 	if(!isliving(user))
 		return

--- a/code/modules/clothing/gloves/antagonist.dm
+++ b/code/modules/clothing/gloves/antagonist.dm
@@ -85,6 +85,6 @@
 		return 1
 
 /obj/item/clothing/gloves/sterile/thieves/Touch(var/atom/A, var/proximity)
-	if(proximity && ishuman(usr) && do_after(usr, 1 SECOND, target = A))
+	if(proximity && ishuman(usr) && && ishuman(A) && do_after(usr, 1 SECOND, target = A))
 		return pickpocket(usr, A, proximity)
 	return 0

--- a/code/modules/clothing/gloves/antagonist.dm
+++ b/code/modules/clothing/gloves/antagonist.dm
@@ -85,6 +85,6 @@
 		return 1
 
 /obj/item/clothing/gloves/sterile/thieves/Touch(var/atom/A, var/proximity)
-	if(proximity && ishuman(usr) && && ishuman(A) && do_after(usr, 1 SECOND, target = A))
+	if(proximity && ishuman(usr) && ishuman(A) && do_after(usr, 1 SECOND, target = A))
 		return pickpocket(usr, A, proximity)
 	return 0

--- a/code/modules/clothing/gloves/antagonist.dm
+++ b/code/modules/clothing/gloves/antagonist.dm
@@ -28,7 +28,7 @@
 		to_chat(target, span_warning("[user] rifles in your pockets!"))
 
 	if(user.a_intent == I_HELP)
-		if(istype(target.back,/obj/item/storage) && do_after(user, 3 SECONDS, target))
+		if(istype(target.back,/obj/item/storage) && do_after(user, 3 SECONDS, target, progress = FALSE))
 			var/obj/item/storage/Backpack = target.back
 			Backpack.open(user)
 		else if(istype(target.belt, /obj/item/storage) && do_after(user, 5 SECONDS, target))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -154,9 +154,11 @@
 
 	else if(istype(wear_mask, /obj/item/clothing/mask))
 		var/obj/item/clothing/mask/M = wear_mask
-		if(M.voicechange)
+		if(M.voicechange) //only horsemasks do this.
 			message_data[1] = pick(M.say_messages)
 			message_data[2] = pick(M.say_verbs)
+			if(istype(M, /obj/item/clothing/mask/horsehead) && prob(0.5))
+				message_data[2] = "HIIII EVERYPONY"
 			. = 1
 
 	else if((CE_SPEEDBOOST in chem_effects) || (get_jittery() >= 100 && !stuttering)) // motor mouth, check for stuttering so anxiety doesn't do hyperzine text

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1553,6 +1553,8 @@
 
 // We check for the module only here
 /mob/living/silicon/robot/proc/has_upgrade_module(var/given_type)
+	if(!module) //If we don't have a module, don't even bother.
+		return null
 	var/obj/T = locate(given_type) in module
 	if(!T)
 		T = locate(given_type) in module.contents

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -58,7 +58,8 @@
 		if(istype(A,/obj/machinery/containment_field) || istype(A,/obj/effect) || istype(A,/obj/singularity))
 			return
 		else
-			Destroy()
+			qdel(A)
+			//Destroy()
 
 /obj/machinery/containment_field/HasProximity(turf/T, datum/weakref/WF, old_loc)
 	if(isnull(WF))

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -38,6 +38,7 @@
 		connect_to_network()
 	AddElement(/datum/element/climbable)
 	AddElement(/datum/element/rotatable)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
 
 /obj/machinery/power/emitter/Destroy()
 	message_admins("Emitter deleted at ([x],[y],[z] - <A href='byond://?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -73,6 +73,7 @@
 	fields = list()
 	connected_gens = list()
 	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
 
 /obj/machinery/field_generator/process()
 	if(Varedit_start == 1)

--- a/code/modules/recycling/disposal_machines.dm
+++ b/code/modules/recycling/disposal_machines.dm
@@ -72,7 +72,7 @@
 
 // attack by item places it in to disposal
 /obj/machinery/disposal/attackby(obj/item/I, mob/user, attack_modifier, click_parameters, drag_dropped = FALSE)
-	if(stat & BROKEN || !I || !user)
+	if(stat & BROKEN || !I || !user || !istype(I))
 		return
 
 	add_fingerprint(user)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -420,6 +420,8 @@
 	if(ishuman(user))
 		to_chat(user, span_narsie(span_bolddanger("HOR-SIE HAS RISEN")))
 		var/obj/item/clothing/mask/horsehead/magichead = new /obj/item/clothing/mask/horsehead
+		magichead.say_verbs = list("neighs", "whinnys", "snorts")
+		magichead.say_messages = list("NEEEEIGH", "KEECHOOOW", "WHIIIINNNY", "NEEEEEEIGHHHH", "KEECHOOOWWW")
 		magichead.canremove = FALSE		//curses!
 		magichead.flags_inv = null	//so you can still see their face
 		magichead.voicechange = 1	//NEEEEIIGHH

--- a/code/modules/spells/targeted/equip/horsemask.dm
+++ b/code/modules/spells/targeted/equip/horsemask.dm
@@ -36,4 +36,6 @@
 		var/obj/item/clothing/mask/horsehead/magichead = new_item
 		magichead.flags_inv = null	//so you can still see their face
 		magichead.voicechange = 1	//NEEEEIIGHH
+		magichead.say_verbs = list("neighs", "whinnys", "snorts")
+		magichead.say_messages = list("NEEEEIGH", "KEECHOOOW", "WHIIIINNNY", "NEEEEEEIGHHHH", "KEECHOOOWWW")
 	return new_item


### PR DESCRIPTION

## About The Pull Request
Fixes a bug with accessories accidentally searching for nearby users.
Gives emitters and field generators EMPPROOF. Not used ATM, but if either one of them has things added, they should be EMP proof.
Fixes partslathe so it doesn't have every part.
Fixes a bug where the field gen would break and never be able to be turned off/restarted if a window or other dense object bumped into it. Instead, it just qdel's the object.
Fixes attempting to drag-drop non-item entities into disposals.
Fixes a borg module runtime
Fixes horsemask, now makes you properly neigh
Makes thieves gloves not show a interaction when using it
Fixes thieves gloves from having a 1 second do_after for EVERY click interaction
## Changelog
:cl: Diana
fix: Fixes a bug with accessories searching for nearby users.
fix: Fixes a bug where partslathe had every part.
fix: Fixes a bug where windows would delete the shield gen containment field
fix: Attempting to drop non-item entities (unintended) into disposal will no longer runtime.
fix: Fixes a borg runtime
fix: Horsemask now properly makes you neigh. Also adds an easter egg...This mask isn't ever used, so...
fix: Fixes some doafters
/:cl:
