### PR TITLE
Fix a rare gas scrubbing runtime

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -3,7 +3,7 @@
 	//Gases with 0 moles are not tracked and are pruned by update_values()
 	var/list/gas
 	//Temperature in Kelvin of this gas mix.
-	var/temperature = 0
+	var/temperature = TCMB
 
 	//Sum of all the gas moles in this mix.  Updated by update_values()
 	var/total_moles = 0


### PR DESCRIPTION
## About The Pull Request
Turns out gas mixture datums has been initializing to an illegal temperature value since XGM gas datums were added. TG uses the cosmic background radiation constant for lowest temp, we do as well but lack the default being correct. This fixes a rare issue where scrubbers with just created gas datums would scrub their current gas, and attempt to merge it with a gas at absolute 0, while calculating the power needed to do so. This calculation uses the sink's temp in a division, and thus divides by 0. 

## Changelog
Gas datums init to TCMB instead of absolute 0.

:cl: Will
fix: Scrubbers no longer rarely divide by 0 when calculating scrubbing power used on their first tick if the pipe network is in a certain state
code: gas mixture datum inits temp to TCMB instead of 0
/:cl:

