### PR TITLE
Borg Click Handler Fix

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -96,7 +96,7 @@
 		// No adjacency checks
 
 		var/resolved = W.resolve_attackby(A, src, click_parameters = params)
-		if(!resolved && A && W)
+		if((resolved != ITEM_INTERACT_SUCCESS)  && A && W)
 			W.afterattack(A,src,1,params)
 		return
 
@@ -108,7 +108,7 @@
 		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach))) // see adjacent.dm, allows robots to use ranged melee weapons
 			SEND_SIGNAL(src, COMSIG_ROBOT_ITEM_ATTACK, W, src, params) //This is we ATTEMPTED to attack someone.
 			var/resolved = W.resolve_attackby(A, src, click_parameters = params)
-			if(!resolved && A && W)
+			if((resolved != ITEM_INTERACT_SUCCESS)  && A && W)
 				W.afterattack(A, src, 1, params)
 			return
 		else


### PR DESCRIPTION
## About The Pull Request
Borgs clickhandler wasn't updated to the new return code. So nothing a borg did would trigger after_attack()

## Changelog
Gives borg click handler proper return handling

:cl: Will
fix: Borg sleepers and various other borg items should function properly again
/:cl:
