### PR TITLE
Glasswires no longer break from flashlight beams

### DIFF
--- a/code/game/objects/traps/glass_wire.dm
+++ b/code/game/objects/traps/glass_wire.dm
@@ -44,7 +44,7 @@
 	if(AM.is_incorporeal())
 		return
 	if(istype(AM,/obj/effect/abstract)) // Stops flashlight beams from breaking them
-		return
+		return // Maybe special handling someday, like making them shine?
 	if(anchored)
 		if(isliving(AM))
 			var/mob/living/L = AM

--- a/code/game/objects/traps/glass_wire.dm
+++ b/code/game/objects/traps/glass_wire.dm
@@ -43,6 +43,8 @@
 /obj/item/material/barbedwire/glass/Crossed(atom/movable/AM)
 	if(AM.is_incorporeal())
 		return
+	if(istype(AM,/obj/effect/abstract)) // Stops flashlight beams from breaking them
+		return
 	if(anchored)
 		if(isliving(AM))
 			var/mob/living/L = AM


### PR DESCRIPTION
## Changelog
Fixes glass wire hazards breaking when flashlight beams cross them.

:cl: Will
fix: Glasswire aberration no longer broken by flashlight beams
/:cl:
