### PR TITLE
Small horror armor fix

### DIFF
--- a/code/modules/mob/_modifiers/horror/redspace_corruption.dm
+++ b/code/modules/mob/_modifiers/horror/redspace_corruption.dm
@@ -81,6 +81,8 @@
 /datum/modifier/redspace_corruption/on_expire()
 	REMOVE_TRAIT(unfortunate_soul, TRAIT_REDSPACE_CORRUPTED, UNHOLY_TRAIT)
 	REMOVE_TRAIT(unfortunate_soul, UNIQUE_MINDSTRUCTURE, UNHOLY_TRAIT)
+	if(armor_deployed)
+		exit_battle_stance()
 	unfortunate_soul = null
 
 /datum/modifier/redspace_corruption/tick()


### PR DESCRIPTION

## About The Pull Request
Fixes an oversight with horror armor.
## Changelog
:cl: Diana
fix: Horror armor will no longer be stuck on permanently pre-death but post-cure
/:cl:
