### PR TITLE
Fix turf slip value persisting through turf change

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -93,7 +93,7 @@
 		W_sim.shandler.manualInit()
 	if(old_fire)
 		old_fire.RemoveFire()
-	if(istype(N,/turf/simulated))
+	if(istype(N, /turf/simulated))
 		var/turf/simulated/new_turf = N
 		new_turf.wet = initial(new_turf.wet)
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -93,6 +93,9 @@
 		W_sim.shandler.manualInit()
 	if(old_fire)
 		old_fire.RemoveFire()
+	if(istype(N,/turf/simulated))
+		var/turf/simulated/new_turf = N
+		new_turf.wet = initial(new_turf.wet)
 
 	if(tell_universe)
 		GLOB.universe.OnTurfChange(W)


### PR DESCRIPTION
## About The Pull Request
TurfChange does not reset the floor's wet value. Meaning floors like ice will retain its slipping properties even if converted to another turf. And turf wet by a mop will lose it's timer and remain wet forever.

## Changelog
Turf changes reset the turf's wet state.

:cl: Will
fix: Wet/slippery turf state no longer persists through turf change
/:cl:
