### PR TITLE
Allows borgs to open the grid checker UI

### DIFF
--- a/code/modules/power/grid_checker.dm
+++ b/code/modules/power/grid_checker.dm
@@ -46,8 +46,6 @@
 		attack_hand(user)
 
 /obj/machinery/power/grid_checker/attack_robot(mob/living/user)
-	if(!user)
-		return
 	interact(user)
 
 /obj/machinery/power/grid_checker/attack_hand(mob/user)

--- a/code/modules/power/grid_checker.dm
+++ b/code/modules/power/grid_checker.dm
@@ -45,6 +45,11 @@
 	else if(istype(W, /obj/item/multitool) || W.has_tool_quality(TOOL_WIRECUTTER))
 		attack_hand(user)
 
+/obj/machinery/power/grid_checker/attack_robot(mob/living/user)
+	if(!user)
+		return
+	interact(user)
+
 /obj/machinery/power/grid_checker/attack_hand(mob/user)
 	if(!user)
 		return


### PR DESCRIPTION
## About The Pull Request
I'm not really sure why this wasn't possible, or if this was even intended? I imagine if it was intended then it would have some kind of firewall to_chat message. Instead of just does nothing. Lets borgs fix gridchecker power out events.

:cl: Will
qol: Borgs can open the gridchecker's UI
/:cl:
