### PR TITLE
Cryoplanet controller should not affect shuttles and elevators

### DIFF
--- a/code/controllers/subsystems/cryoplanets.dm
+++ b/code/controllers/subsystems/cryoplanets.dm
@@ -89,7 +89,7 @@ SUBSYSTEM_DEF(cryoplanets)
 		return FALSE
 
 	var/area/area_check = get_area(T) //Do not freeze dorms
-	if(!area_check || (area_check.flags & AREA_CRYOPLANET_SHIELDED))
+	if(!area_check || (area_check.flags & AREA_CRYOPLANET_SHIELDED || istype(area_check, /area/shuttle) || istype(area_check, /area/turbolift)))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Found while working on downstream map archiving stuff. Has no changes to any map currently run on virgo.

## Changelog
Shuttle and elevator areas are immune from the cryoplanet subsystem

:cl: Will
fix: shuttles and elevators are ignored by the cryoplanets subsystem
/:cl:
