### PR TITLE
Fixes morph body takeover

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -269,38 +269,38 @@
 				possible_mobs += H
 			else
 				continue
-		var/mob/living/L = tgui_input_list(src, "Select a mob to take over:", "Take Over Prey", possible_mobs)
-		if(!L)
-			return
-		if(!L.allow_mimicry)
-			to_chat(src, span_warning("\The [L] cannot be impersonated!"))
-			return
-		if(tgui_alert(src, "You selected [L] to attempt to take over. Are you sure?", "Take Over Prey",list("No","Yes")) == "Yes")
-			log_admin("[key_name_admin(src)] offered [L] to swap bodies as a morph.")
-			if(tgui_alert(L, "\The [src] has elected to attempt to take over your body and control you. Is this something you will allow to happen?", "Allow Morph To Take Over",list("No","Yes")) == "Yes")
-				if(tgui_alert(L, "Are you sure? The only way to undo this on your own is to OOC Escape.", "Allow Morph To Take Over",list("No","Yes")) == "Yes")
-					if(buckled)
-						buckled.unbuckle_mob()
-					if(L.buckled)
-						L.buckled.unbuckle_mob()
-					if(LAZYLEN(buckled_mobs))
-						for(var/buckledmob in buckled_mobs)
-							riding_datum.force_dismount(buckledmob)
-					if(LAZYLEN(L.buckled_mobs))
-						for(var/p_buckledmob in L.buckled_mobs)
-							L.riding_datum.force_dismount(p_buckledmob)
-					if(pulledby)
-						pulledby.stop_pulling()
-					if(L.pulledby)
-						L.pulledby.stop_pulling()
-					stop_pulling()
-					original_ckey = ckey
-					log_and_message_admins("has swapped bodies with [key_name_admin(L)] as a morph at [get_area(src)] - [COORD(src)].", src)
-					new /mob/living/simple_mob/vore/morph/dominated_prey(L.vore_selected, L.ckey, src, L)
-				else
-					to_chat(src, span_warning("\The [L] declined your request for control."))
+	var/mob/living/L = tgui_input_list(src, "Select a mob to take over:", "Take Over Prey", possible_mobs)
+	if(!L)
+		return
+	if(!L.allow_mimicry)
+		to_chat(src, span_warning("\The [L] cannot be impersonated!"))
+		return
+	if(tgui_alert(src, "You selected [L] to attempt to take over. Are you sure?", "Take Over Prey",list("No","Yes")) == "Yes")
+		log_admin("[key_name_admin(src)] offered [L] to swap bodies as a morph.")
+		if(tgui_alert(L, "\The [src] has elected to attempt to take over your body and control you. Is this something you will allow to happen?", "Allow Morph To Take Over",list("No","Yes")) == "Yes")
+			if(tgui_alert(L, "Are you sure? The only way to undo this on your own is to OOC Escape.", "Allow Morph To Take Over",list("No","Yes")) == "Yes")
+				if(buckled)
+					buckled.unbuckle_mob()
+				if(L.buckled)
+					L.buckled.unbuckle_mob()
+				if(LAZYLEN(buckled_mobs))
+					for(var/buckledmob in buckled_mobs)
+						riding_datum.force_dismount(buckledmob)
+				if(LAZYLEN(L.buckled_mobs))
+					for(var/p_buckledmob in L.buckled_mobs)
+						L.riding_datum.force_dismount(p_buckledmob)
+				if(pulledby)
+					pulledby.stop_pulling()
+				if(L.pulledby)
+					L.pulledby.stop_pulling()
+				stop_pulling()
+				original_ckey = ckey
+				log_and_message_admins("has swapped bodies with [key_name_admin(L)] as a morph at [get_area(src)] - [COORD(src)].", src)
+				new /mob/living/simple_mob/vore/morph/dominated_prey(L.vore_selected, L.ckey, src, L)
 			else
 				to_chat(src, span_warning("\The [L] declined your request for control."))
+		else
+			to_chat(src, span_warning("\The [L] declined your request for control."))
 
 /mob/living/simple_mob/vore/morph/dominated_prey
 	name = "subservient node"


### PR DESCRIPTION

## About The Pull Request
Morph body takeover currently only works for the first belly you have. This fixes the code to properly check all bellies you have before presenting you with the option to take someone over.
## Changelog
:cl: Cerami
fix: Fix morph's body takeover to work on bellies beyond the first
/:cl:
