### PR TITLE
Changes RMS material cost to require silver

### DIFF
--- a/code/modules/research/tg/designs/tool_designs.dm
+++ b/code/modules/research/tg/designs/tool_designs.dm
@@ -1208,7 +1208,7 @@
 	name = "Rapid Material Synthesizer"
 	desc = "A device used to rapidly synthesize materials."
 	id = "rms"
-	materials = list(MAT_STEEL = 62500, MAT_GLASS = 15000)
+	materials = list(MAT_STEEL = 62500, MAT_GLASS = 15000, MAT_SILVER = 7500)
 	build_path = /obj/item/rms
 	build_type = AUTOLATHE | PROTOLATHE
 	category = list(


### PR DESCRIPTION

## About The Pull Request
For a tool that's powerful and able to potentially generate every rare material given enough time once you get a stable power source, having a minor cheap material cost feels fair. Once a engine is setup, its also likely a basic mining haul should have come in.
## Changelog
:cl:
balance: RMS material cost changed.
/:cl:
