### PR TITLE
Usr Wire Fix

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -84,19 +84,19 @@
 			if(!mend)
 				//Cutting either one disables the main door power, but unless backup power is also cut, the backup power re-powers the door in 10 seconds. While unpowered, the door may be crowbarred open, but bolts-raising will not work. Cutting these wires may electocute the user.
 				A.loseMainPower()
-				A.shock(usr, 50)
+				A.shock(usr, 50) // TODO - REMOVE USR
 			else
 				A.regainMainPower()
-				A.shock(usr, 50)
+				A.shock(usr, 50) // TODO - REMOVE USR
 
 		if(WIRE_BACKUP_POWER1, WIRE_BACKUP_POWER2)
 			if(!mend)
 				//Cutting either one disables the backup door power (allowing it to be crowbarred open, but disabling bolts-raising), but may electocute the user.
 				A.loseBackupPower()
-				A.shock(usr, 50)
+				A.shock(usr, 50) // TODO - REMOVE USR
 			else
 				A.regainBackupPower()
-				A.shock(usr, 50)
+				A.shock(usr, 50) // TODO - REMOVE USR
 
 		if(WIRE_DOOR_BOLTS)
 			if(!mend)

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -31,7 +31,7 @@
 				A.locked = TRUE
 
 		if(WIRE_MAIN_POWER1)
-			A.shock(usr, 50)
+			A.shock(usr, 50) // TODO - REMOVE USR
 			A.shorted = !mend
 			A.update_icon()
 

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -54,13 +54,13 @@
 		if(WIRE_MAIN_POWER1, WIRE_MAIN_POWER2)
 			if(!mend)
 				if(isliving(usr))
-					A.shock(usr, 50)
+					A.shock(usr, 50) // TODO - REMOVE USR
 				A.shorted = TRUE
 
 			else if(!is_cut(WIRE_MAIN_POWER1) && !is_cut(WIRE_MAIN_POWER2))
 				A.shorted = FALSE
 				if(isliving(usr))
-					A.shock(usr, 50)
+					A.shock(usr, 50) // TODO - REMOVE USR
 
 		if(WIRE_AI_CONTROL)
 			A.aidisabled = !mend

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -42,7 +42,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr)
+			A.update_tgui_static_data(usr) // TODO - REMOVE USR
 			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
 		if(WIRE_ELECTRIFY)
 			A.shocked = !A.shocked

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -28,7 +28,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !mend
-			A.update_tgui_static_data(usr)
+			A.update_static_data_for_all_viewers()
 		if(WIRE_ELECTRIFY)
 			A.shocked = !mend
 		if(WIRE_LATHE_DISABLE)

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -42,8 +42,8 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr) // TODO - REMOVE USR
-			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
+			A.update_static_data_for_all_viewers()
+			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK), 5 SECONDS)
 		if(WIRE_ELECTRIFY)
 			A.shocked = !A.shocked
 			addtimer(CALLBACK(src, PROC_REF(reset_electrify), WIRE_ELECTRIFY), 5 SECONDS)
@@ -52,11 +52,11 @@
 			addtimer(CALLBACK(src, PROC_REF(reset_disable), WIRE_LATHE_DISABLE), 5 SECONDS)
 	..()
 
-/datum/wires/autolathe/proc/reset_hacked(wire, mob/user)
+/datum/wires/autolathe/proc/reset_hacked(wire)
 	var/obj/machinery/autolathe/A = holder
 	if(A && !is_cut(wire))
 		A.hacked = FALSE
-		A.update_tgui_static_data(user)
+		A.update_static_data_for_all_viewers()
 
 /datum/wires/autolathe/proc/reset_electrify(wire)
 	var/obj/machinery/autolathe/A = holder

--- a/code/datums/wires/circuit_imprinter.dm
+++ b/code/datums/wires/circuit_imprinter.dm
@@ -39,7 +39,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr)
+			A.update_tgui_static_data(usr) // TODO - REMOVE USR
 			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !A.disabled

--- a/code/datums/wires/circuit_imprinter.dm
+++ b/code/datums/wires/circuit_imprinter.dm
@@ -39,8 +39,8 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr) // TODO - REMOVE USR
-			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
+			A.update_static_data_for_all_viewers()
+			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK), 5 SECONDS)
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !A.disabled
 			addtimer(CALLBACK(src, PROC_REF(reset_disable), WIRE_LATHE_DISABLE), 5 SECONDS)
@@ -50,7 +50,7 @@
 	var/obj/machinery/rnd/production/circuit_imprinter/A = holder
 	if(A && !is_cut(wire))
 		A.hacked = FALSE
-		A.update_tgui_static_data(user)
+		A.update_static_data_for_all_viewers()
 
 /datum/wires/circuit_imprinter/proc/reset_disable(wire)
 	var/obj/machinery/rnd/production/circuit_imprinter/A = holder

--- a/code/datums/wires/circuit_imprinter.dm
+++ b/code/datums/wires/circuit_imprinter.dm
@@ -27,7 +27,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !mend
-			A.update_tgui_static_data(usr)
+			A.update_static_data_for_all_viewers()
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !mend
 	..()

--- a/code/datums/wires/foodsynth.dm
+++ b/code/datums/wires/foodsynth.dm
@@ -43,7 +43,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr)
+			A.update_tgui_static_data(usr) // TODO - REMOVE USR
 			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
 		if(WIRE_ELECTRIFY)
 			A.shocked = !A.shocked

--- a/code/datums/wires/foodsynth.dm
+++ b/code/datums/wires/foodsynth.dm
@@ -43,8 +43,8 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr) // TODO - REMOVE USR
-			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
+			A.update_static_data_for_all_viewers()
+			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK), 5 SECONDS)
 		if(WIRE_ELECTRIFY)
 			A.shocked = !A.shocked
 			addtimer(CALLBACK(src, PROC_REF(reset_electrify), WIRE_ELECTRIFY), 5 SECONDS)
@@ -56,7 +56,7 @@
 	var/obj/machinery/synthesizer/A = holder
 	if(A && !is_cut(wire))
 		A.hacked = FALSE
-		A.update_tgui_static_data(user)
+		A.update_static_data_for_all_viewers()
 
 /datum/wires/synthesizer/proc/reset_electrify(wire)
 	var/obj/machinery/synthesizer/A = holder

--- a/code/datums/wires/foodsynth.dm
+++ b/code/datums/wires/foodsynth.dm
@@ -29,7 +29,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !mend
-			A.update_tgui_static_data(usr)
+			A.update_static_data_for_all_viewers()
 		if(WIRE_ELECTRIFY)
 			A.shocked = !mend
 		if(WIRE_LATHE_DISABLE)

--- a/code/datums/wires/grid_checker.dm
+++ b/code/datums/wires/grid_checker.dm
@@ -60,5 +60,5 @@
 		if(WIRE_ELECTRIFY)
 			if(G.wire_locked_out)
 				return
-			G.shock(usr, 70)
+			G.shock(usr, 70) // TODO - REMOVE USR
 	..()

--- a/code/datums/wires/grid_checker.dm
+++ b/code/datums/wires/grid_checker.dm
@@ -37,7 +37,7 @@
 		if(WIRE_ELECTRIFY)
 			if(G.wire_locked_out)
 				return
-			G.shock(usr, 70)
+			G.shock(usr, 70) // TODO - REMOVE USR
 	..()
 
 /datum/wires/grid_checker/on_pulse(wire)

--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -32,7 +32,7 @@
 	switch(wire)
 		if(WIRE_MAIN_POWER1)
 			holder.visible_message(span_notice("[icon2html(A,viewers(holder))] The power light flickers."))
-			A.shock(usr, 90)
+			A.shock(usr, 90) // TODO - REMOVE USR
 		if(WIRE_JUKEBOX_HACK)
 			holder.visible_message(span_notice("[icon2html(A,viewers(holder))] The parental guidance light flickers."))
 		if(WIRE_REVERSE)

--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -50,7 +50,7 @@
 		if(WIRE_NEXT)
 			A.NextTrack()
 		else
-			A.shock(usr, 10) // The nothing wires give a chance to shock just for fun
+			A.shock(usr, 10) // The nothing wires give a chance to shock just for fun // TODO - REMOVE USR
 
 /datum/wires/jukebox/on_cut(wire, mend)
 	var/obj/machinery/media/jukebox/A = holder
@@ -58,7 +58,7 @@
 	switch(wire)
 		if(WIRE_MAIN_POWER1)
 			// TODO - Actually make machine electrified or something.
-			A.shock(usr, 90)
+			A.shock(usr, 90) // TODO - REMOVE USR
 
 		if(WIRE_JUKEBOX_HACK)
 			A.set_hacked(!mend)

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -20,7 +20,7 @@
 			C.toggle_power()
 
 		if(WIRE_PARTICLE_STRENGTH)
-			C.add_strength(usr)
+			C.add_strength(usr) // TODO - REMOVE USR
 
 		if(WIRE_PARTICLE_INTERFACE)
 			C.interface_control = !C.interface_control

--- a/code/datums/wires/protolathe.dm
+++ b/code/datums/wires/protolathe.dm
@@ -39,7 +39,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr)
+			A.update_tgui_static_data(usr) // TODO - REMOVE USR
 			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !A.disabled

--- a/code/datums/wires/protolathe.dm
+++ b/code/datums/wires/protolathe.dm
@@ -27,7 +27,7 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !mend
-			A.update_tgui_static_data(usr)
+			A.update_static_data_for_all_viewers()
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !mend
 	..()

--- a/code/datums/wires/protolathe.dm
+++ b/code/datums/wires/protolathe.dm
@@ -39,8 +39,8 @@
 	switch(wire)
 		if(WIRE_LATHE_HACK)
 			A.hacked = !A.hacked
-			A.update_tgui_static_data(usr) // TODO - REMOVE USR
-			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK, usr), 5 SECONDS)
+			A.update_static_data_for_all_viewers()
+			addtimer(CALLBACK(src, PROC_REF(reset_hacked), WIRE_LATHE_HACK), 5 SECONDS)
 		if(WIRE_LATHE_DISABLE)
 			A.disabled = !A.disabled
 			addtimer(CALLBACK(src, PROC_REF(reset_disable), WIRE_LATHE_DISABLE), 5 SECONDS)
@@ -50,7 +50,7 @@
 	var/obj/machinery/rnd/production/protolathe/A = holder
 	if(A && !is_cut(wire))
 		A.hacked = FALSE
-		A.update_tgui_static_data(user)
+		A.update_static_data_for_all_viewers()
 
 /datum/wires/protolathe/proc/reset_disable(wire)
 	var/obj/machinery/rnd/production/protolathe/A = holder

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -286,6 +286,8 @@ Class Procs:
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()
+	if(!isliving(user))
+		return 0
 	if(electrocute_mob(user, get_area(src), src, 0.7))
 		var/area/temp_area = get_area(src)
 		if(temp_area)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -835,7 +835,9 @@
 	take_hit((100/severity), "electrical pulse", 1)
 
 /obj/item/rig/proc/shock(mob/user)
-	if (electrocute_mob(user, cell, src)) //electrocute_mob() handles removing charge from the cell, no need to do that here.
+	if(!ismob(user))
+		return 0
+	if(electrocute_mob(user, cell, src)) //electrocute_mob() handles removing charge from the cell, no need to do that here.
 		spark_system.start()
 		if(user.stunned)
 			return 1

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -22,7 +22,7 @@
 				rig.req_one_access = initial(rig.req_one_access)
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			rig.electrified = mend ? 0 : -1
-			rig.shock(usr,100)
+			rig.shock(usr,100) // TODO - REMOVE USR
 
 /datum/wires/rig/on_pulse(wire)
 	var/obj/item/rig/rig = holder
@@ -37,14 +37,14 @@
 			rig.malfunctioning += 10
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20
-			rig.shock(usr,100)
+			rig.shock(usr,100) // TODO - REMOVE USR
 		if(WIRE_RIG_INTERFACE_LOCK)
 			rig.interface_locked = !rig.interface_locked
 			rig.visible_message("\The [rig] clicks audibly as the software interface [rig.interface_locked?"darkens":"brightens"].")
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			if(rig.electrified != -1)
 				rig.electrified = 30
-			rig.shock(usr,100)
+			rig.shock(usr,100) // TODO - REMOVE USR
 
 /datum/wires/rig/interactable(mob/user)
 	var/obj/item/rig/rig = holder

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -22,7 +22,8 @@
 				rig.req_one_access = initial(rig.req_one_access)
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			rig.electrified = mend ? 0 : -1
-			rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			if(isliving(rig.wearer))
+				rig.shock(rig.wearer,100) // TODO - REMOVE USR
 
 /datum/wires/rig/on_pulse(wire)
 	var/obj/item/rig/rig = holder
@@ -37,14 +38,16 @@
 			rig.malfunctioning += 10
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20
-			rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			if(isliving(rig.wearer))
+				rig.shock(rig.wearer,100) // TODO - REMOVE USR
 		if(WIRE_RIG_INTERFACE_LOCK)
 			rig.interface_locked = !rig.interface_locked
 			rig.visible_message("\The [rig] clicks audibly as the software interface [rig.interface_locked?"darkens":"brightens"].")
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			if(rig.electrified != -1)
 				rig.electrified = 30
-			rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			if(isliving(rig.wearer))
+				rig.shock(rig.wearer,100) // TODO - REMOVE USR
 
 /datum/wires/rig/interactable(mob/user)
 	var/obj/item/rig/rig = holder

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -22,8 +22,7 @@
 				rig.req_one_access = initial(rig.req_one_access)
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			rig.electrified = mend ? 0 : -1
-			if(isliving(rig.wearer))
-				rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			rig.shock(usr,100) // TODO - REMOVE USR
 
 /datum/wires/rig/on_pulse(wire)
 	var/obj/item/rig/rig = holder
@@ -38,16 +37,14 @@
 			rig.malfunctioning += 10
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20
-			if(isliving(rig.wearer))
-				rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			rig.shock(usr,100) // TODO - REMOVE USR
 		if(WIRE_RIG_INTERFACE_LOCK)
 			rig.interface_locked = !rig.interface_locked
 			rig.visible_message("\The [rig] clicks audibly as the software interface [rig.interface_locked?"darkens":"brightens"].")
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			if(rig.electrified != -1)
 				rig.electrified = 30
-			if(isliving(rig.wearer))
-				rig.shock(rig.wearer,100) // TODO - REMOVE USR
+			rig.shock(usr,100) // TODO - REMOVE USR
 
 /datum/wires/rig/interactable(mob/user)
 	var/obj/item/rig/rig = holder

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -22,7 +22,7 @@
 				rig.req_one_access = initial(rig.req_one_access)
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			rig.electrified = mend ? 0 : -1
-			rig.shock(usr,100) // TODO - REMOVE USR
+			rig.shock(rig.wearer,100) // TODO - REMOVE USR
 
 /datum/wires/rig/on_pulse(wire)
 	var/obj/item/rig/rig = holder
@@ -37,14 +37,14 @@
 			rig.malfunctioning += 10
 			if(rig.malfunction_delay <= 0)
 				rig.malfunction_delay = 20
-			rig.shock(usr,100) // TODO - REMOVE USR
+			rig.shock(rig.wearer,100) // TODO - REMOVE USR
 		if(WIRE_RIG_INTERFACE_LOCK)
 			rig.interface_locked = !rig.interface_locked
 			rig.visible_message("\The [rig] clicks audibly as the software interface [rig.interface_locked?"darkens":"brightens"].")
 		if(WIRE_RIG_INTERFACE_SHOCK)
 			if(rig.electrified != -1)
 				rig.electrified = 30
-			rig.shock(usr,100) // TODO - REMOVE USR
+			rig.shock(rig.wearer,100) // TODO - REMOVE USR
 
 /datum/wires/rig/interactable(mob/user)
 	var/obj/item/rig/rig = holder

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -320,6 +320,8 @@
 
 	if (!cell && !PN)
 		return 0
+	if(!isliving(M))
+		return 0
 	var/PN_damage = 0
 	var/cell_damage = 0
 	if (PN)
@@ -333,8 +335,6 @@
 	else
 		power_source = cell
 		shock_damage = cell_damage
-	if(!isliving(M))
-		return 0
 	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	var/drained_energy = drained_hp*20
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -272,7 +272,7 @@
 //power_source is a source of electricity, can be powercell, area, apc, cable, powernet or null
 //source is an object caused electrocuting (airlock, grille, etc)
 //No animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/M as mob, power_source, obj/source, siemens_coeff = 1.0)
+/proc/electrocute_mob(mob/living/M, power_source, obj/source, siemens_coeff = 1.0)
 	if(istype(M.loc,/obj/mecha))	return 0	//feckin mechs are dumb
 	if(issilicon(M))	return 0	//No more robot shocks from machinery
 	var/area/source_area
@@ -333,6 +333,8 @@
 	else
 		power_source = cell
 		shock_damage = cell_damage
+	if(!isliving(M))
+		return 0
 	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	var/drained_energy = drained_hp*20
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -77,7 +77,7 @@
 		return 1
 	return 0
 
-/obj/machinery/containment_field/shock(mob/living/user as mob)
+/obj/machinery/containment_field/shock(mob/living/user)
 	if(hasShocked)
 		return 0
 	if(!FG1 || !FG2)


### PR DESCRIPTION
## About The Pull Request
Several instances of usr are present in wire pulsing/cutting/mending. This usr value can be in an invalid state if not called from a verb, such as emps by mobs. I have corrected the few instances where this isn't actually an issue, but cases where shock() is called remain unsolvable.

I'm not sure what to do here, as removing the shock is bad for gameplay. However i'd need to modify all wire procs to pass user, and then nullcheck it for each shock(if shock already doesn't do so.) In this case we significantly deviate from TG wire code. TG has this same code for air alarms, and appears to have removed or replaced shock() on wire modification in most other places.  ( as seen here on TG's repo https://github.com/tgstation/tgstation/blob/197496bca0ee32b9883b09df09aca6a970ff46a7/code/datums/wires/airalarm.dm#L59 ) 

Shock() behavior is not the same as electrifying the device, as electrified devices are often per-object handling on touching them to electrify the user doing so AFTER it has been cut. Shock() behavior instantly zaps the user performing the wire cut. Replacing one with the other seems unsatisfactory. 

This issue is exclusively with shock() as all other usr related issues were just tgui static data updating, which could be replaced by "update all users" which TG also does.

This PR needs discussion tag, 

Locations in code with issues are marked in this PR.

## Changelog
Replaced usr from wire interaction code.

:cl: Will
code: replaced usr from wire interaction behaviors
/:cl:
