### PR TITLE
Show insufficiently treated wounds when examined

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -69,6 +69,8 @@
 #define MODULAR_BODYPART_PROSTHETIC 1 // Can be detached or reattached freely.
 #define MODULAR_BODYPART_CYBERNETIC 2 // Can be detached or reattached to compatible parent organs.
 
+#define WOUND_CRITICAL_HEAL_LIMIT 50 // Damage that wounds will not self-heal from, even if treated by basic medical supplies. Chems/surgery ignores this.
+
 //CitRP Port
 #define CYBERBEAST_MONITOR_STYLES "blank=cyber_blank;\
 	default=cyber_default;\

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -230,10 +230,15 @@
 					status += "burning and feels like it's on fire"
 				else if(org.germ_level > INFECTION_LEVEL_TWO-INFECTION_LEVEL_ONE) //Early warning
 					status += "warm to the touch"
+				var/has_critical_wound = FALSE
 				if(LAZYLEN(org.wounds))
 					for(var/datum/wound/W in org.wounds)
 						if(W.internal)
 							status += "[can_feel_pain(org) ? "hurting and " : ""]showing a slowly growing bruise"
+						else if(W.can_autoheal() && W.wound_damage() >= WOUND_CRITICAL_HEAL_LIMIT)
+							has_critical_wound = TRUE
+				if(has_critical_wound)
+					status += "insufficiently treated"
 				if(!org.is_usable() || org.is_dislocated())
 					status += "dangling uselessly"
 				if(status.len)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -891,7 +891,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/heal_amt = 0
 
 		// if damage >= 50 AFTER treatment then it's probably too severe to heal within the timeframe of a round.
-		if (W.can_autoheal() && W.wound_damage() < 50)
+		if (W.can_autoheal() && W.wound_damage() < WOUND_CRITICAL_HEAL_LIMIT)
 			heal_amt += 0.5
 
 		//we only update wounds once in [wound_update_accuracy] ticks so have to emulate realtime
@@ -1509,13 +1509,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(W.internal && !open) continue // can't see internal wounds
 		var/this_wound_desc = W.desc
 
+		var/insuffic = "" // Wound is treated, but the wound is so large it won't heal without surgery
+		if(W.can_autoheal() && W.wound_damage() >= WOUND_CRITICAL_HEAL_LIMIT)
+			insuffic = "insufficiently "
+
 		if(W.damage_type == BURN && W.salved)
-			this_wound_desc = "salved [this_wound_desc]"
+			this_wound_desc = "[insuffic]salved [this_wound_desc]"
 
 		if(W.bleeding())
 			this_wound_desc = "bleeding [this_wound_desc]"
 		else if(W.bandaged)
-			this_wound_desc = "bandaged [this_wound_desc]"
+			this_wound_desc = "[W.damage_type != BURN ? insuffic : ""]bandaged [this_wound_desc]"
 
 		if(W.germ_level > 600)
 			this_wound_desc = "badly infected [this_wound_desc]"


### PR DESCRIPTION
## About The Pull Request
There is a very niche mechanic where a wound with over 50 damage itself (not 50 damage on the limb the wound is on) cannot be treated by bruise packs or ointment. As the would is too large to self heal. This mechanic only applies to wounds over this damage threshold, 12 wounds that equal 50+ damage will still heal, as each wound is less than 50. 

This PR only makes these wounds show feedback in examine text that your current attempts to treat them are insufficient. As they require surgery or chems to fix.

## Changelog
Add examine text showing if a wound is too large to be treated by bruise packs or ointment.
Moved the wound "auto heal limit threshold" to a define instead of a magic number.

:cl: Will
qol: Limbs with massive wounds that cannot be be healed with bruise packs or ointment will now show examine feedback that the treatment is insufficient.
/:cl:
