### PR TITLE
APCs can no longer be unlocked from anywhere

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -699,7 +699,8 @@ GLOBAL_LIST_EMPTY(apcs)
 
 /obj/machinery/power/apc/click_alt(mob/user)
 	..()
-	togglelock(user)
+	if(Adjacent(user) || isrobot(user))
+		togglelock(user)
 
 /obj/machinery/power/apc/emag_act(remaining_charges, mob/user)
 	if(!(emagged || hacker))		// trying to unlock with an emag card


### PR DESCRIPTION
## About The Pull Request
Missing range check on APC altclick. You could unlock APCs from across the station if you wanted to as a human.

## Changelog
Adds a range and robot check to APC alt-clicking.

:cl: Will
fix: APCs properly check if you are in range when alt-clicked to toggle lock.
/:cl:

