### PR TITLE
Fix flashlight beam interactions

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(mapped_autostrips_mob)
 	var/list/affecting = list()
 
 /obj/effect/step_trigger/thrower/Trigger(atom/A)
-	if(!A || !istype(A, /atom/movable))
+	if(!A || !istype(A, /atom/movable) || istype(A, /obj/effect/abstract))
 		return
 	var/atom/movable/AM = A
 	var/curtiles = 0

--- a/code/modules/power/singularity/act.dm
+++ b/code/modules/power/singularity/act.dm
@@ -65,6 +65,9 @@
 /obj/effect/overlay/singularity_pull()
 	return
 
+/obj/effect/abstract/singularity_act()
+	return
+
 /obj/machinery/power/supermatter/shard/singularity_act()
 	qdel(src)
 	return 5000


### PR DESCRIPTION
## About The Pull Request
Fixes flashlight light beams being pushed by physical forces.

## Changelog
Fixed singularities being able to pull flashlight beams
Fixed shuttle throwers being able to launch flashlight beams 

:cl: Will
fix: Flashlight light beams can no longer be thrown by shuttle throw triggers, or pulled by singularities
/:cl:
