### PR TITLE
Pain fix & addition

### DIFF
--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -29,21 +29,25 @@
 			switch(power)
 				if(0 to 5)
 					next_pain_time = world.time + 300 SECONDS
-					multilimb_pain_time = world.time + 45 SECONDS
+					multilimb_pain_time = world.time + 1 MINUTE
 				if(6 to 20)
-					next_pain_time = world.time + clamp((30 - power) SECONDS, 10 SECONDS, 30 SECONDS)
-					multilimb_pain_time = world.time + clamp((30 - power) SECONDS, 10 SECONDS, 30 SECONDS)
+					next_pain_time = world.time + clamp((100 - power) SECONDS, 80 SECONDS, 95 SECONDS)
+					multilimb_pain_time = world.time + clamp((100 - power) SECONDS, 80 SECONDS, 95 SECONDS)
 				if(21 to INFINITY)
-					next_pain_time = world.time + (100 - power)
-					multilimb_pain_time = world.time + (100 - power)
+					next_pain_time = world.time + clamp((200 - power) SECONDS, 100 SECONDS, 3 MINUTES)
+					multilimb_pain_time = world.time + clamp((200 - power) SECONDS, 100 SECONDS, 3 MINUTES)
 			last_pain_message = message
 			to_chat(src,message)
+			if(prob(power / 10) && !isbelly(loc)) // No pain noises inside bellies.
+				emote("pain")
 
 	else if(force || (message != last_pain_message) || (world.time >= next_pain_time))
 		last_pain_message = message
 		to_chat(src,message)
-		next_pain_time = world.time + (100 - power)
-		multilimb_pain_time = world.time + (100 - power)
+		next_pain_time = world.time + clamp((200 - power) SECONDS, 100 SECONDS, 3 MINUTES)
+		multilimb_pain_time = clamp(world.time + (200 - power) SECONDS, 100 SECONDS, 3 MINUTES)
+		if(prob(power / 10) && !isbelly(loc)) // No pain noises inside bellies.
+			emote("pain")
 
 /mob/living/carbon/human/proc/handle_pain()
 	if(stat)


### PR DESCRIPTION

## About The Pull Request
Fixes a bug where the chat would be spammed with pain messages if you were significantly damaged.
Makes it so when you are significantly injured you have a chance to make a pain sound. (At a 20 strength injury, this is a 2% chance every time the pain message occurs)
Makes it so pain messages have longer cooldown timers depending on their severity. A 'minor' injury will only pop up per limb once every 60 seconds. A moderate injury every 80-95 seconds. A major every 100 seconds to 3 minutes. The reason for this is that more painful injuries are in MUCH LARGER TEXT in the chat.
## Changelog
:cl: Diana
add: Small chance for pain emote when taking a painful attack.
fix: Fixes a bug where pain would spam your chat with pain messages if they were significantly strong.
fix: Pain messages have proper times now, instead of having possibly 0 times per message.
/:cl:
