### PR TITLE
Universal Pipe Fix Take 2

### DIFF
--- a/code/ATMOSPHERICS/pipes/universal.dm
+++ b/code/ATMOSPHERICS/pipes/universal.dm
@@ -1,6 +1,8 @@
 #define LIST_NODE1 1
 #define LIST_NODE2 2
 
+#define REBUILD_UNIVERSAL_NODE_LIST if(!length(universal_nodes)) {universal_nodes = new/list(PIPING_LAYER_AUX);universal_nodes[PIPING_LAYER_SUPPLY] = list(null, null);universal_nodes[PIPING_LAYER_REGULAR] = list(null, null);universal_nodes[PIPING_LAYER_SCRUBBER] = list(null, null);universal_nodes[PIPING_LAYER_FUEL] = list(null, null);universal_nodes[PIPING_LAYER_AUX] = list(null, null);};
+
 //
 // Universal Pipe Adapter - Designed for connecting scrubbers, normal, and supply pipes together.
 // Visible varient
@@ -20,19 +22,14 @@
 	universal_destroy(universal_nodes)
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/atmos_init()
-	if(!universal_nodes) // Done here, because other things can remotely call atmos_init() from around this pipe
-		universal_nodes = new/list(PIPING_LAYER_AUX)
-		universal_nodes[PIPING_LAYER_SUPPLY] = list(null, null)
-		universal_nodes[PIPING_LAYER_REGULAR] = list(null, null)
-		universal_nodes[PIPING_LAYER_SCRUBBER] = list(null, null)
-		universal_nodes[PIPING_LAYER_FUEL] = list(null, null)
-		universal_nodes[PIPING_LAYER_AUX] = list(null, null)
+	REBUILD_UNIVERSAL_NODE_LIST
 	universal_atmos_init(universal_nodes)
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/disconnect(obj/machinery/atmospherics/reference)
 	universal_disconnect(universal_nodes, reference)
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/pipeline_expansion()
+	REBUILD_UNIVERSAL_NODE_LIST
 	var/list/all_nodes = list()
 	for(var/list/sublist in universal_nodes)
 		all_nodes += sublist
@@ -67,19 +64,14 @@
 	universal_destroy(universal_nodes)
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/atmos_init()
-	if(!universal_nodes) // Done here, because other things can remotely call atmos_init() from around this pipe
-		universal_nodes = new/list(PIPING_LAYER_AUX)
-		universal_nodes[PIPING_LAYER_SUPPLY] = list(null, null)
-		universal_nodes[PIPING_LAYER_REGULAR] = list(null, null)
-		universal_nodes[PIPING_LAYER_SCRUBBER] = list(null, null)
-		universal_nodes[PIPING_LAYER_FUEL] = list(null, null)
-		universal_nodes[PIPING_LAYER_AUX] = list(null, null)
+	REBUILD_UNIVERSAL_NODE_LIST
 	universal_atmos_init(universal_nodes)
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/disconnect(obj/machinery/atmospherics/reference)
 	universal_disconnect(universal_nodes, reference)
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/pipeline_expansion()
+	REBUILD_UNIVERSAL_NODE_LIST
 	var/list/all_nodes = list()
 	for(var/list/sublist in universal_nodes)
 		all_nodes += sublist
@@ -217,6 +209,8 @@
 			underlays += GLOB.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 	else
 		underlays += GLOB.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "retracted" + icon_connect_type)
+
+#undef REBUILD_UNIVERSAL_NODE_LIST
 
 #undef LIST_NODE1
 #undef LIST_NODE2


### PR DESCRIPTION
## About The Pull Request
Fixes universal pipes not always connecting all nodes during init. Turns out that I need to do that list init check in more than just atmo_init(). So moved it to a define for reuse.


:cl: Will
fix: Fixes universal pipe init again
/:cl:
