### PR TITLE
Fix invalid item in arcade prizes

### DIFF
--- a/code/game/objects/items/toys/mech_toys.dm
+++ b/code/game/objects/items/toys/mech_toys.dm
@@ -460,7 +460,7 @@
 	icon_state = "ripleytoy"
 
 /obj/random/mech_toy/item_to_spawn()
-	return pick(typesof(/obj/item/toy/mecha))
+	return pick(subtypesof(/obj/item/toy/mecha))
 
 /obj/item/toy/mecha/ripley
 	name = "toy ripley"

--- a/code/game/objects/items/toys/toys_vr.dm
+++ b/code/game/objects/items/toys/toys_vr.dm
@@ -797,7 +797,7 @@
 	icon_state = "aliencharacter"
 
 /obj/random/miniature/item_to_spawn()
-	return pick(typesof(/obj/item/toy/character))
+	return pick(subtypesof(/obj/item/toy/character))
 
 /*
  * Snake popper


### PR DESCRIPTION
## About The Pull Request
The base type of /obj/item/toy/character is invalid for gameplay, and results in a "item" object with a cube sprite. The randomized character figure spawner could rarely pick the base type as it uses typesof, instead of subtypes of. This corrects that. Same goes for the mechtoy spawner, but it's less obvious as it visually looks like a ripley toy, just named "item" instead.

These random item spawners is only really used by the arcade prize pool, and some POIs, so they're mostly visible from the arcade when it happens.

## Changelog
Removes an invalid item from arcade prize pool.

:cl: Will
fix: Removes an invalid item from the arcade prize pool
/:cl:
