### PR TITLE
Lasereyes Adjustment

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -322,11 +322,15 @@
 		to_chat(src, span_warning("You're out of energy!  You need food!"))
 		return
 	if(glasses && glasses.body_parts_covered & EYES)
-		to_chat(src, span_warning("Your glasses block your laser vision!"))
-		return
+		var/obj/item/clothing/our_glasses = glasses
+		if(istype(our_glasses) && our_glasses.flash_protection > FLASH_PROTECTION_NONE)
+			to_chat(src, span_warning("Your glasses block your laser vision!"))
+			return
 	if(head && head.body_parts_covered & FACE)
-		to_chat(src, span_warning("Your helmet blocks your laser vision!"))
-		return
+		var/obj/item/clothing/our_head = head
+		if(istype(our_head) && our_head.flash_protection > FLASH_PROTECTION_NONE)
+			to_chat(src, span_warning("Your helmet blocks your laser vision!"))
+			return
 	..()
 	nutrition = max(nutrition - 25,0)
 	handle_regular_hud_updates()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -318,12 +318,18 @@
 	LE.fire()
 
 /mob/living/carbon/human/LaserEyes(atom/A, params)
-	if(nutrition>0)
-		..()
-		nutrition = max(nutrition - rand(1,5),0)
-		handle_regular_hud_updates()
-	else
+	if(!nutrition)
 		to_chat(src, span_warning("You're out of energy!  You need food!"))
+		return
+	if(glasses && glasses.body_parts_covered & EYES)
+		to_chat(src, span_warning("Your glasses block your laser vision!"))
+		return
+	if(head && head.body_parts_covered & FACE)
+		to_chat(src, span_warning("Your helmet blocks your laser vision!"))
+		return
+	..()
+	nutrition = max(nutrition - 25,0)
+	handle_regular_hud_updates()
 
 // Simple helper to face what you clicked on, in case it should be needed in more than one place
 /mob/proc/face_atom(atom/atom_to_face)


### PR DESCRIPTION

## About The Pull Request
Applies a few adjustments to laser vision.

Nutrition loss is now 25 instead of a rand(1,5) per laser eye vision. The nutrition cap is in the thousands, so this isn't a big adjustment.
Laser eyes can not be used if using glasses that cover your eyes or a helmet that covers your face that has flash protection.
## Changelog
:cl: Diana
balance: Laser eyes now take 25 nutrition per shot, up from rand(1,5)
balance: Laser eyes can not be used if wearing flash protective eye/headwear.
/:cl:
