### PR TITLE
Buffs RUST radiation generation

### DIFF
--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -544,13 +544,13 @@
 	return
 
 //Reaction radiation is fairly buggy and there's at least three procs dealing with radiation here, this is to ensure constant radiation output.
-/obj/effect/fusion_em_field/proc/radiation_scale()
+/obj/effect/fusion_em_field/proc/radiation_scale() // Power sits ~50. Sometimes higher, sometimes lower.cal
 	radiation_pulse(
 		src,
-		max_range = 5,
-		threshold = RAD_MEDIUM_INSULATION,
+		max_range = CLAMP(round(energy * 0.25), 7, 50),
+		threshold = RAD_EXTREME_INSULATION,
 		chance = (URANIUM_IRRADIATION_CHANCE + (plasma_temperature / PLASMA_TEMP_RADIATION_DIVISIOR)),
-		strength = energy * 0.01 //Might need to be increased.
+		strength = max(round(plasma_temperature / PLASMA_TEMP_RADIATION_DIVISIOR) * 0.7, 100) //Increased. Now on par with the mag traps. This room is LETHAL when it's running.
 	)
 
 //Somehow fixing the radiation issue managed to break this, but moving it to it's own proc seemed to have fixed it. I don't know.

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -335,7 +335,7 @@
 
 	radiation_pulse(
 		src,
-		max_range = 7,
+		max_range = 14,
 		threshold = RAD_EXTREME_INSULATION,
 		chance = 100,
 		strength = radiation * 0.01 //This is what happens when it EXPLODES.

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -336,9 +336,9 @@
 	radiation_pulse(
 		src,
 		max_range = 7,
-		threshold = RAD_HEAVY_INSULATION,
-		chance = URANIUM_IRRADIATION_CHANCE,
-		strength = energy * 0.001 //Might need to be increased.
+		threshold = RAD_EXTREME_INSULATION,
+		chance = 100,
+		strength = radiation * 0.01 //This is what happens when it EXPLODES.
 		)
 	Radiate()
 


### PR DESCRIPTION

## About The Pull Request
Buffs the RUST radiation generation. The previous levels did absolutely nothing.
When I did the rad rework, I had 0 RUSTs to go off of and no testing with the RUST, so a 'ballpark number' was used and found to be much too low.

This increases the range to scale on energy (like the SM), the power to scale based on phoron temperature (like it did previously) and increases the threshold from MEDIUM insulation to EXTREME insulation (Requires rad collectors to block it)

Likewise, when the RUST explodes, it does a 14 tile wide radiation blast with massive amounts of rads based on the reactants within it.
## Changelog
:cl: Diana
qol: Changes the RUST generator to produce more radiation and radiate further. Rad collectors (at 1013kpa) now collect about as much as a mag-trap

/:cl:
