### PR TITLE
is_hot() global proc removal

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1010,41 +1010,44 @@ GLOBAL_LIST_INIT(common_tools, list(
 		return TRUE
 	return
 
-/proc/is_hot(obj/item/W as obj)
-	switch(W.type)
-		if(/obj/item/weldingtool)
-			var/obj/item/weldingtool/WT = W
-			if(WT.isOn())
-				return 3800
-			else
-				return 0
-		if(/obj/item/tool/transforming)
-			var/obj/item/tool/transforming/TT = W
-			if(TT.possible_tooltypes[TT.current_tooltype] == TOOL_WELDER)
-				return 3800
-			else
-				return 0
-		if(/obj/item/flame/lighter)
-			if(W:lit)
-				return 1500
-			else
-				return 0
-		if(/obj/item/flame/match)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/clothing/mask/smokable/cigarette)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/pickaxe/plasmacutter)
+/proc/is_hot(obj/item/W)
+	if(istype(W, /obj/item/weldingtool))
+		var/obj/item/weldingtool/WT = W
+		if(WT.isOn())
 			return 3800
-		if(/obj/item/melee/energy)
-			return 3500
-		else
-			return 0
+		return 0
+
+	if(istype(W, /obj/item/tool/transforming))
+		var/obj/item/tool/transforming/TT = W
+		if(TT.possible_tooltypes[TT.current_tooltype] == TOOL_WELDER)
+			return 3800
+		return 0
+
+	if(istype(W, /obj/item/flame/lighter))
+		var/obj/item/flame/lighter/ligh = W
+		if(ligh.lit)
+			return 1500
+		return 0
+
+	if(istype(W, /obj/item/flame/match))
+		var/obj/item/flame/match/mach = W
+		if(mach.lit)
+			return 1000
+		return 0
+
+	if(istype(W, /obj/item/clothing/mask/smokable/cigarette))
+		var/obj/item/clothing/mask/smokable/cigarette/cig = W
+		if(cig.lit)
+			return 1000
+		return 0
+
+	if(istype(W, /obj/item/pickaxe/plasmacutter))
+		return 3800
+
+	if(istype(W, /obj/item/melee/energy))
+		return 3500
+
+	return 0
 
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/item/O)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1010,45 +1010,6 @@ GLOBAL_LIST_INIT(common_tools, list(
 		return TRUE
 	return
 
-/proc/is_hot(obj/item/W)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.isOn())
-			return 3800
-		return 0
-
-	if(istype(W, /obj/item/tool/transforming))
-		var/obj/item/tool/transforming/TT = W
-		if(TT.possible_tooltypes[TT.current_tooltype] == TOOL_WELDER)
-			return 3800
-		return 0
-
-	if(istype(W, /obj/item/flame/lighter))
-		var/obj/item/flame/lighter/ligh = W
-		if(ligh.lit)
-			return 1500
-		return 0
-
-	if(istype(W, /obj/item/flame/match))
-		var/obj/item/flame/match/mach = W
-		if(mach.lit)
-			return 1000
-		return 0
-
-	if(istype(W, /obj/item/clothing/mask/smokable/cigarette))
-		var/obj/item/clothing/mask/smokable/cigarette/cig = W
-		if(cig.lit)
-			return 1000
-		return 0
-
-	if(istype(W, /obj/item/pickaxe/plasmacutter))
-		return 3800
-
-	if(istype(W, /obj/item/melee/energy))
-		return 3500
-
-	return 0
-
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/item/O)
 	if(!isitem(O))

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -411,9 +411,9 @@
 	icon = 'icons/obj/doors/Doorphoron.dmi'
 	mineral = MAT_PHORON
 
-/obj/machinery/door/airlock/phoron/attackby(obj/C, mob/user)
+/obj/machinery/door/airlock/phoron/attackby(obj/item/C, mob/user)
 	if(C)
-		ignite(is_hot(C))
+		ignite(C.is_hot())
 	. = ..()
 
 /obj/machinery/door/airlock/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -154,8 +154,15 @@
 
 	if(W)
 		radiate()
-		if(is_hot(W))
-			burn(is_hot(W))
+		if(W.is_hot())
+			var/burn_temp = 1000
+			if(istype(W, /obj/item/flame/lighter))
+				burn_temp = 1500
+			if(istype(W, /obj/item/melee/energy))
+				burn_temp = 3500
+			if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/tool/transforming) || istype(W, /obj/item/pickaxe/plasmacutter))
+				burn_temp = 3800
+			burn(burn_temp)
 
 	if(istype(W, /obj/item/electronic_assembly/wallmount))
 		var/obj/item/electronic_assembly/wallmount/IC = W


### PR DESCRIPTION
## About The Pull Request
Removes a barely used is_hot() global proc. This is a confusingly named proc that shares a name with the /obj/item proc is_hot(). It returned a temperature that was only checked by wall attack interactions. 

:cl: Will
refactor: removed global is_hot() proc only used by wall attacks
/:cl:
