### PR TITLE
Cleanup A Remote View Proc

### DIFF
--- a/code/datums/components/remote_view.dm
+++ b/code/datums/components/remote_view.dm
@@ -114,6 +114,10 @@
 	if(settings.use_zoom_hud && !host_mob.hud_used.hud_shown)
 		host_mob.toggle_zoom_hud()
 
+	// Unregister remaining signals
+	// to_chat(world, "======================================== ENDED VIEW on: [remote_view_target]")
+	. = ..()
+
 	// Update the mob's vision right away if it still exists
 	if(!QDELETED(host_mob) && host_mob.client)
 		settings.detatch_from_mob(src, host_mob)
@@ -122,10 +126,6 @@
 		host_mob.client.pixel_y = 0
 		host_mob.handle_vision()
 		host_mob.handle_regular_hud_updates()
-
-	// Unregister remaining signals
-	// to_chat(world, "======================================== ENDED VIEW on: [remote_view_target]")
-	. = ..()
 
 	// Finish cleanup
 	QDEL_NULL(settings)

--- a/code/datums/remote_view_config.dm
+++ b/code/datums/remote_view_config.dm
@@ -88,7 +88,7 @@
 	return
 
 /// Handles relayed movement during a remote view. Override this in a subtype to handle specialized logic. If it returns true, the mob will not move, allowing you to handle remotely controlled movement.
-/datum/remote_view_config/proc/handle_relay_movement(datum/component/remote_view/owner_component, mob/host_mob, datum/coordinator, atom/movable/remote_view_target, direction)
+/datum/remote_view_config/proc/handle_relay_movement(datum/component/remote_view/owner_component, mob/host_mob, direction)
 	SIGNAL_HANDLER
 	return remote_view_target.relaymove(host_mob, direction)
 

--- a/code/datums/remote_view_config.dm
+++ b/code/datums/remote_view_config.dm
@@ -90,6 +90,7 @@
 /// Handles relayed movement during a remote view. Override this in a subtype to handle specialized logic. If it returns true, the mob will not move, allowing you to handle remotely controlled movement.
 /datum/remote_view_config/proc/handle_relay_movement(datum/component/remote_view/owner_component, mob/host_mob, direction)
 	SIGNAL_HANDLER
+	var/atom/remote_view_target = owner_component.get_target()
 	return remote_view_target.relaymove(host_mob, direction)
 
 /// Handles visual changes to mob's hud or flags when in use, it is fired every life tick.


### PR DESCRIPTION
## About The Pull Request
Removes two arguments not used by handle_relay_movement() in remote views. The proc only use the first three arguments in all subtypes, and called it expecting three arguments. The base proc has more, but is incorrectly laid out. This has no change on logic due to how byond handles arguments being passed. It just makes the base type reflect all its children (as well as how it is called). The data passed by those arguments would of been trivial to ask the already passed component for anyway, which is how the children of this proc handle it.

addendum: Fixes remote view huds not being updated in the correct order when a remote view ends.

:cl: Will
code: corrects base arguments of remote_view_config/handle_relay_movement() proc
fix: remote views with hud modifiers end correctly instead of waiting an extra life tick
/:cl:
