### PR TITLE
Station boiler radiators respect fuel properly

### DIFF
--- a/code/controllers/subsystems/stationheater.dm
+++ b/code/controllers/subsystems/stationheater.dm
@@ -61,7 +61,7 @@ SUBSYSTEM_DEF(stationheater)
 	// Update radiator icon if the main boiler is functioning or not
 	radiator.set_state(assigned_boiler?.is_heating())
 	var/turf/radiator_turf = get_turf(radiator)
-	if(!radiator.actively_radiating || !SScryoplanets.is_station_temp_change_turf(radiator_turf))
+	if(!radiator.get_radiating() || !SScryoplanets.is_station_temp_change_turf(radiator_turf))
 		return
 
 	// If the temp is colder than the radiator, begin heating!

--- a/code/controllers/subsystems/stationheater.dm
+++ b/code/controllers/subsystems/stationheater.dm
@@ -60,11 +60,8 @@ SUBSYSTEM_DEF(stationheater)
 
 	// Update radiator icon if the main boiler is functioning or not
 	radiator.set_state(assigned_boiler?.is_heating())
-	radiator.update_icon()
-
-	// Remove us if we are in an invalid radiator turf
 	var/turf/radiator_turf = get_turf(radiator)
-	if(!SScryoplanets.is_station_temp_change_turf(radiator_turf))
+	if(!radiator.actively_radiating || !SScryoplanets.is_station_temp_change_turf(radiator_turf))
 		return
 
 	// If the temp is colder than the radiator, begin heating!

--- a/code/game/machinery/atmoalter/station_boiler_radiator.dm
+++ b/code/game/machinery/atmoalter/station_boiler_radiator.dm
@@ -27,7 +27,7 @@
 		return
 	actively_radiating = activate
 	update_icon()
-	set_light(1, 0.9, "#e9400dff", l_on = actively_radiating)
+	set_light(actively_radiating, 0.9, "#e9400dff")
 
 /obj/machinery/stationboiler_radiator/update_icon()
 	icon_state = actively_radiating ? "on" : "off"

--- a/code/game/machinery/atmoalter/station_boiler_radiator.dm
+++ b/code/game/machinery/atmoalter/station_boiler_radiator.dm
@@ -29,6 +29,9 @@
 	update_icon()
 	set_light(actively_radiating, 0.9, "#e9400dff")
 
+/obj/machinery/stationboiler_radiator/proc/get_radiating()
+	return actively_radiating
+
 /obj/machinery/stationboiler_radiator/update_icon()
 	icon_state = actively_radiating ? "on" : "off"
 


### PR DESCRIPTION
## About The Pull Request
Missed this when testing as I cleaned up some parts of station boiler code, but forgot to handle them running out of fuel when I tested. Does not affect any of virgo's current maps.

## Changelog
Station boilers that run out of fuel properly disable their radiators as well.

:cl: Will
fix: Station boiler radiators respect boiler fuel
/:cl:
