### PR TITLE
Chameleon clerical kit

### DIFF
--- a/code/modules/research/tg/designs/illegal_designs.dm
+++ b/code/modules/research/tg/designs/illegal_designs.dm
@@ -26,6 +26,20 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
+/datum/design_techweb/clerical
+	name = "clerical equipment kit"
+	desc = "A kit of clerical equipment with a pen and stamp that can change appearance and color."
+	id = "clerical"
+	// req_tech = list(TECH_ILLEGAL = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_STEEL = 500)
+	build_path = /obj/item/storage/box/syndie_kit/clerical
+	category = list(
+		RND_CATEGORY_HACKED,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MISC
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design_techweb/bodysnatcher
 	name = "Body Snatcher"
 	id = "bodysnatcher"

--- a/code/modules/research/tg/techwebs/nodes/research_nodes.dm
+++ b/code/modules/research/tg/techwebs/nodes/research_nodes.dm
@@ -68,6 +68,7 @@
 		"beacon",
 		"beacon_locator",
 		"chameleon",
+		"clerical",
 		"shelter_capsule",
 		"shelter_capsule_luxury",
 		"shelter_capsule_recroom",


### PR DESCRIPTION

## About The Pull Request
Adds the Clerical equipment kit to the hacked protolathe.
Less impactful than the holographic equipment kit, but 100x less buggy and 10x more useless (unless you're actually doing paperwork)
## Changelog
:cl:
add: Adds the Clerical Equipment Kit to the hacked protolathe.
/:cl:
