### PR TITLE
Makes Chemical Refinery Pipes Cheaper

### DIFF
--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -245,6 +245,7 @@ GLOBAL_LIST(construction_frame_floor)
 
 /datum/frame/frame_types/industrial_reagent_pipe
 	name = "Industrial Chemical Pipe"
+	circuit = /obj/item/circuitboard/industrial_reagent_pipe // Comes with it's own circuitboard now
 	icon_override = 'icons/obj/stock_parts_refinery.dmi'
 	frame_class = FRAME_CLASS_MACHINE
 

--- a/code/modules/research/tg/designs/boards/refinery.dm
+++ b/code/modules/research/tg/designs/boards/refinery.dm
@@ -38,6 +38,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
+/* Comes with it's own circuitboard now
 /datum/design_techweb/board/industrial_reagent_pipe
 	SET_CIRCUIT_DESIGN_NAMEDESC("Industrial Reagent Pipe")
 	id = "industrial_reagent_pipe"
@@ -47,6 +48,7 @@
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_REFINERY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+*/
 
 /datum/design_techweb/board/industrial_reagent_pump
 	SET_CIRCUIT_DESIGN_NAMEDESC("Industrial Reagent Pump")

--- a/code/modules/research/tg/techwebs/nodes/engi_nodes.dm
+++ b/code/modules/research/tg/techwebs/nodes/engi_nodes.dm
@@ -367,7 +367,7 @@
 		"industrial_reagent_furnace",
 		"industrial_reagent_grinder",
 		"industrial_reagent_hub",
-		"industrial_reagent_pipe",
+	//	"industrial_reagent_pipe", // comes with it's own circuitboard now
 		"industrial_reagent_pump",
 		"industrial_reagent_reactor",
 		"industrial_reagent_vat",


### PR DESCRIPTION
## About The Pull Request
Makes the refinery pipe frame's circuit board implicit. Meaning it spawns with it, and deconstructs without spawning the board from a frame. Like cell rechargers. This is from feedback that standard pipes are not often used compared to hoses due to their construction time and tedium.

## Changelog
Makes the refinery pipe frame start with a board like some other small machines
Comments out the refinery pipe board from research as it's not used

:cl: Will
balance: Chemical refinery pipe machines no longer require a circuit board to construct
/:cl:
