### PR TITLE
Adding Food synths to all maps

### DIFF
--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -9031,6 +9031,9 @@
 /obj/structure/noticeboard{
 	pixel_y = -32
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 8
+	},
 /turf/simulated/floor/lino{
 	edge_blending_priority = 0.1
 	},
@@ -12004,8 +12007,7 @@
 /turf/simulated/floor/bmarble,
 /area/groundbase/cargo/office)
 "Hz" = (
-/obj/structure/table/marble,
-/obj/machinery/camera/network/civilian{
+/obj/machinery/synthesizer{
 	dir = 8
 	},
 /turf/simulated/floor/lino{

--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -7206,6 +7206,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/crew_quarters/bar)
 "po" = (
@@ -22884,9 +22887,7 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
 "YD" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
+/obj/machinery/synthesizer,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/crew_quarters/bar)
 "YE" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -11465,6 +11465,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"asR" = (
+/obj/machinery/synthesizer{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "asS" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/water/pool,
@@ -45611,12 +45617,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"wWD" = (
-/obj/machinery/synthesizer{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "wXr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
@@ -61378,7 +61378,7 @@ aLd
 baC
 bcm
 aAG
-wWD
+asR
 ayM
 ayc
 bdZ

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -31900,6 +31900,7 @@
 /area/crew_quarters/bar)
 "bdQ" = (
 /obj/machinery/media/jukebox,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bdR" = (
@@ -45610,6 +45611,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"wWD" = (
+/obj/machinery/synthesizer{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "wXr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
@@ -61371,7 +61378,7 @@ aLd
 baC
 bcm
 aAG
-bbW
+wWD
 ayM
 ayc
 bdZ


### PR DESCRIPTION
Shifted elements: 

Stellar Delight: Moved notice board in bar to same tile as the borg charger, put the synth in its place.
Tether: Moved light on Surface bar to over jukebox,
Groundbase: Shifted camera one tile down, deleted empty table,. 


These are actually intended to be mapped in, as there isn't always a chef to make food and most probably no cargo to order generic pizza boxes. Leaving them to be engineering built means they wouldn't be built in a round either. 

:cl: Poojawa
maptweak: Food Synths have been added to Groundbase, Stellar Delight, and Tether!
/:cl:
