### PR TITLE
Fixes a borg gripper bug

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -437,18 +437,18 @@
 		..()
 	return
 
-/obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/stack/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/gripper))
 		var/obj/item/gripper/G = W
-		G.consolidate_stacks(src)
+		G.consolidate_stacks(src, user)
 		if(QDELETED(src))
-			return
+			return TRUE
 
 	else if(istype(W, /obj/item/stack))
 		var/obj/item/stack/S = W
 		src.transfer_to(S)
 		if(QDELETED(src))
-			return
+			return TRUE
 
 		if (S && user.check_current_machine(S))
 			S.interact(user)

--- a/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
+++ b/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
@@ -158,10 +158,10 @@
 		return
 	update_ref(WEAKREF(wrapped))
 
-	if(pick_up_item(target, user))
+	if(handle_afterattack_special(target, user))
 		return
 
-	if(handle_afterattack_special(target, user))
+	if(pick_up_item(target, user))
 		return
 
 	if(item_left_gripper(wrapped))
@@ -281,6 +281,9 @@
 			"You remove the power cell."
 		)
 
+		return TRUE
+
+	if(istype(target, /obj/item/stack) && QDELETED(target)) //We handle the special stuff above already.
 		return TRUE
 
 	return FALSE
@@ -421,13 +424,13 @@
 	return wrapped
 
 /// Consolidates material stacks by searching our pockets to see if we currently have any stacks. Done in /obj/item/stack/attackby
-/obj/item/gripper/proc/consolidate_stacks(obj/item/stack/stack_to_consolidate)
+/obj/item/gripper/proc/consolidate_stacks(obj/item/stack/stack_to_consolidate, mob/user)
 	if(!stack_to_consolidate || !istype(stack_to_consolidate, /obj/item/stack))
-		return
+		return FALSE
 
 	var/obj/item/current_item = get_wrapped_item()
 	if(current_item?.type == stack_to_consolidate.type)
-		return
+		return FALSE
 
 	for(var/obj/item/storage/internal/gripper/pocket in pockets)
 		if(!LAZYLEN(pocket.contents))
@@ -435,7 +438,8 @@
 		for(var/obj/item/stack/stack in pocket.contents)
 			if(istype(stack_to_consolidate, stack))
 				stack_to_consolidate.transfer_to(stack)
-				return
+				to_chat(user, "You collect \the [stack_to_consolidate] and consolidate it.")
+				return TRUE
 
 /obj/item/gripper/proc/grab_cell(obj/item/cell, mob/user)
 	var/obj/item/storage/internal/gripper/P = find_empty_pocket()

--- a/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
+++ b/code/modules/mob/living/silicon/robot/robot_gripper_handling.dm
@@ -143,8 +143,6 @@
 	return ..()
 
 /obj/item/gripper/afterattack(atom/target, mob/living/user, proximity, params)
-	if(!proximity)
-		return // This will prevent them using guns at range but adminbuse can add them directly to modules, so eh.
 
 	if(is_in_use(user))
 		return
@@ -154,9 +152,16 @@
 		clear_and_select_item()
 		return
 
-	if(use_item(target, user, wrapped)) //Already have an item.
+	if(!proximity && !allow_ranged_usage) //Prevents using guns or using items at range
 		return
+
+	if(use_item(target, user, wrapped, proximity, params)) //Already have an item.
+		return
+
 	update_ref(WEAKREF(wrapped))
+
+	if(!proximity && !allow_ranged_pickup)
+		return
 
 	if(handle_afterattack_special(target, user))
 		return
@@ -167,7 +172,7 @@
 	if(item_left_gripper(wrapped))
 		clear_and_select_item()
 
-/obj/item/gripper/proc/use_item(atom/target, mob/user, obj/item/wrapped)
+/obj/item/gripper/proc/use_item(atom/target, mob/user, obj/item/wrapped, proximity, params)
 	if(!wrapped)
 		return FALSE
 
@@ -186,7 +191,7 @@
 
 	var/resolved = target.attackby(wrapped, user)
 	if(!resolved && wrapped && target)
-		wrapped.afterattack(target, user, TRUE)
+		wrapped.afterattack(target, user, proximity, params)
 
 	if(item_left_gripper(wrapped))
 		clear_and_select_pocket()

--- a/code/modules/mob/living/silicon/robot/robot_simple_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_simple_items.dm
@@ -564,6 +564,12 @@
 
 	var/mob/living/silicon/robot/our_robot
 
+	//If we allow using our gripper at range at all . Adminbus only.
+	var/allow_ranged_usage = FALSE
+
+	//If we allow using our gripper at range to pick up things. Adminbus only.
+	var/allow_ranged_pickup = FALSE
+
 	pickup_sound = 'sound/items/pickup/device.ogg'
 	drop_sound = 'sound/items/drop/device.ogg'
 


### PR DESCRIPTION

## About The Pull Request
Fixes a bug with borg grippers where picking up material sheets would cause problems where it'd place them in a new pocket and then qdel them.

Adds some admin only vars for grippers to allow ranged usage and ranged pickup.

Makes grippers pass args to afterattack properly. 

## Changelog
:cl: Diana
fix: Fixes borg gripper interactions with stacks of items.
/:cl:
