### PR TITLE
Shredder accepts 40 pages before being full instead of 10

### DIFF
--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -14,7 +14,7 @@
 	active_power_usage = 200
 	power_channel = EQUIP
 	circuit = /obj/item/circuitboard/papershredder
-	var/max_paper = 10
+	var/max_paper = 40
 	var/paperamount = 0
 	var/list/shred_amounts = list(
 		/obj/item/photo = 1,

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -31,6 +31,10 @@
 	update_icon()
 	AddElement(/datum/element/climbable)
 
+/obj/machinery/papershredder/examine(mob/user as mob)
+	. = ..()
+	. += "A little amber screen shows there's [paperamount] sheets worth of paper in the bin."
+
 /obj/machinery/papershredder/attackby(obj/item/W, mob/user)
 
 	if(istype(W, /obj/item/storage))


### PR DESCRIPTION

## About The Pull Request
We now have spam mail. It's really, really easy to fill up those shredders in cargo, and it practically takes more time than simply using a disposal outlet. Real ones could probably handle 10X that, but that should be fine. 

Also, tiny description.
## Changelog
:cl:
balance: Increase the paper shredder paper capacity.
qol: Added a lil' description for it too. 
/:cl:
