### PR TITLE
Brainmobs that get reagents no longer runtime

### DIFF
--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -180,7 +180,7 @@
 	removed = min(removed, volume)
 	max_dose = max(volume, max_dose)
 	dose = min(dose + removed, max_dose)
-	if(M.species.medallergens & medallergen_type) // Medical allergies don't gain ANY benefits...
+	if(M.species && (M.species.medallergens & medallergen_type)) // Medical allergies don't gain ANY benefits...
 		M.add_chemical_effect(CE_ALLERGEN, allergen_factor * removed)
 		remove_self(removed)
 		return


### PR DESCRIPTION
## About The Pull Request
Not sure how this happens, but brains don't have a species, so this runtimes. Adds a nullcheck.

:cl: Will
fix: Fix a runtime in brain mob's lifetick with reagents
/:cl:
