### PR TITLE
Fix for Glowing Eyes trait not working on dispersed eyes species

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -534,8 +534,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts) //see UpdateDamageIcon()
 	if(!species.has_glowing_eyes)
 		return
 
-	//Our glowy eyes should be hidden if some equipment hides them.
-	if(!should_have_organ(O_EYES) || (head && (head.flags_inv & BLOCKHAIR)) || (wear_mask && (wear_mask.flags_inv & BLOCKHAIR)))
+	//Our glowy eyes should be hidden if some equipment hides them. | Added Promethean/dispersed eyes species support for Glowing Eyes.
+	if((!should_have_organ(O_EYES) && !species.dispersed_eyes) || (head && (head.flags_inv & BLOCKHAIR)) || (wear_mask && (wear_mask.flags_inv & BLOCKHAIR)))
 		return
 
 	//Get the head, we'll need it later.
@@ -550,7 +550,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts) //see UpdateDamageIcon()
 
 	var/icon/eyes_icon = new/icon(head_organ.eye_icon_location, head_organ.eye_icon)
 	if(!findtext(head_organ.eye_icon, regex("-colored")))
-		if(eyes)
+		if(species.dispersed_eyes) // Set so all species who would lack eye organs due to dispersed eyes can still use Glowing Eyes.
+			eyes_icon.Blend(rgb(r_eyes, g_eyes, b_eyes))
+		else if(eyes)
 			eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
 		else
 			eyes_icon.Blend(rgb(128,0,0), ICON_ADD)


### PR DESCRIPTION

## About The Pull Request

Adds a check to Glowing Eyes to pull the color reference that eyeballs use so Prometheans and other Dispersed Eyes species can use the Glowing Eyes trait.

## Changelog
:cl:
fix: Adds checks to Glowing Eyes code to check for dispersed eyes.
/:cl:
