### PR TITLE
Aghost Logging

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -57,7 +57,7 @@ ADMIN_VERB(admin_ghost, R_HOLDER, "Aghost", "Ghost out of your body with the opt
 		to_chat(user, span_filter_system(span_warning("Error: Aghost: Can't admin-ghost whilst in the lobby. Join or Observe first.")))
 	else
 		//ghostize
-		log_admin("[key_name(mob)] has aghosted.")
+		log_admin("[key_name(user)] has aghosted.")
 		var/mob/body = mob
 		var/mob/observer/dead/ghost
 		if(build_mode)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -57,7 +57,7 @@ ADMIN_VERB(admin_ghost, R_HOLDER, "Aghost", "Ghost out of your body with the opt
 		to_chat(user, span_filter_system(span_warning("Error: Aghost: Can't admin-ghost whilst in the lobby. Join or Observe first.")))
 	else
 		//ghostize
-		log_admin("[key_name(src)] has aghosted.")
+		log_admin("[key_name(mob)] has aghosted.")
 		var/mob/body = mob
 		var/mob/observer/dead/ghost
 		if(build_mode)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -57,7 +57,7 @@ ADMIN_VERB(admin_ghost, R_HOLDER, "Aghost", "Ghost out of your body with the opt
 		to_chat(user, span_filter_system(span_warning("Error: Aghost: Can't admin-ghost whilst in the lobby. Join or Observe first.")))
 	else
 		//ghostize
-		log_admin("has aghosted.")
+		log_admin("[key_name(src)] has aghosted.")
 		var/mob/body = mob
 		var/mob/observer/dead/ghost
 		if(build_mode)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -57,6 +57,7 @@ ADMIN_VERB(admin_ghost, R_HOLDER, "Aghost", "Ghost out of your body with the opt
 		to_chat(user, span_filter_system(span_warning("Error: Aghost: Can't admin-ghost whilst in the lobby. Join or Observe first.")))
 	else
 		//ghostize
+		log_admin("has aghosted.")
 		var/mob/body = mob
 		var/mob/observer/dead/ghost
 		if(build_mode)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -277,6 +277,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(!found_rune)
 			to_chat(src, span_warning("The astral cord that ties your body and your spirit has been severed. You are likely to wander the realm beyond until your body is finally dead and thus reunited with you."))
 			return
+	if(admin_ghosted)
+		log_admin("re-entered their body.")
 	mind.current.ajourn=0
 	mind.current.key = key
 	mind.current.teleop = null
@@ -288,8 +290,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		B.update(1)
 	if(!admin_ghosted)
 		announce_ghost_joinleave(mind, 0, "They now occupy their body again.")
-	if(admin_ghosted)
-		log_and_message_admins("Admin [key_name(src)] re-entered their body.")
 	return 1
 
 /mob/observer/dead/verb/toggle_medHUD()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -278,7 +278,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			to_chat(src, span_warning("The astral cord that ties your body and your spirit has been severed. You are likely to wander the realm beyond until your body is finally dead and thus reunited with you."))
 			return
 	if(admin_ghosted)
-		log_admin("re-entered their body.")
+		log_admin("[key_name(src)] re-entered their body.")
 	mind.current.ajourn=0
 	mind.current.key = key
 	mind.current.teleop = null


### PR DESCRIPTION

Adjusts the placement of the re-enter body admin log for aghosting so that it reports the key correctly.

Per directive after consulting Joan:
Adds an admin log to the opposite end of aghosting (when you aghost) as it seemed to be missing.
Makes both a regular admin log instead of log_and_message_admins, as there doesn't seem to be much point in messaging the admins every time someone aghosts.
## Changelog
:cl:
fix: Aghost admin logs record the associated key.
change: Aghost admin logs no longer message admins
add: Aghost admin log on aghost

/:cl:
