### PR TITLE
Fix brainsnax logic

### DIFF
--- a/code/modules/reagents/reagents/food_drinks_vr.dm
+++ b/code/modules/reagents/reagents/food_drinks_vr.dm
@@ -551,7 +551,7 @@
 
 /datum/reagent/nutriment/protein/brainzsnax/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
-	if(prob(5) && !(alien == IS_CHIMERA || alien == IS_SLIME || alien == IS_PLANT || alien == IS_DIONA || alien == IS_SHADEKIN && !M.isSynthetic()))
+	if(prob(5) && !(alien == IS_CHIMERA || alien == IS_SLIME || alien == IS_PLANT || alien == IS_DIONA || alien == IS_SHADEKIN) && !M.isSynthetic())
 		M.adjustBrainLoss(removed) //Any other species risks prion disease.
 		M.Confuse(5)
 		M.hallucination = max(M.hallucination, 25)


### PR DESCRIPTION
## About The Pull Request
Synths are meant to be immune to brainsnax's bad effects. Instead you needed to be a synthetic shadekin.

## Changelog
Fixes a broken brainsnax inssynthetic() check.

:cl: Will, Reo
fix: synthetics no longer affected by brainsnax braindamage
/:cl:

