### PR TITLE
No salve RNG

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -928,7 +928,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		W.heal_damage(heal_amt)
 
 		// Salving also helps against infection
-		if(W.germ_level > 0 && W.salved && prob(2))
+		if(W.germ_level > 0 && W.salved)
 			W.disinfected = 1
 			W.germ_level = 0
 


### PR DESCRIPTION

## About The Pull Request
Removes the 2% RNG chance for ointment (and advanced packs) to actually disinfect wounds, which is extremely unintuitive. 
## Changelog
:cl: Diana
qol: Ointment and advanced burn packs properly disinfect wounds now instead of having a 2% chance to do so.
/:cl:
