### PR TITLE
Fixed grippers being unable to put sheets into unlinked RnD machines

### DIFF
--- a/code/datums/components/materials/material_container.dm
+++ b/code/datums/components/materials/material_container.dm
@@ -466,7 +466,8 @@
 	SIGNAL_HANDLER
 	if(istype(I, /obj/item/storage/bag/sheetsnatcher))
 		return OnSheetSnatcher(source, user, I)
-
+	if(istype(I, /obj/item/gripper))
+		return OnGripper(source, user, I)
 	return attempt_insert(user, I)
 
 /datum/component/material_container/proc/OnSheetSnatcher(datum/source, mob/user, obj/item/storage/bag/sheetsnatcher/S)
@@ -476,6 +477,17 @@
 	var/list/sheets = S.quick_empty()
 	for(var/obj/item/stack/material/M as anything in sheets)
 		attempt_insert(user, M)
+	return FALSE
+
+/datum/component/material_container/proc/OnGripper(datum/source, mob/user, obj/item/gripper/G)
+	SIGNAL_HANDLER
+	// this is called both locally and from remote_materials
+
+	var/obj/item/wrapped = G.get_wrapped_item()
+	attempt_insert(user, wrapped)
+	if(G.item_left_gripper(wrapped))
+		G.update_ref(null)
+	return FALSE
 
 /// Proc that allows players to fill the parent with mats
 /datum/component/material_container/proc/attempt_insert(mob/living/user, obj/item/weapon)

--- a/code/datums/components/materials/remote_materials.dm
+++ b/code/datums/components/materials/remote_materials.dm
@@ -172,10 +172,7 @@ handles linking back and forth.
 		return mat_container.OnSheetSnatcher(source, user, target)
 
 	if(istype(target, /obj/item/gripper))
-		var/obj/item/gripper/robot_gripper = target
-		target = robot_gripper.get_wrapped_item()
-		attempt_insert(user, target)
-		return FALSE
+		return mat_container.OnGripper(source, user, target)
 
 	return attempt_insert(user, target)
 


### PR DESCRIPTION
## About The Pull Request
Turns out lathe-linked machines have separate code that runs if the machine isn't linked during sheet insertion. Fixes and unifies that code. Linked silo machines worked fine, just trying to put sheets into an unlinked machine was broken. Only for grippers of course!

## Changelog
Moves RnD machine gripper sheet insertion logic to a proc
Grippers properly call sheet insert when an RnD machine is unlinked.

:cl: Will
fix: Grippers can now insert material sheets into RnD machines that are not linked to the silo(or if no silo exists)
/:cl:

