### PR TITLE
Enables moving while shooting

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -379,10 +379,6 @@
 
 	var/shoot_time = (burst - 1)* burst_delay
 
-	//These should apparently be disabled to allow for the automatic system to function without causing near-permanant paralysis. Re-enabling them while we sort that out.
-	user.setClickCooldown(shoot_time) //no clicking on things while shooting
-	user.setMoveCooldown(shoot_time) //no moving while shooting either
-
 	next_fire_time = world.time + shoot_time
 	handle_gunfire(target, user, clickparams, pointblank, reflex, 1, FALSE)
 


### PR DESCRIPTION

## About The Pull Request
Does what it says on the tin.
Enables running and gunning. A years old coder comment mentioned having disabling the delay to allow for running and gunning. This enables it.

You can actually move during burst fire.

## Changelog
:cl: Diana
qol: You can now move and shoot at the same time. No longer will you shoot and get stuck in place.
/:cl:
