### PR TITLE
Fix masks blocking stuttering

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -150,18 +150,18 @@
 				if(istype(first) && first.speaking == GLOB.all_languages["Noise"])
 					return ..()
 		message_data[1] = ""
-		. = 1
+		return 1
 
-	else if(istype(wear_mask, /obj/item/clothing/mask))
+	if(istype(wear_mask, /obj/item/clothing/mask))
 		var/obj/item/clothing/mask/M = wear_mask
 		if(M.voicechange) //only horsemasks do this.
 			message_data[1] = pick(M.say_messages)
 			message_data[2] = pick(M.say_verbs)
 			if(istype(M, /obj/item/clothing/mask/horsehead) && prob(0.5))
 				message_data[2] = "HIIII EVERYPONY"
-			. = 1
+			return 1
 
-	else if((CE_SPEEDBOOST in chem_effects) || (get_jittery() >= 100 && !stuttering)) // motor mouth, check for stuttering so anxiety doesn't do hyperzine text
+	if((CE_SPEEDBOOST in chem_effects) || (get_jittery() >= 100 && !stuttering)) // motor mouth, check for stuttering so anxiety doesn't do hyperzine text
 		// Despite trying to url/html decode these, byond is just being bad and I dunno.
 		var/static/regex/speedboost_initial = new (@"&[a-z]{2,5};|&#\d{2};","g")
 		// Not herestring because bad vs code syntax highlight panics at apostrophe
@@ -169,9 +169,9 @@
 		for(var/datum/multilingual_say_piece/S in message_data[1])
 			S.message = speedboost_initial.Replace(S.message, "")
 			S.message = speedboost_main.Replace(S.message, "")
-		. = 1
-	else
-		. = ..(message_data)
+		return 1
+
+	. = ..(message_data)
 
 /mob/living/carbon/human/handle_message_mode(message_mode, list/message_pieces, verb, used_radios)
 	switch(message_mode)


### PR DESCRIPTION
## About The Pull Request
Wearing any mask at all would prevent stuttering, and any other say modifiers like wingdings or hyperzine.

## Changelog
Cleans up handle_speech_problems() to use early returns, and fixes the mask bug

:cl: Will
fix: wearing a mask no longer prevent stuttering, hyperzine, and wingding say modifiers
/:cl:
