### PR TITLE
Fixed belly display name

### DIFF
--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -556,7 +556,7 @@
 				last_transfer_log = world.time
 				entrance_log_count = 0
 			if(world.time >= next_transfer_log)
-				to_chat(owner,span_vnotice("[thing] slides into your [lowertext(name)]."))
+				to_chat(owner,span_vnotice("[thing] slides into your [lowertext(get_belly_name())]."))
 				entrance_log_count++
 				if(entrance_log_count >= MAX_ENTRY_MESSAAGES)
 					next_transfer_log = world.time + ENTRY_MESSAGE_INTERVAL
@@ -706,7 +706,7 @@
 
 	//Print notifications/sound if necessary
 	if(!silent && count)
-		owner.visible_message(span_vnotice(span_green(span_bold("[owner] [release_verb] everything from their [lowertext(name)]!"))), range = privacy_range)
+		owner.visible_message(span_vnotice(span_green(span_bold("[owner] [release_verb] everything from their [lowertext(get_belly_name())]!"))), range = privacy_range)
 		var/soundfile
 		if(!fancy_vore)
 			soundfile = GLOB.classic_release_sounds[release_sound]
@@ -796,7 +796,7 @@
 		if(isitem(M))
 			owner.visible_message(span_vnotice(span_green(span_bold(belly_format_string(trash_eater_out, M, item=M)))),range = privacy_range) //double dip. prey = item, item = prey. sanity check in case they use %prey in the message.
 		else
-			owner.visible_message(span_vnotice(span_green(span_bold("[owner] [release_verb] [M] from their [lowertext(name)]!"))),range = privacy_range)
+			owner.visible_message(span_vnotice(span_green(span_bold("[owner] [release_verb] [M] from their [lowertext(get_belly_name())]!"))),range = privacy_range)
 		var/soundfile
 		if(!fancy_vore)
 			soundfile = GLOB.classic_release_sounds[release_sound]
@@ -1177,7 +1177,7 @@
 	if(ismob(prey))
 		var/autotransfer_owner_message
 		var/autotransfer_prey_message
-		var/dest_belly_name = dest_belly.name
+		var/dest_belly_name = dest_belly.get_belly_name()
 		if(dest_belly.name == autotransferlocation)
 			autotransfer_owner_message = span_vwarning(belly_format_string(primary_autotransfer_messages_owner, prey, dest = dest_belly_name))
 			autotransfer_prey_message = span_vwarning(belly_format_string(primary_autotransfer_messages_prey, prey, dest = dest_belly_name))
@@ -1829,7 +1829,6 @@
 		. += AM
 
 /obj/belly/proc/get_belly_name(original)
-	var/display_name = ""
 	if(original)
 		return display_name ? display_name : name
 	return display_name ? lowertext(display_name) : lowertext(name)

--- a/code/modules/vore/eating/belly_obj_resist.dm
+++ b/code/modules/vore/eating/belly_obj_resist.dm
@@ -171,8 +171,8 @@
 		transferlocation = null
 		return TRUE
 
-	var/primary_transfer_owner_message = span_vwarning(belly_format_string(primary_transfer_messages_owner, living_prey, dest = transferlocation))
-	var/primary_transfer_prey_message = span_vwarning(belly_format_string(primary_transfer_messages_prey, living_prey, dest = transferlocation))
+	var/primary_transfer_owner_message = span_vwarning(belly_format_string(primary_transfer_messages_owner, living_prey, dest = dest_belly.get_belly_name()))
+	var/primary_transfer_prey_message = span_vwarning(belly_format_string(primary_transfer_messages_prey, living_prey, dest = dest_belly.get_belly_name()))
 
 	to_chat(living_prey, primary_transfer_prey_message)
 	to_chat(owner, primary_transfer_owner_message)
@@ -199,8 +199,8 @@
 		transferlocation_secondary = null
 		return TRUE
 
-	var/secondary_transfer_owner_message = span_vwarning(belly_format_string(secondary_transfer_messages_owner, living_prey, dest = transferlocation_secondary))
-	var/secondary_transfer_prey_message = span_vwarning(belly_format_string(secondary_transfer_messages_prey, living_prey, dest = transferlocation_secondary))
+	var/secondary_transfer_owner_message = span_vwarning(belly_format_string(secondary_transfer_messages_owner, living_prey, dest = dest_belly.get_belly_name()))
+	var/secondary_transfer_prey_message = span_vwarning(belly_format_string(secondary_transfer_messages_prey, living_prey, dest = dest_belly.get_belly_name()))
 
 	to_chat(living_prey, secondary_transfer_prey_message)
 	to_chat(owner, secondary_transfer_owner_message)

--- a/code/modules/vore/eating/panel_databackend/vorepanel_vore_data.dm
+++ b/code/modules/vore/eating/panel_databackend/vorepanel_vore_data.dm
@@ -50,7 +50,7 @@
 
 	inside = list(
 		"absorbed" = owner.absorbed,
-		"belly_name" = inside_belly.name,
+		"belly_name" = inside_belly.get_belly_name(),
 		"belly_mode" = inside_belly.digest_mode,
 		"desc" = inside_desc,
 		"pred" = pred,

--- a/code/modules/vore/eating/vore_procs.dm
+++ b/code/modules/vore/eating/vore_procs.dm
@@ -108,13 +108,13 @@
 	var/success_msg = "ERROR: Vore message couldn't be created. Notify a dev. (sc)"
 
 	if(prey.is_slipping)
-		success_msg = span_vwarning("[prey] suddenly slides into [pred]'s [lowertext(belly.name)]!")
+		success_msg = span_vwarning("[prey] suddenly slides into [pred]'s [lowertext(belly.get_belly_name())]!")
 	else if(pred.is_slipping)
-		success_msg = span_vwarning("[prey] suddenly slips inside of [pred]'s [lowertext(belly.name)] as [pred] slides into them!")
+		success_msg = span_vwarning("[prey] suddenly slips inside of [pred]'s [lowertext(belly.get_belly_name())] as [pred] slides into them!")
 	else if(user == pred) //Feeding someone to yourself
-		success_msg = span_vwarning("[pred] manages to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!")
+		success_msg = span_vwarning("[pred] manages to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.get_belly_name())]!")
 	else //Feeding someone to another person
-		success_msg = span_vwarning("[user] manages to make [pred] [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!")
+		success_msg = span_vwarning("[user] manages to make [pred] [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.get_belly_name())]!")
 	return success_msg
 
 /**
@@ -127,13 +127,13 @@
 	var/attempt_msg = "ERROR: Vore message couldn't be created. Notify a dev. (sc)"
 
 	if(prey.is_slipping)
-		attempt_msg = span_vwarning("It seems like [prey] is about to slide into [pred]'s [lowertext(belly.name)]!")
+		attempt_msg = span_vwarning("It seems like [prey] is about to slide into [pred]'s [lowertext(belly.get_belly_name())]!")
 	else if(pred.is_slipping)
-		attempt_msg = span_vwarning("It seems like [prey] is gonna end up inside [pred]'s [lowertext(belly.name)] as [pred] comes sliding over!")
+		attempt_msg = span_vwarning("It seems like [prey] is gonna end up inside [pred]'s [lowertext(belly.get_belly_name())] as [pred] comes sliding over!")
 	else if(user == pred) //Feeding someone to yourself
-		attempt_msg = span_vwarning("[pred] is attempting to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!")
+		attempt_msg = span_vwarning("[pred] is attempting to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.get_belly_name())]!")
 	else //Feeding someone to another person
-		attempt_msg = span_vwarning("[user] is attempting to make [pred] [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!")
+		attempt_msg = span_vwarning("[user] is attempting to make [pred] [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.get_belly_name())]!")
 	return attempt_msg
 
 /**


### PR DESCRIPTION

## About The Pull Request
This feature wasn't working at all due to a bug where it set the display name to empty each time it tried to use it. Removed that bug and fixed up a number of places to use the get_belly_name proc when displaying the belly to chat or to prey in the vorepanel. Tested in several cases to make sure it works properly under most normal uses, but there still could be some edge cases where it still uses the original name.
## Changelog
:cl:
fix: Belly display names now work
/:cl:
