### PR TITLE
make account uplink terminal labels wrap

### DIFF
--- a/tgui/packages/tgui/interfaces/AccountsTerminal.tsx
+++ b/tgui/packages/tgui/interfaces/AccountsTerminal.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   LabeledList,
   Section,
+  Stack,
   Table,
   Tabs,
 } from 'tgui-core/components';
@@ -46,24 +47,32 @@ export const AccountsTerminal = (props) => {
 
   return (
     <Window width={400} height={640}>
-      <Window.Content scrollable>
-        <Section>
-          <LabeledList>
-            <LabeledList.Item label="Machine" color="average">
-              {machine_id}
-            </LabeledList.Item>
-            <LabeledList.Item label="ID">
-              <Button
-                icon={id_inserted ? 'eject' : 'sign-in-alt'}
-                fluid
-                onClick={() => act('insert_card')}
-              >
-                {id_card}
-              </Button>
-            </LabeledList.Item>
-          </LabeledList>
-        </Section>
-        {access_level > 0 && <AccountTerminalContent />}
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Section>
+              <LabeledList>
+                <LabeledList.Item label="Machine" color="average">
+                  {machine_id}
+                </LabeledList.Item>
+                <LabeledList.Item label="ID">
+                  <Button
+                    icon={id_inserted ? 'eject' : 'sign-in-alt'}
+                    fluid
+                    onClick={() => act('insert_card')}
+                  >
+                    {id_card}
+                  </Button>
+                </LabeledList.Item>
+              </LabeledList>
+            </Section>
+          </Stack.Item>
+          {access_level > 0 && (
+            <Stack.Item grow>
+              <AccountTerminalContent />
+            </Stack.Item>
+          )}
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -75,32 +84,38 @@ const AccountTerminalContent = (props) => {
   const { creating_new_account, detailed_account_view } = data;
 
   return (
-    <Section title="Menu">
-      <Tabs>
-        <Tabs.Tab
-          selected={!creating_new_account && !detailed_account_view}
-          icon="home"
-          onClick={() => act('view_accounts_list')}
-        >
-          Home
-        </Tabs.Tab>
-        <Tabs.Tab
-          selected={!!creating_new_account}
-          icon="cog"
-          onClick={() => act('create_account')}
-        >
-          New Account
-        </Tabs.Tab>
-        {!creating_new_account ? (
-          <Tabs.Tab icon="print" onClick={() => act('print')}>
-            Print
-          </Tabs.Tab>
-        ) : (
-          ''
-        )}
-      </Tabs>
-      {(creating_new_account && <NewAccountView />) ||
-        (detailed_account_view && <DetailedView />) || <ListView />}
+    <Section fill title="Menu">
+      <Stack vertical fill>
+        <Stack.Item>
+          <Tabs>
+            <Tabs.Tab
+              selected={!creating_new_account && !detailed_account_view}
+              icon="home"
+              onClick={() => act('view_accounts_list')}
+            >
+              Home
+            </Tabs.Tab>
+            <Tabs.Tab
+              selected={!!creating_new_account}
+              icon="cog"
+              onClick={() => act('create_account')}
+            >
+              New Account
+            </Tabs.Tab>
+            {!creating_new_account ? (
+              <Tabs.Tab icon="print" onClick={() => act('print')}>
+                Print
+              </Tabs.Tab>
+            ) : (
+              ''
+            )}
+          </Tabs>
+        </Stack.Item>
+        <Stack.Item grow>
+          {(creating_new_account && <NewAccountView />) ||
+            (detailed_account_view && <DetailedView />) || <ListView />}
+        </Stack.Item>
+      </Stack>
     </Section>
   );
 };
@@ -112,7 +127,7 @@ const NewAccountView = (props) => {
   const [newMoney, setMoney] = useSharedState('money', '');
 
   return (
-    <Section title="Create Account">
+    <Section fill scrollable title="Create Account">
       <LabeledList>
         <LabeledList.Item label="Account Holder">
           <Input value={holder} fluid onChange={(val) => setHolder(val)} />
@@ -154,6 +169,8 @@ const DetailedView = (props) => {
 
   return (
     <Section
+      fill
+      scrollable
       title="Account Details"
       buttons={
         <Button
@@ -234,11 +251,12 @@ const ListView = (props) => {
   const { accounts } = data;
 
   return (
-    <Section title="NanoTrasen Accounts">
+    <Section fill scrollable title="NanoTrasen Accounts">
       {(accounts.length && (
         <LabeledList>
           {accounts.map((acc) => (
             <LabeledList.Item
+              labelWrap
               label={acc.owner_name + acc.suspended}
               color={acc.suspended ? 'bad' : undefined}
               key={acc.account_index}

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsolTypes.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsolTypes.tsx
@@ -8,7 +8,7 @@ export const RequestConsoleSupplies = (props) => {
   const { data } = useBackend<Data>();
   const { department, supply_dept } = data;
   return (
-    <Section title="Supplies">
+    <Section fill scrollable title="Supplies">
       <RequestConsoleSendMenu dept_list={supply_dept} department={department} />
     </Section>
   );
@@ -18,7 +18,7 @@ export const RequestConsoleAssistance = (props) => {
   const { data } = useBackend<Data>();
   const { department, assist_dept } = data;
   return (
-    <Section title="Request assistance from another department">
+    <Section fill scrollable title="Request assistance from another department">
       <RequestConsoleSendMenu dept_list={assist_dept} department={department} />
     </Section>
   );
@@ -28,7 +28,7 @@ export const RequestConsoleRelay = (props) => {
   const { data } = useBackend<Data>();
   const { department, info_dept } = data;
   return (
-    <Section title="Report Anonymous Information">
+    <Section fill scrollable title="Report Anonymous Information">
       <RequestConsoleSendMenu dept_list={info_dept} department={department} />
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleMessage.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleMessage.tsx
@@ -2,14 +2,13 @@ import { useBackend } from 'tgui/backend';
 import { Box, Button, LabeledList, Section } from 'tgui-core/components';
 import { decodeHtmlEntities } from 'tgui-core/string';
 
-import { RCS_MAINMENU } from './constants';
 import type { Data } from './types';
 
 export const RequestConsoleViewMessages = (props) => {
   const { act, data } = useBackend<Data>();
   const { message_log } = data;
   return (
-    <Section title="Messages">
+    <Section fill scrollable title="Messages">
       {(message_log.length &&
         message_log.map((msg, i) => (
           <LabeledList.Item
@@ -32,9 +31,10 @@ export const RequestConsoleViewMessages = (props) => {
   );
 };
 
-export const RequestConsoleMessageAuth = (props) => {
+export const RequestConsoleMessageAuth = (props: { lastTab: number }) => {
   const { act, data } = useBackend<Data>();
   const { message, recipient, priority, msgStamped, msgVerified } = data;
+  const { lastTab } = props;
   return (
     <Section title="Message Authentication">
       <LabeledList>
@@ -70,7 +70,7 @@ export const RequestConsoleMessageAuth = (props) => {
       </Button>
       <Button
         icon="undo"
-        onClick={() => act('setScreen', { setScreen: RCS_MAINMENU })}
+        onClick={() => act('setScreen', { setScreen: lastTab })}
       >
         Back
       </Button>
@@ -78,9 +78,10 @@ export const RequestConsoleMessageAuth = (props) => {
   );
 };
 
-export const RequestConsoleAnnounce = (props) => {
+export const RequestConsoleAnnounce = (props: { lastTab: number }) => {
   const { act, data } = useBackend<Data>();
   const { message, announceAuth } = data;
+  const { lastTab } = props;
   return (
     <Section title="Send Station-Wide Announcement">
       {(announceAuth && (
@@ -120,7 +121,7 @@ export const RequestConsoleAnnounce = (props) => {
       </Button>
       <Button
         icon="undo"
-        onClick={() => act('setScreen', { setScreen: RCS_MAINMENU })}
+        onClick={() => act('setScreen', { setScreen: lastTab })}
       >
         Back
       </Button>

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleMessage.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleMessage.tsx
@@ -13,6 +13,7 @@ export const RequestConsoleViewMessages = (props) => {
       {(message_log.length &&
         message_log.map((msg, i) => (
           <LabeledList.Item
+            labelWrap
             label={decodeHtmlEntities(msg[0])}
             key={i}
             buttons={

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSend.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSend.tsx
@@ -26,6 +26,7 @@ export const RequestConsoleSendMenu = (props: {
                   </Stack.Item>
                   <Stack.Item>
                     <Button
+                      color="red"
                       icon="exclamation-triangle"
                       onClick={() => act('write', { write: dept, priority: 2 })}
                     >

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSend.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSend.tsx
@@ -1,8 +1,6 @@
 import { useBackend } from 'tgui/backend';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
 
-import { RCS_MAINMENU } from './constants';
-
 export const RequestConsoleSendMenu = (props: {
   dept_list: string[];
   department: string;
@@ -44,8 +42,9 @@ export const RequestConsoleSendMenu = (props: {
   );
 };
 
-export const RequestConsoleSendPass = (props) => {
-  const { act, data } = useBackend();
+export const RequestConsoleSendPass = (props: { lastTab: number }) => {
+  const { act } = useBackend();
+  const { lastTab } = props;
   return (
     <Section>
       <Box fontSize={2} color="good">
@@ -54,7 +53,7 @@ export const RequestConsoleSendPass = (props) => {
       <Box>
         <Button
           icon="arrow-right"
-          onClick={() => act('setScreen', { setScreen: RCS_MAINMENU })}
+          onClick={() => act('setScreen', { setScreen: lastTab })}
         >
           Continue
         </Button>
@@ -63,8 +62,9 @@ export const RequestConsoleSendPass = (props) => {
   );
 };
 
-export const RequestConsoleSendFail = (props) => {
-  const { act, data } = useBackend();
+export const RequestConsoleSendFail = (props: { lastTab: number }) => {
+  const { act } = useBackend();
+  const { lastTab } = props;
   return (
     <Section>
       <Box fontSize={1.5} bold color="bad">
@@ -73,7 +73,7 @@ export const RequestConsoleSendFail = (props) => {
       <Box>
         <Button
           icon="arrow-right"
-          onClick={() => act('setScreen', { setScreen: RCS_MAINMENU })}
+          onClick={() => act('setScreen', { setScreen: lastTab })}
         >
           Continue
         </Button>

--- a/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSettings.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/RequestConsoleSettings.tsx
@@ -7,7 +7,7 @@ export const RequestConsoleSettings = (props) => {
   const { act, data } = useBackend<Data>();
   const { silent } = data;
   return (
-    <Section title="Settings">
+    <Section fill title="Settings">
       <Button
         selected={!silent}
         icon={silent ? 'volume-mute' : 'volume-up'}

--- a/tgui/packages/tgui/interfaces/RequestConsole/index.tsx
+++ b/tgui/packages/tgui/interfaces/RequestConsole/index.tsx
@@ -1,7 +1,7 @@
+import { useState } from 'react';
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
-import { Section, Tabs } from 'tgui-core/components';
-
+import { Section, Stack, Tabs } from 'tgui-core/components';
 import {
   RCS_ANNOUNCE,
   RCS_MAINMENU,
@@ -34,79 +34,94 @@ export const RequestConsole = (props) => {
   const { act, data } = useBackend<Data>();
   const { screen, newmessagepriority, announcementConsole } = data;
 
+  const [lastTab, setLastTab] = useState<number>(RCS_VIEWMSGS);
+
   const body: React.JSX.Element[] = [];
 
   body[RCS_MAINMENU] = <RequestConsoleSettings />;
   body[RCS_RQASSIST] = <RequestConsoleAssistance />;
   body[RCS_RQSUPPLY] = <RequestConsoleSupplies />;
   body[RCS_SENDINFO] = <RequestConsoleRelay />;
-  body[RCS_SENTPASS] = <RequestConsoleSendPass />;
-  body[RCS_SENTFAIL] = <RequestConsoleSendFail />;
+  body[RCS_SENTPASS] = <RequestConsoleSendPass lastTab={lastTab} />;
+  body[RCS_SENTFAIL] = <RequestConsoleSendFail lastTab={lastTab} />;
   body[RCS_VIEWMSGS] = <RequestConsoleViewMessages />;
-  body[RCS_MESSAUTH] = <RequestConsoleMessageAuth />;
-  body[RCS_ANNOUNCE] = <RequestConsoleAnnounce />;
+  body[RCS_MESSAUTH] = <RequestConsoleMessageAuth lastTab={lastTab} />;
+  body[RCS_ANNOUNCE] = <RequestConsoleAnnounce lastTab={lastTab} />;
+
+  function adjustTab(newTab: number) {
+    setLastTab(newTab);
+    act('setScreen', { setScreen: newTab });
+  }
 
   return (
     <Window width={520} height={410}>
-      <Window.Content scrollable>
-        <Tabs>
-          <Tabs.Tab
-            selected={screen === RCS_VIEWMSGS}
-            onClick={() => act('setScreen', { setScreen: RCS_VIEWMSGS })}
-            icon="envelope-open-text"
-          >
-            Messages
-          </Tabs.Tab>
-          <Tabs.Tab
-            selected={screen === RCS_RQASSIST}
-            onClick={() => act('setScreen', { setScreen: RCS_RQASSIST })}
-            icon="share-square"
-          >
-            Assistance
-          </Tabs.Tab>
-          <Tabs.Tab
-            selected={screen === RCS_RQSUPPLY}
-            onClick={() => act('setScreen', { setScreen: RCS_RQSUPPLY })}
-            icon="share-square"
-          >
-            Supplies
-          </Tabs.Tab>
-          <Tabs.Tab
-            selected={screen === RCS_SENDINFO}
-            onClick={() => act('setScreen', { setScreen: RCS_SENDINFO })}
-            icon="share-square-o"
-          >
-            Report
-          </Tabs.Tab>
-          {(announcementConsole && (
-            <Tabs.Tab
-              selected={screen === RCS_ANNOUNCE}
-              onClick={() => act('setScreen', { setScreen: RCS_ANNOUNCE })}
-              icon="volume-up"
-            >
-              Announce
-            </Tabs.Tab>
-          )) ||
-            null}
-          <Tabs.Tab
-            selected={screen === RCS_MAINMENU}
-            onClick={() => act('setScreen', { setScreen: RCS_MAINMENU })}
-            icon="cog"
-          />
-        </Tabs>
-        {(newmessagepriority && (
-          <Section
-            title={
-              newmessagepriority > 1
-                ? 'NEW PRIORITY MESSAGES'
-                : 'There are new messages!'
-            }
-            color={newmessagepriority > 1 ? 'bad' : 'average'}
-            bold={newmessagepriority > 1}
-          />
-        )) ||
-          null}
-        {body[screen] || ''}
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Tabs>
+              <Tabs.Tab
+                selected={screen === RCS_VIEWMSGS}
+                onClick={() => adjustTab(RCS_VIEWMSGS)}
+                icon="envelope-open-text"
+              >
+                Messages
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={screen === RCS_RQASSIST}
+                onClick={() => adjustTab(RCS_VIEWMSGS)}
+                icon="share-square"
+              >
+                Assistance
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={screen === RCS_RQSUPPLY}
+                onClick={() => adjustTab(RCS_RQSUPPLY)}
+                icon="share-square"
+              >
+                Supplies
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={screen === RCS_SENDINFO}
+                onClick={() => adjustTab(RCS_SENDINFO)}
+                icon="share-square-o"
+              >
+                Report
+              </Tabs.Tab>
+              {(announcementConsole && (
+                <Tabs.Tab
+                  selected={screen === RCS_ANNOUNCE}
+                  onClick={() => adjustTab(RCS_ANNOUNCE)}
+                  icon="volume-up"
+                >
+                  Announce
+                </Tabs.Tab>
+              )) ||
+                null}
+              <Tabs.Tab
+                selected={screen === RCS_MAINMENU}
+                onClick={() => adjustTab(RCS_MAINMENU)}
+                icon="cog"
+              >
+                Settings
+              </Tabs.Tab>
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow>
+            {(newmessagepriority && (
+              <Section
+                title={
+                  newmessagepriority > 1
+                    ? 'NEW PRIORITY MESSAGES'
+                    : 'There are new messages!'
+                }
+                color={newmessagepriority > 1 ? 'bad' : 'average'}
+                bold={newmessagepriority > 1}
+              />
+            )) ||
+              null}
+            {body[screen] || ''}
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: longer account names no longer move the account buttons outside of the UI view of the accounts uplink terminal
/:cl:
