### PR TITLE
Death overrides

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -527,6 +527,8 @@
 	derez() //holograms can't gib
 
 /mob/living/simple_mob/animal/space/carp/holodeck/death()
+	if(QDELETED(src))
+		return
 	..()
 	derez()
 

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -115,6 +115,8 @@
 		return
 
 /mob/living/bot/death()
+	if(QDELETED(src))
+		return
 	explode()
 
 /mob/living/bot/attackby(obj/item/O, mob/user)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/jellyfish.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/jellyfish.dm
@@ -127,6 +127,8 @@ GLOBAL_VAR_INIT(jellyfish_count, 0)
 		parent.faction = faction
 
 /mob/living/simple_mob/vore/alienanimals/space_jellyfish/death()
+	if(QDELETED(src))
+		return
 	. = ..()
 	new /obj/item/reagent_containers/food/snacks/jellyfishcore(loc, nutrition)
 	GLOB.jellyfish_count --

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
@@ -111,6 +111,8 @@
 	playsound(src, projectilesound, 80, 1)
 
 /mob/living/simple_mob/vore/alienanimals/space_ghost/death(gibbed, deathmessage = "fades away!")
+	if(QDELETED(src))
+		return
 	. = ..()
 	qdel(src)
 
@@ -186,6 +188,8 @@
 	speak_chance = 0
 
 /mob/living/simple_mob/vore/alienanimals/spooky_ghost/death(gibbed, deathmessage = "fades away!")
+	if(QDELETED(src))
+		return
 	. = ..()
 	qdel(src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/succlet.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/succlet.dm
@@ -125,6 +125,8 @@
 	succlet_last_health = health	//The succlet will try to move if it has taken damage
 
 /mob/living/simple_mob/vore/alienanimals/succlet/death(gibbed, deathmessage = "shrieks in agony as it is eradicated from reality.")
+	if(QDELETED(src))
+		return
 	. = ..()
 	if(isbelly(loc))
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/synx.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/synx.dm
@@ -777,6 +777,8 @@
 
 //HOLOSEEDSPAWNCODE
 /mob/living/simple_mob/animal/synx/ai/pet/holo/death()
+	if(QDELETED(src))
+		return
 	..()
 	visible_message(span_notice("\The [src] fades away!"))
 	var/location = get_turf(src)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother_spawn.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/broodmother_spawn.dm
@@ -13,10 +13,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/frost/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/electric/broodling
 	maxHealth = 30
@@ -33,10 +34,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/electric/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/hunter/broodling
 	maxHealth = 40
@@ -50,10 +52,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/hunter/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/lurker/broodling
 	maxHealth = 40
@@ -67,10 +70,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/lurker/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/nurse/broodling
 	maxHealth = 60
@@ -85,10 +89,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/nurse/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/pepper/broodling
 	maxHealth = 40
@@ -102,10 +107,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/pepper/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/thermic/broodling
 	maxHealth = 40
@@ -122,10 +128,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/thermic/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/tunneler/broodling
 	maxHealth = 40
@@ -139,10 +146,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/tunneler/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/webslinger/broodling
 	maxHealth = 30
@@ -158,10 +166,11 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 2 MINUTES)
 
 /mob/living/simple_mob/animal/giant_spider/webslinger/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_mob/animal/giant_spider/broodling
 	maxHealth = 60
@@ -186,7 +195,8 @@
 	. = ..()
 
 /mob/living/simple_mob/animal/giant_spider/broodling/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
 
-	if(!QDELETED(src))
-		qdel(src)
+	qdel(src)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
@@ -70,6 +70,8 @@
 		explosion(src.loc, explosion_dev_range, explosion_heavy_range, explosion_light_range, explosion_flash_range)
 
 /mob/living/simple_mob/animal/giant_spider/phorogenic/death()
+	if(stat == DEAD)
+		return
 	visible_message(span_critical("\The [src]'s body begins to rupture!"))
 	var/delay = rand(explosion_delay_lower, explosion_delay_upper)
 	animate(src, color = "#000000", time = 0.1 SECONDS, loop = ceil(delay/2))

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
@@ -49,6 +49,8 @@
 
 //Deletes the body upon death
 /mob/living/simple_mob/animal/passive/cockroach/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/bug_remains(src.loc)
 	qdel(src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat_vr.dm
@@ -67,6 +67,8 @@
 
 //Emergency teleport - Until a spriter makes something better
 /mob/living/simple_mob/animal/passive/cat/tabiranth/death(gibbed, deathmessage = "teleports away!")
+	if(stat == DEAD)
+		return
 	cut_overlays()
 	icon_state = ""
 	flick("kphaseout",src)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
@@ -314,6 +314,8 @@
 	derez() // Holograms can't gib.
 
 /mob/living/simple_mob/animal/space/carp/holographic/death()
+	if(QDELETED(src))
+		return
 	..()
 	derez()
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
@@ -226,6 +226,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive
 
 /mob/living/simple_mob/animal/space/mouse_army/ammo/death()
+	if(stat == DEAD)
+		return
 	visible_message(span_critical("\The [src]'s body begins to rupture!"))
 	var/delay = rand(explosion_delay_lower, explosion_delay_upper)
 	spawn(0)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/vox.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/vox.dm
@@ -36,6 +36,8 @@
 	var/quills = 3
 
 /mob/living/simple_mob/vox/armalis/death(gibbed = FALSE)
+	if(QDELETED(src))
+		return
 	..(TRUE)
 	var/turf/gloc = get_turf(loc)
 	visible_message(span_bolddanger("[src] shudders violently and explodes!"),span_warning("You feel your body rupture!"))

--- a/code/modules/mob/living/simple_mob/subtypes/blob/spore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/blob/spore.dm
@@ -66,6 +66,8 @@
 	return ..()
 
 /mob/living/simple_mob/blob/spore/death(gibbed, deathmessage = "bursts!")
+	if(QDELETED(src))
+		return
 	if(overmind)
 		overmind.blob_type.on_spore_death(src)
 	..(gibbed, deathmessage)

--- a/code/modules/mob/living/simple_mob/subtypes/glamour/homunculus.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/homunculus.dm
@@ -22,6 +22,8 @@
 	var/owner
 
 /mob/living/simple_mob/homunculus/death()
+	if(QDELETED(src))
+		return
 	if(owner)
 		var/obj/item/glamour_face/O = owner
 		O.homunculus = 0

--- a/code/modules/mob/living/simple_mob/subtypes/glamour/ysbryd.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/glamour/ysbryd.dm
@@ -129,6 +129,8 @@
 	chosen_target = null
 
 /mob/living/simple_mob/ysbryd/death()
+	if(QDELETED(src))
+		return
 	if(chosen_target)
 		disconnect_target()
 	qdel(src)

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/cultist.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/cultist.dm
@@ -76,6 +76,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
 /mob/living/simple_mob/humanoid/cultist/human/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/remains/human (src.loc)
 	..(null,"let's out a maddening laugh as his body crumbles away.")
 	ghostize()
@@ -244,6 +246,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
 /mob/living/simple_mob/humanoid/cultist/tesh/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/ash (src.loc)
 	..(null,"let's out a shrill chirp as his body turns to dust.")
 	ghostize()
@@ -295,6 +299,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
 /mob/living/simple_mob/humanoid/cultist/lizard/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/remains/unathi (src.loc)
 	..(null,"hisses as he collapses into a pile of bones.")
 	ghostize()
@@ -347,6 +353,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged
 
 /mob/living/simple_mob/humanoid/cultist/caster/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/remains/human (src.loc)
 	new /obj/effect/decal/cleanable/blood/gibs (src.loc)
 	..(null,"melts into a pile of blood and bones.")
@@ -396,6 +404,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
 /mob/living/simple_mob/humanoid/cultist/initiate/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/remains/human (src.loc)
 	..(null,"lets out a horrified scream as his body crumbles away.")
 	ghostize()
@@ -447,6 +457,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/kiting
 
 /mob/living/simple_mob/humanoid/cultist/castertesh/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/ash (src.loc)
 	..(null,"burns away into nothing.")
 	ghostize()
@@ -517,6 +529,8 @@
 		..()
 
 /mob/living/simple_mob/humanoid/cultist/elite/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/remains/human (src.loc)
 	new /obj/effect/decal/cleanable/blood/gibs (src.loc)
 	new /obj/item/material/shard (src.loc)
@@ -574,6 +588,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/kiting
 
 /mob/living/simple_mob/humanoid/cultist/magus/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/blood/gibs (src.loc)
 	..(null,"let's out a dark laugh as it collapses into a puddle of blood.")
 	ghostize()
@@ -652,6 +668,8 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/aggressive/blood_hunter
 
 /mob/living/simple_mob/humanoid/cultist/hunter/death()
+	if(QDELETED(src))
+		return
 	new /obj/effect/decal/cleanable/blood/gibs (src.loc)
 	..(null,"laughs as he melts away. His laughs echo through the air even after only a dense red goo remains.")
 	ghostize()

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/humanoid.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/humanoid.dm
@@ -27,6 +27,8 @@
 	can_be_drop_prey = FALSE
 
 /mob/living/simple_mob/humanoid/death()
+	if(QDELETED(src))
+		return
 	..()
 	if(corpse)
 		var/mob/new_corpse = new corpse(src.loc)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/corrupt_maint_drone_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/corrupt_maint_drone_vr.dm
@@ -67,5 +67,7 @@
 
 
 /mob/living/simple_mob/mechanical/corrupt_maint_drone/death()
+	if(QDELETED(src))
+		return
 	..(null,"is smashed into pieces!")
 	qdel(src)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/combat_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/combat_drone.dm
@@ -81,6 +81,8 @@
 	return ..()
 
 /mob/living/simple_mob/mechanical/combat_drone/death()
+	if(QDELETED(src))
+		return
 	..(null,"suddenly breaks apart.")
 	qdel(src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
@@ -85,6 +85,8 @@
 	return ..()
 
 /mob/living/simple_mob/mechanical/mining_drone/death()
+	if(QDELETED(src))
+		return
 	my_storage.forceMove(get_turf(src))
 	my_storage = null
 	..(null,"suddenly breaks apart.")

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/golem.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/golem.dm
@@ -70,6 +70,8 @@
 	return ..()
 
 /mob/living/simple_mob/mechanical/technomancer_golem/death()
+	if(QDELETED(src))
+		return
 	..()
 	visible_message("\The [src] disintegrates!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/hivebot.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/hivebot.dm
@@ -22,6 +22,8 @@
 
 
 /mob/living/simple_mob/mechanical/hivebot/death()
+	if(QDELETED(src))
+		return
 	..()
 	visible_message(span_warning("\The [src] blows apart!"))
 	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/support.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/support.dm
@@ -103,6 +103,8 @@
 	water_resist = 1 //Harry lives under the sea!
 
 /mob/living/simple_mob/mechanical/hivebot/support/harry/death()
+	if(QDELETED(src))
+		return
 	..()
 	visible_message(span_warning("Connection... terminated... Sweet Release... obtained."),span_danger("\The [src] blows apart!"))
 	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/viscerator.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/viscerator.dm
@@ -55,6 +55,8 @@
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_mob/mechanical/viscerator/death()
+	if(QDELETED(src))
+		return
 	..(null,"is smashed into pieces!")
 	qdel(src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/ward/ward.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/ward/ward.dm
@@ -31,6 +31,8 @@
 	var/mob/living/owner = null // The mob that made the ward, if any. Used to ensure the ward does not interfere with its creator.
 
 /mob/living/simple_mob/mechanical/ward/death()
+	if(QDELETED(src))
+		return
 	..(null,"is smashed into pieces!")
 	qdel(src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
@@ -118,6 +118,8 @@
 */
 
 /mob/living/simple_mob/construct/death()
+	if(QDELETED(src))
+		return
 	new /obj/item/ectoplasm (src.loc)
 	..(null,"collapses in a shattered heap.")
 	ghostize()

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/shade.dm
@@ -39,6 +39,8 @@
 	..()
 
 /mob/living/simple_mob/construct/shade/death()
+	if(QDELETED(src))
+		return
 	..()
 	for(var/mob/M in viewers(src, null))
 		if((M.client && !( M.blinded )))

--- a/code/modules/mob/living/simple_mob/subtypes/occult/unknown.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/unknown.dm
@@ -58,6 +58,8 @@
 	combustion = TRUE
 
 /mob/living/simple_mob/glitch_boss/death(gibbed, deathmessage="suddenly %runtime error in unknown.dm, line 56%")
+	if(QDELETED(src))
+		return
 	. = ..()
 	new /obj/effect/temp_visual/glitch(get_turf(src))
 	qdel(src)
@@ -326,6 +328,8 @@
 	prob_respawn = 60
 
 /mob/living/simple_mob/glitch_boss_fake/death(gibbed, deathmessage="disappears in cloud of static.")
+	if(QDELETED(src))
+		return
 	new /obj/effect/temp_visual/glitch(get_turf(src))
 	if(prob(prob_respawn))
 		new /mob/living/simple_mob/glitch_boss_fake(get_turf(src))

--- a/code/modules/mob/living/simple_mob/subtypes/plant/tree.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/plant/tree.dm
@@ -43,6 +43,8 @@
 			L.visible_message(span_danger("\The [src] knocks down \the [L]!"))
 
 /mob/living/simple_mob/animal/space/tree/death()
+	if(QDELETED(src))
+		return
 	..(null,"is hacked into pieces!")
 	playsound(src, 'sound/effects/woodcutting.ogg', 100, 1)
 	new /obj/item/stack/material/wood(loc)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/macrophage.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/macrophage.dm
@@ -126,6 +126,8 @@
 	set_AI_busy(FALSE)
 */
 /mob/living/simple_mob/vore/aggressive/macrophage/death()
+	if(QDELETED(src))
+		return
 	..()
 	if(isbelly(loc))
 		var/obj/belly/belly = loc

--- a/code/modules/mob/living/simple_mob/subtypes/vore/mimic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/mimic.dm
@@ -144,6 +144,8 @@
 	return FALSE
 
 /mob/living/simple_mob/vore/aggressive/mimic/death()
+	if(QDELETED(src))
+		return
 	..()
 	if(real_crate)
 		real_crate.forceMove(loc)
@@ -239,6 +241,8 @@
 	return FALSE
 
 /mob/living/simple_mob/vore/aggressive/mimic/airlock/death()
+	if(QDELETED(src))
+		return
 	new/obj/machinery/door/airlock/maintenance/common (src.loc)
 	real_crate = null
 	qdel(src)
@@ -334,6 +338,8 @@
 	return FALSE
 
 /mob/living/simple_mob/vore/aggressive/mimic/closet/death()
+	if(QDELETED(src))
+		return
 	..()
 	if(real_crate)
 		real_crate.forceMove(loc)
@@ -423,6 +429,8 @@
 	base_attack_cooldown = 5
 
 /mob/living/simple_mob/vore/aggressive/mimic/floor/death()
+	if(QDELETED(src))
+		return
 	qdel(src)
 
 /obj/effect/floormimic/tile

--- a/code/modules/mob/living/simple_mob/subtypes/vore/oregrub.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/oregrub.dm
@@ -133,6 +133,8 @@
 			inject_poison(L, target_zone)
 
 /mob/living/simple_mob/vore/oregrub/death()
+	if(stat == DEAD)
+		return
 	visible_message(span_warning("\The [src] shudders and collapses, expelling the ores it had devoured!"))
 	var/i = rand(min_ore,max_ore)
 	while(i>1)
@@ -150,6 +152,8 @@
 		glow_override = FALSE
 
 /mob/living/simple_mob/vore/oregrub/lava/death()
+	if(stat == DEAD)
+		return
 	set_light(0)
 	var/p = rand(lava_min_ore,lava_max_ore)
 	while(p>1)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -220,6 +220,8 @@
 
 //They phase back to the dark when killed
 /mob/living/simple_mob/shadekin/death(gibbed, deathmessage = "phases to somewhere far away!")
+	if(stat == DEAD)
+		return
 	var/special_handling = FALSE //varswitch for downstream
 	if(!special_handling)
 		cut_overlays()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/softdog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/softdog.dm
@@ -283,6 +283,8 @@ GLOBAL_VAR_INIT(woof_current, 0)
 	. = ..()
 
 /mob/living/simple_mob/vore/woof/hostile/aweful/death()
+	if(QDELETED(src))
+		return
 	. = ..()
 	var/thismany = rand(0,3)
 	if(!thismany || killswitch || GLOB.woof_maximum >= 20)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth.dm
@@ -137,6 +137,8 @@
 	return
 
 /mob/living/simple_mob/vore/solarmoth/death()
+	if(stat == DEAD)
+		return
 	explode()
 	..()
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
@@ -326,6 +326,8 @@
 	color = random_color(TRUE)
 
 /mob/living/simple_mob/vore/vore_hostile/gelatinous_cube/death()
+	if(QDELETED(src))
+		return
 	. = ..()
 
 	qdel(src)


### PR DESCRIPTION

## About The Pull Request
This is ab older and yet larger issue... when death is not checking the stat or qdel, we'll end up with multiple calls on  it in some cases like ash, which calls it directly, followed by the damage call.... we might have to check the stat on the other call of it

We really should look into a smarter way than what is currently done here with the death overrides
## Changelog
:cl:
fix: some death multi calls
/:cl:
