### PR TITLE
Grippers can insert borg powercells again

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -178,7 +178,7 @@
 	if(isrobot(M))
 		var/mob/living/silicon/robot/target = M
 		if(target.opened)
-			return ITEM_INTERACT_SUCCESS
+			return ITEM_INTERACT_SKIP_TO_ATTACK
 	..()
 
 /obj/item/cell/attackby(obj/item/W, mob/user)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Grippers have very specific attack chain handling. So returning interaction success didn't result in attackby() being run. Tested both human and borg to be working as intended with the change. Though humans never reach this section of code anyway, as they call attackby() in a different order than grippers do.

:cl: Will
fix: Gripper can insert powercells into borgs again
/:cl:
