### PR TITLE
Cryocell Insertion Fix

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -182,21 +182,29 @@
 		var/obj/item/grab/grab = G
 		if(!ismob(grab.affecting))
 			return
-		if(occupant)
-			to_chat(user,span_warning("\The [src] is already occupied by [occupant]."))
-		if(grab.affecting.has_buckled_mobs())
-			to_chat(user, span_warning("\The [grab.affecting] has other entities attached to it. Remove them first."))
-			return
 		var/mob/M = grab.affecting
+		if(!check_put(M, user))
+			return
 		qdel(grab)
 		put_mob(M)
 
 	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(mob/target, mob/user) //Allows borgs to put people into cryo without external assistance
-	if(user.stat || user.lying || !Adjacent(user) || !target.Adjacent(user)|| !ishuman(target))
+	if(!check_put(target, user))
 		return
 	put_mob(target)
+
+/obj/machinery/atmospherics/unary/cryo_cell/proc/check_put(mob/target, mob/user)
+	if(user.stat || user.lying || !Adjacent(user) || !target.Adjacent(user)|| !ishuman(target))
+		return FALSE
+	if(occupant)
+		to_chat(user,span_warning("\The [src] is already occupied by [occupant]."))
+		return FALSE
+	if(target.has_buckled_mobs() || target.buckled)
+		to_chat(user, span_warning("\The [target] has other entities attached to it. Remove them first."))
+		return FALSE
+	return TRUE
 
 /obj/machinery/atmospherics/unary/cryo_cell/update_icon()
 	cut_overlay(fluid)


### PR DESCRIPTION
## About The Pull Request
Only the combat grab had an real restrictions on putting someone in the medical cryocell. 

## Changelog
Moves cryocell drag and grab checks to a single proc that safely checks all states.

:cl: Will
fix: You can no longer insert buckled players into multiple cryocells at once
/:cl:
