### PR TITLE
Fix an issue with fulton beacons

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -112,9 +112,14 @@
 				L.drowsyness = 0
 			sleep(30)
 			var/list/flooring_near_beacon = list()
+			var/had_option = FALSE
 			for(var/turf/simulated/floor/floor in orange(1, beacon))
+				had_option = TRUE
 				flooring_near_beacon += floor
-			holder_obj.forceMove(pick(flooring_near_beacon))
+			if(had_option)
+				holder_obj.forceMove(pick(flooring_near_beacon))
+			else
+				holder_obj.forceMove(beacon.loc)
 			animate(holder_obj, pixel_z = 10, time = 50)
 			sleep(50)
 			animate(holder_obj, pixel_z = 15, time = 10)


### PR DESCRIPTION

## About The Pull Request
Adds a failsafe mode if the fulton beacon doesn't have a simulated floor next to it to send someone to.
## Changelog
:cl: Cerami
fix: Adds an emergency failsafe to the fulton if it doesn't see a valid tile to transport to.
/:cl:
