### PR TITLE
Fixes a shower runtime

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -542,8 +542,6 @@
 	A.wash(CLEAN_WASH)
 	A.wash(CLEAN_SCRUB)
 
-	reagents.splash(A, reaction_volume / 20, 1, TRUE, min_spill = 0, max_spill = 0) //Reaction volume needs to be divided by 20 due to a larger internal volume
-
 	if(isliving(A))
 		var/mob/living/L = A
 		check_heat(L)
@@ -556,6 +554,8 @@
 			if(C.touching)
 				var/remove_amount = C.touching.maximum_volume * C.reagent_permeability() //take off your suit first
 				C.touching.remove_any(remove_amount)
+
+	reagents.splash(A, reaction_volume / 20, 1, TRUE, min_spill = 0, max_spill = 0) //Reaction volume needs to be divided by 20 due to a larger internal volume
 
 /obj/machinery/shower/process()
 	if(on)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -542,24 +542,20 @@
 	A.wash(CLEAN_WASH)
 	A.wash(CLEAN_SCRUB)
 
-	//flush away reagents on the skin
-	var/mob/living/carbon/C = A
-	if(C.touching)
-		var/remove_amount = C.touching.maximum_volume * C.reagent_permeability() //take off your suit first
-		C.touching.remove_any(remove_amount)
-
 	reagents.splash(A, reaction_volume / 20, 1, TRUE, min_spill = 0, max_spill = 0) //Reaction volume needs to be divided by 20 due to a larger internal volume
 
-	if(!isliving(A))
-		return
-	var/mob/living/L = A
-	check_heat(L)
-	L.extinguish_mob()
-	L.adjust_fire_stacks(-20) //Douse ourselves with water to avoid fire more easily
-	L.radiation = CLAMP(L.radiation - 5, 0, RADIATION_CAP)
-
-	if(!iscarbon(A))
-		return
+	if(isliving(A))
+		var/mob/living/L = A
+		check_heat(L)
+		L.extinguish_mob()
+		L.adjust_fire_stacks(-20) //Douse ourselves with water to avoid fire more easily
+		L.radiation = CLAMP(L.radiation - 5, 0, RADIATION_CAP)
+		//flush away reagents on the skin
+		if(iscarbon(A))
+			var/mob/living/carbon/C = A
+			if(C.touching)
+				var/remove_amount = C.touching.maximum_volume * C.reagent_permeability() //take off your suit first
+				C.touching.remove_any(remove_amount)
 
 /obj/machinery/shower/process()
 	if(on)


### PR DESCRIPTION

## About The Pull Request

Fixes showers throwing runtimes when cleaning non-carbon mobs

## Changelog
:cl: Guti
fix: Fixed showers throwing a runtime when cleaning anything but carbon mobs
/:cl:
