### PR TITLE
Optimize Cryoplanet Subsystem

### DIFF
--- a/code/controllers/subsystems/cryoplanets.dm
+++ b/code/controllers/subsystems/cryoplanets.dm
@@ -63,14 +63,10 @@ SUBSYSTEM_DEF(cryoplanets)
 
 	// Check if this would be affected by the station mainboiler's radiators.
 	var/area/check_area = get_area(T) // If we have an active radiator in the area, then there is no point in starting a temperature war....
-	if(check_area && length(SSstationheater.radiators) && target_temp < SSstationheater.target_heat_temperature)
+	if(check_area && length(check_area.radiators) && target_temp < SSstationheater.target_heat_temperature)
 		var/obj/structure/stationboiler/current_heater = SSstationheater.get_current_boiler()
 		if(current_heater?.is_heating()) // If the current boiler isn't on... It won't matter.
-			for(var/obj/machinery/stationboiler_radiator/radiator in SSstationheater.radiators)
-				CHECK_TICK
-				if(get_area(radiator) != check_area)
-					continue
-				return // Area had an active radiator, we'll drop out!
+			return // Area had an active radiator, we'll drop out!
 	//testing("Energy: [neededEnergy]")
 	currentAir.add_thermal_energy(neededEnergy)
 

--- a/code/controllers/subsystems/cryoplanets.dm
+++ b/code/controllers/subsystems/cryoplanets.dm
@@ -62,11 +62,11 @@ SUBSYSTEM_DEF(cryoplanets)
 		neededEnergy = max(neededEnergy, -max_thermal_change)
 
 	// Check if this would be affected by the station mainboiler's radiators.
-	var/area/check_area = get_area(T) // If we have an active radiator in the area, then there is no point in starting a temperature war....
-	if(check_area && length(check_area.radiators) && target_temp < SSstationheater.target_heat_temperature)
-		var/obj/structure/stationboiler/current_heater = SSstationheater.get_current_boiler()
-		if(current_heater?.is_heating()) // If the current boiler isn't on... It won't matter.
-			return // Area had an active radiator, we'll drop out!
+	// If we have an active radiator in the area, then there is no point in starting a temperature war....
+	var/area/check_area = get_area(T)
+	var/obj/structure/stationboiler/current_heater = SSstationheater.get_current_boiler()
+	if(current_heater?.is_heating() && check_area && length(check_area.radiators) && target_temp < SSstationheater.target_heat_temperature)
+		return
 	//testing("Energy: [neededEnergy]")
 	currentAir.add_thermal_energy(neededEnergy)
 

--- a/code/controllers/subsystems/cryoplanets.dm
+++ b/code/controllers/subsystems/cryoplanets.dm
@@ -64,9 +64,12 @@ SUBSYSTEM_DEF(cryoplanets)
 	// Check if this would be affected by the station mainboiler's radiators.
 	// If we have an active radiator in the area, then there is no point in starting a temperature war....
 	var/area/check_area = get_area(T)
-	var/obj/structure/stationboiler/current_heater = SSstationheater.get_current_boiler()
-	if(current_heater?.is_heating() && check_area && length(check_area.radiators) && target_temp < SSstationheater.target_heat_temperature)
-		return
+	if(check_area && length(check_area.radiators) && target_temp < SSstationheater.target_heat_temperature)
+		var/obj/machinery/stationboiler_radiator/check_rad = check_area.radiators[1] // It won't matter which radiator in the area, as they're all on the same planet anyway
+		if(check_rad.get_radiating())
+			return
+
+	// Time to chill the area...
 	//testing("Energy: [neededEnergy]")
 	currentAir.add_thermal_energy(neededEnergy)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_EMPTY(areas_by_type)
 	var/music = null
 	var/has_gravity = TRUE // Don't check this var directly; use get_gravity() instead
 	var/obj/machinery/power/apc/apc = null
+	var/list/radiators = null
 	var/no_air = null
 //	var/list/lights				// list of all lights on this area
 	var/list/all_doors = null		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area

--- a/code/game/machinery/atmoalter/station_boiler_radiator.dm
+++ b/code/game/machinery/atmoalter/station_boiler_radiator.dm
@@ -17,10 +17,23 @@
 /obj/machinery/stationboiler_radiator/Initialize(mapload)
 	. = ..()
 	SSstationheater.radiators += src
+	var/area/new_area = get_area(src)
+	if(new_area)
+		LAZYADD(new_area.radiators, src)
 
 /obj/machinery/stationboiler_radiator/Destroy()
 	SSstationheater.radiators -= src
+	var/area/our_area = get_area(src)
+	if(our_area)
+		LAZYREMOVE(our_area.radiators, src)
 	. = ..()
+
+/obj/machinery/stationboiler_radiator/area_changed(area/old_area, area/new_area)
+	. = ..()
+	if(old_area)
+		LAZYREMOVE(old_area.radiators, src)
+	if(new_area)
+		LAZYADD(new_area.radiators, src)
 
 /obj/machinery/stationboiler_radiator/proc/set_state(activate)
 	if(actively_radiating == activate)


### PR DESCRIPTION
## About The Pull Request
Optimizes cryoplanets subsystem by removing an internal loop.

## Changelog
Removes an ugly internal loop that checks areas and replaces it with a check in the area itself.
Adds a lazylist to /area for station radiators. Will be null on stations without radiators

:cl: Will
refactor: Optimizes cryoplanet subsystem
/:cl:

