### PR TITLE
Fixes borg wires

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -208,6 +208,7 @@
 
 	AddComponent(/datum/component/hose_connector/input/borg)
 	AddComponent(/datum/component/hose_connector/output/borg)
+	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 
 /mob/living/silicon/robot/LateInitialize()
 	pick_module()


### PR DESCRIPTION

## About The Pull Request
Makes it so EMPing borgs doesn't pulse the wires (this resulted in major issues like lockdowns upon being EMP'd)
## Changelog
:cl: Diana
fix: Borg wires no longer become EMP'd.
/:cl:
