### PR TITLE
Allow security officers and wardens to authorize warrants.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -137,7 +137,7 @@ GLOBAL_VAR_INIT(warrant_uid, 0)
 
 		if("editwarrantauth")
 			. = TRUE
-			if(!(ACCESS_HOS in I.GetAccess())) // VOREStation edit begin
+			if(!(ACCESS_BRIG in I.GetAccess())) // VOREStation edit begin
 				to_chat(ui.user, span_warning("You don't have the access to do this!"))
 				return // VOREStation edit end
 			activewarrant.fields["auth"] = "[I.registered_name] - [I.assignment ? I.assignment : "(Unknown)"]"


### PR DESCRIPTION

## About The Pull Request
Currently, only the head of security can authorize warrants in the Warrant Assistant computer program.
This PR sets it to ACCESS_BRIG so anyone that can fiddle with the cell timers can set warrants. I thought about using ACCESS_SECURITY, but you might have some funky roles that get that access, so this feels more inline.

This change was inspired by this following issue on chomp : 
https://github.com/CHOMPStation2/CHOMPStation2/issues/12145

## Changelog
:cl:
fix: Fixed warrants only being authorized by the head of security
/:cl:
