### PR TITLE
Mob vore is now for mobs as pred only

### DIFF
--- a/code/_helpers/vore.dm
+++ b/code/_helpers/vore.dm
@@ -22,7 +22,7 @@
 		return FALSE
 	if(!prey.is_dead() && !prey.can_be_afk_prey && (!prey.client || prey.away_from_keyboard))
 		return FALSE
-	if(!prey.allowmobvore && isanimal(pred) && !pred.ckey || (!pred.allowmobvore && isanimal(prey) && !prey.ckey))
+	if(!prey.allowmobvore && isanimal(pred) && !pred.ckey)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
The description of the mob vore preference suggests that it is only for mobs eating you. This fixes it so that the pref only disables mobs as preds, allowing you to still eat mobs yourself.
## Changelog
:cl: Cerami
fix: adjusts mob vore pref to only be for mobs as preds
/:cl:
