### PR TITLE
Fix dna modifier eject

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -133,8 +133,14 @@
 	var/mob/living/carbon/WC = get_occupant()
 	go_out()
 	for(var/obj/O in src)
-		if((!istype(O,/obj/item/reagent_containers)) && (!istype(O,/obj/item/circuitboard/clonescanner)) && (!istype(O,/obj/item/stock_parts)) && (!istype(O,/obj/item/stack/cable_coil)))
-			O.forceMove(get_turf(src)) //Ejects items that manage to get in there (exluding the components)
+		//Ejects items that manage to get in there (exluding the components, and beakers)
+		if(O == beaker)
+			continue
+		if(O == circuit)
+			continue
+		if(O in component_parts)
+			continue
+		O.forceMove(get_turf(src))
 	if(!WC)
 		for(var/mob/M in src)//Failsafe so you can get mobs out
 			M.forceMove(get_turf(src))
@@ -597,11 +603,7 @@
 		if("ejectOccupant")
 			playsound(src, 'sound/machines/button.ogg', 30, 1, 0)
 			connected.eject_occupant()
-			// Eject disk too, because we can't get to the UI otherwise
-			if(!disk)
-				return TRUE
-			disk.forceMove(get_turf(src))
-			disk = null
+			return TRUE
 		// Transfer Buffer Management
 		if("bufferOption")
 			var/bufferOption = params["option"]


### PR DESCRIPTION
## Changelog
Cleans up eject code for the dna modifier that could result in items stuck inside the machine
Dna modifier no longer locks out the entire UI when there is no occupant, so the disk being ejected with occupant is no longer needed.

:cl: Will
fix: DNA modifier no longer ejects disk along with occupant
/:cl:
