### PR TITLE
Refactors throw vore code. Again.

### DIFF
--- a/code/datums/elements/vore/spontaneous_vore.dm
+++ b/code/datums/elements/vore/spontaneous_vore.dm
@@ -83,7 +83,7 @@
 		if(!destination_belly)
 			return
 		if(source.stat != DEAD && source.trash_catching)
-			if(source.eat_trash_proc(thrown_object))
+			if(source.eat_trash_proc(thrown_object, thrown = TRUE))
 				return COMSIG_CANCEL_HITBY
 
 	//Throwing a prey into a pred takes priority. After that it checks to see if the person being thrown is a pred.

--- a/code/datums/elements/vore/spontaneous_vore.dm
+++ b/code/datums/elements/vore/spontaneous_vore.dm
@@ -78,14 +78,12 @@
 
 	//Handle object throw vore
 	if(isitem(hitby))
-		var/obj/item/O = hitby
-		var/obj/belly/destination_belly = source.get_current_spont_belly(O)
+		var/obj/item/thrown_object = hitby
+		var/obj/belly/destination_belly = source.get_current_spont_belly(thrown_object)
 		if(!destination_belly)
 			return
 		if(source.stat != DEAD && source.trash_catching)
-			if(source.expanded_trasheat || is_type_in_list(O, GLOB.edible_trash) && O.trash_eatable && !is_type_in_list(O, GLOB.item_vore_blacklist))
-				source.visible_message(span_vwarning("[O] is thrown directly into [source]'s [lowertext(destination_belly.name)]!"))
-				destination_belly.nom_atom(O)
+			if(source.eat_trash_proc(thrown_object))
 				return COMSIG_CANCEL_HITBY
 
 	//Throwing a prey into a pred takes priority. After that it checks to see if the person being thrown is a pred.

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -95,15 +95,16 @@
 
 
 /mob/living/proc/eat_trash_proc(obj/item/item_to_eat, thrown = FALSE)
-	if(!item_to_eat.check_item_devourability(src))
+	if(!item_to_eat.check_item_devourability(src) && !thrown)
 		to_chat(src, span_warning("You can not eat this item."))
 		return FALSE
 
-	if(!item_to_eat.on_trash_eaten(src, send_failure_message = TRUE)) // shows object's rejection message itself
+	if(!item_to_eat.on_trash_eaten(src, send_failure_message = !thrown)) // shows object's rejection message itself
 		return FALSE
 
 	if(!thrown)
 		drop_item()
+
 	vore_selected.nom_atom(item_to_eat)
 	updateVRPanel()
 	log_admin("VORE: [src] used Eat Trash to swallow [item_to_eat].")

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -21,7 +21,8 @@
 		message_to_send = "You really should not be eating this."
 		message_admins("[key_name(user)] has attempted to ingest an uplink item. ([user ? ADMIN_JMP(user) : "null"])")
 
-	if(message_to_send)
+	if(!message_to_send)
+		return TRUE
 		if(send_failure_message)
 			to_chat(user, span_warning(message_to_send))
 			return FALSE

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -1,5 +1,5 @@
 // checks for when items are consumed by trash/ore eater
-/obj/item/proc/on_trash_eaten(mob/living/user)
+/obj/item/proc/on_trash_eaten(mob/living/user, send_failure_message)
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/signal_results = SEND_SIGNAL(src, COMSIG_ITEM_TRASH_EATEN, user) | SEND_SIGNAL(user, COMSIG_MOB_TRASH_EATING, src)
@@ -9,18 +9,24 @@
 		return TRUE
 
 	var/item_found = recursive_trash_eat_search(user)
+	var/message_to_send
+
 	if(item_found) //Checks for blacklisted items.
-		to_chat(user, span_warning("You are not allowed to eat \the [item_found]."))
-		return FALSE
+		message_to_send = "You are not allowed to eat \the [item_found]."
 
 	if(!trash_eatable) //OOC pref. This /IS/ respected, even if expanded_trasheat is enabled
-		to_chat(user, span_warning("You can't eat that so casually!"))
-		return FALSE
+		message_to_send = "You can't eat that so casually!"
 
 	if(hidden_uplink)
-		to_chat(user, span_warning("You really should not be eating this."))
+		message_to_send = "You really should not be eating this."
 		message_admins("[key_name(user)] has attempted to ingest an uplink item. ([user ? ADMIN_JMP(user) : "null"])")
+
+	if(message_to_send)
+		if(send_failure_message)
+			to_chat(user, span_warning(message_to_send))
+			return FALSE
 		return FALSE
+
 
 	return TRUE
 
@@ -67,6 +73,59 @@
 			return next_item_to_search
 	return FALSE
 
+/mob/living/proc/eat_trash_verb()
+	set name = "Eat Trash"
+	set category = "Abilities.Vore"
+	set desc = "Consume held garbage."
+
+	if(stat || is_paralyzed() || weakened || stunned || world.time < last_special)
+		to_chat(src, span_warning("You can't do that in your current state."))
+		return FALSE
+
+	if(!vore_selected)
+		to_chat(src,span_warning("You either don't have a belly selected, or don't have a belly!"))
+		return FALSE
+
+	var/obj/item/I = get_active_hand()
+	if(!I)
+		to_chat(src, span_warning("You are not holding anything."))
+		return FALSE
+
+	eat_trash_proc(I)
+
+
+/mob/living/proc/eat_trash_proc(obj/item/item_to_eat, thrown = FALSE)
+	if(!item_to_eat.check_item_devourability(src))
+		to_chat(src, span_warning("You can not eat this item."))
+		return FALSE
+
+	if(!item_to_eat.on_trash_eaten(src, send_failure_message = TRUE)) // shows object's rejection message itself
+		return FALSE
+
+	if(!thrown)
+		drop_item()
+	vore_selected.nom_atom(item_to_eat)
+	updateVRPanel()
+	log_admin("VORE: [src] used Eat Trash to swallow [item_to_eat].")
+	item_to_eat.after_trash_eaten(src)
+	visible_message(span_vwarning(src.vore_selected.belly_format_string(src.vore_selected.trash_eater_in, item_to_eat, item=item_to_eat)))
+	return TRUE
+
+/mob/living/proc/toggle_trash_catching() //Ported from chompstation
+	set name = "Toggle Trash Catching"
+	set category = "Abilities.Vore"
+	set desc = "Toggle Trash Eater throw vore abilities."
+	trash_catching = !trash_catching
+	to_chat(src, span_vwarning("Trash catching [trash_catching ? "enabled" : "disabled"]."))
+
+/mob/living/proc/eat_minerals() //Actual eating abstracted so the user isn't given a prompt due to an argument in this verb.
+	set name = "Eat Minerals"
+	set category = "Abilities.Vore"
+	set desc = "Consume held raw ore, gems and refined minerals. Snack time!"
+
+	handle_eat_minerals()
+
+
 /// Override this for post-swallow messages. Returns true if components on mob or item allow trash eating messages
 /obj/proc/after_trash_eaten(mob/living/user)
 	SHOULD_CALL_PARENT(TRUE)
@@ -82,7 +141,7 @@
 	to_chat(user, span_notice("You can taste the flavor of garbage. Delicious."))
 
 // PAI
-/obj/item/paicard/on_trash_eaten(mob/living/user)
+/obj/item/paicard/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	var/mob/living/silicon/pai/pocketpal = pai
@@ -100,7 +159,7 @@
 		to_chat(pai, span_boldnotice("[B.desc]"))
 
 // Book
-/obj/item/book/on_trash_eaten(mob/living/user)
+/obj/item/book/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	if(carved)
@@ -114,7 +173,7 @@
 	to_chat(user, span_notice("You can taste the dry flavor of knowledge."))
 
 // PDA
-/obj/item/pda/on_trash_eaten(mob/living/user)
+/obj/item/pda/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	if(owner)
@@ -151,7 +210,7 @@
 
 // ID
 
-/obj/item/card/id/on_trash_eaten(mob/living/user)
+/obj/item/card/id/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	if(registered_name)
@@ -175,7 +234,7 @@
 	to_chat(user, span_notice("You can taste the delicious flavour of a person's whole identity."))
 
 // Shoes
-/obj/item/clothing/shoes/on_trash_eaten(mob/living/user)
+/obj/item/clothing/shoes/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	if(holding)
@@ -184,7 +243,7 @@
 	return TRUE
 
 // Capture crystal
-/obj/item/capture_crystal/on_trash_eaten(mob/living/user)
+/obj/item/capture_crystal/on_trash_eaten(mob/living/user, send_failure_message)
 	if(!..())
 		return FALSE
 	if(!bound_mob.devourable)

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -23,13 +23,10 @@
 
 	if(!message_to_send)
 		return TRUE
-		if(send_failure_message)
-			to_chat(user, span_warning(message_to_send))
-			return FALSE
-		return FALSE
 
-
-	return TRUE
+	if(send_failure_message)
+		to_chat(user, span_warning(message_to_send))
+	return FALSE
 
 ///Checks to see if the item fails critieria to allow it to be eaten. Does NOT check the blacklist, as it's checked before this is called.
 /obj/item/proc/check_item_devourability(mob/living/user)

--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -95,8 +95,9 @@
 
 
 /mob/living/proc/eat_trash_proc(obj/item/item_to_eat, thrown = FALSE)
-	if(!item_to_eat.check_item_devourability(src) && !thrown)
-		to_chat(src, span_warning("You can not eat this item."))
+	if(!item_to_eat.check_item_devourability(src))
+		if(!thrown)
+			to_chat(src, span_warning("You can not eat this item."))
 		return FALSE
 
 	if(!item_to_eat.on_trash_eaten(src, send_failure_message = !thrown)) // shows object's rejection message itself

--- a/code/modules/admin/player_effects.dm
+++ b/code/modules/admin/player_effects.dm
@@ -605,7 +605,7 @@ ADMIN_VERB_AND_CONTEXT_MENU(player_effects, R_FUN, "Player Effects", "Modify a p
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
 				return
-			add_verb(Tar, /mob/living/proc/eat_trash)
+			add_verb(Tar, /mob/living/proc/eat_trash_verb)
 			add_verb(Tar, /mob/living/proc/toggle_trash_catching)
 
 		if("active_cloaking")

--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -414,14 +414,14 @@
 
 /datum/trait/neutral/trashcan/apply(datum/species/S,mob/living/carbon/human/H)
 	..()
-	add_verb(H, /mob/living/proc/eat_trash)
+	add_verb(H, /mob/living/proc/eat_trash_verb)
 	add_verb(H, /mob/living/proc/toggle_trash_catching)
 
 // Traitgenes made into a genetrait
 /datum/trait/neutral/trashcan/unapply(datum/species/S, mob/living/carbon/human/H, trait_prefs)
 	..()
-	if(!(/mob/living/proc/eat_trash in S.inherent_verbs))
-		remove_verb(H,/mob/living/proc/eat_trash)
+	if(!(/mob/living/proc/eat_trash_verb in S.inherent_verbs))
+		remove_verb(H,/mob/living/proc/eat_trash_verb)
 	if(!(/mob/living/proc/toggle_trash_catching in S.inherent_verbs))
 		remove_verb(H,/mob/living/proc/toggle_trash_catching)
 

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -229,7 +229,7 @@
 	add_verb(src, /mob/living/simple_mob/proc/animal_nom)
 	add_verb(src, /mob/living/proc/shred_limb)
 	add_verb(src, /mob/living/simple_mob/proc/nutrition_heal)
-	add_verb(src, /mob/living/proc/eat_trash)
+	add_verb(src, /mob/living/proc/eat_trash_verb)
 	add_verb(src, /mob/living/proc/toggle_trash_catching)
 
 	if(LAZYLEN(vore_organs))

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -196,15 +196,13 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			if(O.brute_dam > 0 || O.burn_dam > 0) //Making sure healing continues until fixed.
 				O.heal_damage(0.5, 0.5, 0, 1) // Less effective healing as able to fix broken limbs
 				B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
-				if(B.health_impacts_size)
-					B.owner.handle_belly_update()
+
 			if(L.health < L.getMaxHealth())
 				L.adjustToxLoss(-2)
 				L.adjustOxyLoss(-2)
 				L.adjustCloneLoss(-1)
 				B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
-				if(B.health_impacts_size)
-					B.owner.handle_belly_update()
+
 	if(B.owner.nutrition > 90 && (L.health < L.getMaxHealth()) && !H.isSynthetic())
 		L.adjustBruteLoss(-2.5)
 		L.adjustFireLoss(-2.5)
@@ -212,13 +210,13 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		L.adjustOxyLoss(-5)
 		L.adjustCloneLoss(-1.25)
 		B.owner.adjust_nutrition(-2)
-		if(B.health_impacts_size)
-			B.owner.handle_belly_update()
 		if(L.nutrition <= 400)
 			L.adjust_nutrition(1)
 	else if(B.owner.nutrition > 90 && (L.nutrition <= 400))
 		B.owner.adjust_nutrition(-1)
 		L.adjust_nutrition(1)
+	if(B.health_impacts_size)
+		B.owner.handle_belly_update()
 	if(L.stat != oldstat)
 		return list("to_update" = TRUE)
 

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -187,6 +187,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 
 /datum/digest_mode/heal/process_mob(obj/belly/B, mob/living/L)
 	var/oldstat = L.stat
+	var/needs_stomach_update = FALSE
 	if(L.stat == DEAD || !L.permit_healbelly) //healpref check
 		return null // Can't heal the dead with healbelly
 	var/mob/living/carbon/human/H = L
@@ -198,12 +199,14 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
 
 		if(L.health < L.getMaxHealth())
+			needs_stomach_update = TRUE
 			L.adjustToxLoss(-2)
 			L.adjustOxyLoss(-2)
 			L.adjustCloneLoss(-1)
 			B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
 
 	if(B.owner.nutrition > 90 && (L.health < L.getMaxHealth()) && !H.isSynthetic())
+		needs_stomach_update = TRUE
 		L.adjustBruteLoss(-2.5)
 		L.adjustFireLoss(-2.5)
 		L.adjustToxLoss(-5)
@@ -215,7 +218,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	else if(B.owner.nutrition > 90 && (L.nutrition <= 400))
 		B.owner.adjust_nutrition(-1)
 		L.adjust_nutrition(1)
-	if(B.health_impacts_size)
+	if(B.health_impacts_size && needs_stomach_update)
 		B.owner.handle_belly_update()
 	if(L.stat != oldstat)
 		return list("to_update" = TRUE)

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -197,11 +197,11 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				O.heal_damage(0.5, 0.5, 0, 1) // Less effective healing as able to fix broken limbs
 				B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
 
-			if(L.health < L.getMaxHealth())
-				L.adjustToxLoss(-2)
-				L.adjustOxyLoss(-2)
-				L.adjustCloneLoss(-1)
-				B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
+		if(L.health < L.getMaxHealth())
+			L.adjustToxLoss(-2)
+			L.adjustOxyLoss(-2)
+			L.adjustCloneLoss(-1)
+			B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
 
 	if(B.owner.nutrition > 90 && (L.health < L.getMaxHealth()) && !H.isSynthetic())
 		L.adjustBruteLoss(-2.5)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -837,53 +837,6 @@
 /mob/living/proc/get_digestion_efficiency_modifier()
 	return 1
 
-/mob/living/proc/eat_trash()
-	set name = "Eat Trash"
-	set category = "Abilities.Vore"
-	set desc = "Consume held garbage."
-
-	if(stat || is_paralyzed() || weakened || stunned || world.time < last_special)
-		to_chat(src, span_warning("You can't do that in your current state."))
-		return FALSE
-
-	if(!vore_selected)
-		to_chat(src,span_warning("You either don't have a belly selected, or don't have a belly!"))
-		return FALSE
-
-	var/obj/item/I = get_active_hand()
-	if(!I)
-		to_chat(src, span_warning("You are not holding anything."))
-		return FALSE
-
-	if(!I.check_item_devourability(src))
-		to_chat(src, span_warning("You can not eat this item."))
-		return FALSE
-
-	if(!I.on_trash_eaten(src)) // shows object's rejection message itself
-		return FALSE
-
-	drop_item()
-	vore_selected.nom_atom(I)
-	updateVRPanel()
-	log_admin("VORE: [src] used Eat Trash to swallow [I].")
-	I.after_trash_eaten(src)
-	visible_message(span_vwarning(src.vore_selected.belly_format_string(src.vore_selected.trash_eater_in, I, item=I)))
-	return FALSE
-
-/mob/living/proc/toggle_trash_catching() //Ported from chompstation
-	set name = "Toggle Trash Catching"
-	set category = "Abilities.Vore"
-	set desc = "Toggle Trash Eater throw vore abilities."
-	trash_catching = !trash_catching
-	to_chat(src, span_vwarning("Trash catching [trash_catching ? "enabled" : "disabled"]."))
-
-/mob/living/proc/eat_minerals() //Actual eating abstracted so the user isn't given a prompt due to an argument in this verb.
-	set name = "Eat Minerals"
-	set category = "Abilities.Vore"
-	set desc = "Consume held raw ore, gems and refined minerals. Snack time!"
-
-	handle_eat_minerals()
-
 /mob/living/proc/handle_eat_minerals(obj/item/snack, mob/living/user)
 	var/mob/living/feeder = user ? user : src //Whoever's doing the feeding - us or someone else.
 	var/mob/living/carbon/human/H = src


### PR DESCRIPTION

## About The Pull Request
Refactors throw code:

Eat Trash is no longer a verb-proc, instead is a proc that calls a helper proc after doing some checks.

Throw vore now does the proper recursive checks.

Also adds a fix for healbellies. 

## Changelog
:cl:
refactor: Trasheat code is a bit easier to follow on the backend, now.
fix: Throwing trash now properly respects the recursive search check.
code: Optimizes healbelly code so that handle_belly_update isn't called upwards of 26 times a cycle, only called one time a cycle now.
/:cl:
