### PR TITLE
Fix cyborgs bleeding oil when hit by the hound tongue

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -217,7 +217,7 @@
 
 	standard_weapon_hit_effects(I, user, effective_force, blocked, hit_zone)
 
-	if(I.damtype == BRUTE && prob(33)) // Added blood for whacking non-humans too
+	if(I.damtype == BRUTE && prob(33) && I.force > 0) // Added blood for whacking non-humans too
 		var/turf/simulated/location = get_turf(src)
 		if(istype(location)) location.add_blood_floor(src)
 


### PR DESCRIPTION

## About The Pull Request
This PR fixes this issue from downstream.
https://github.com/CHOMPStation2/CHOMPStation2/issues/12958

If something has no force, no bleeding. Plushes and other things like that probably would be doing it too.
## Changelog
:cl:

fix: fix cyborg licks making other cyborgs bleed
/:cl:
