### PR TITLE
Stop iframe storage from hanging on error

### DIFF
--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -112,8 +112,14 @@ class IFrameIndexedDbBackend implements StorageBackend {
   async get(key: string): Promise<any> {
     return new Promise((resolve) => {
       const handler = (message: MessageEvent) => {
-        if (message.source === this.iframeWindow && message.data?.key === key) {
-          window.removeEventListener('message', handler);
+        if (message.source !== this.iframeWindow) {
+          return;
+        }
+
+        if (message.data?.error) {
+          console.error(message.data.error);
+          resolve(undefined);
+        } else if (message.data?.key === key) {
           resolve(message.data.value);
         }
       };

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -56,6 +56,8 @@
                 { key: messageEvent.data.key, value: value },
                 '*',
               );
+            }, (error) => {
+              messageEvent.source.postMessage({ error }, '*');
             });
             break;
           case 'set':


### PR DESCRIPTION

## About The Pull Request

Previously, iframe storage could indefinitely hang an `await storage.get()` request if it encountered an internal promise rejection, as it would never notify the host window that an error occurred.

Now, it'll notify the host, they'll log an error, and resolve(undefined).

## Changelog
Dev stuff only