### PR TITLE
Fix ripleys floating in openspace

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -27,7 +27,7 @@
 	icon_scale_x = 1.2
 	icon_scale_y = 1.2
 
-/obj/mecha/working/ripley/Move()
+/obj/mecha/working/ripley/Move(atom/newloc, direct = 0, movetime)
 	. = ..()
 	if(.)
 		collect_ore()


### PR DESCRIPTION
## About The Pull Request
Ripleys were missing arguments on their Move() so the argument list was being dropped or failing to pass on the parent proc call as a missing namedarg.

## Changelog
Adds missing arguments to ripley Move.

:cl: Will
fix: Ripleys no longer float over openspace
/:cl:
