### PR TITLE
Throwing and Turf Signals Fixes

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -93,6 +93,9 @@
 	if(triggered)
 		return
 
+	if(M.throwing) // Weee!
+		return
+
 	if(istype(M, /obj/mecha))
 		explode(M)
 

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -29,6 +29,10 @@
 	update_light()
 	return ..()
 
+/turf/simulated/floor/lava/Destroy()
+	. = ..()
+	STOP_PROCESSING(SSturfs, src)
+
 /turf/simulated/floor/lava/make_outdoors()
 	..()
 	name = "lava"
@@ -51,6 +55,7 @@
 /turf/simulated/floor/lava/Entered(atom/movable/AM)
 	if(burn_stuff(AM))
 		START_PROCESSING(SSturfs, src)
+	. = ..()
 
 /turf/simulated/floor/lava/hitby(atom/movable/source, datum/thrownthing/throwingdatum)
 	if(burn_stuff(source))
@@ -70,26 +75,31 @@
 	. = FALSE
 
 	if(is_safe())
-		return FALSE
+		return PROCESS_KILL
 
+	// If argument is set, we're only burning JUST that thing. Otherwise this burns all turf contents.
 	var/thing_to_check = src
 	if(AM)
 		thing_to_check = list(AM)
 
-	for(var/thing in thing_to_check)
+	for(var/atom/movable/thing in thing_to_check)
+		if(thing.throwing || thing.is_incorporeal())
+			continue
 		if(isobj(thing))
 			var/obj/O = thing
-			if(O.throwing || O.is_incorporeal())
-				continue
 			. = TRUE
 			O.lava_act()
-
-		else if(isliving(thing))
+			continue
+		if(isliving(thing))
 			var/mob/living/L = thing
-			if(L.hovering || L.throwing || L.is_incorporeal()) // Flying over the lava. We're just gonna pretend convection doesn't exist.
+			if(L.hovering || L.flying) // Flying over the lava. We're just gonna pretend convection doesn't exist.
 				continue
 			. = TRUE
 			L.lava_act()
+			continue
+
+	if(!.) // Nothing to burn
+		return PROCESS_KILL
 
 // Lava that does nothing at all.
 /turf/simulated/floor/lava/harmless/burn_stuff(atom/movable/AM)

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -76,7 +76,7 @@
 	. = FALSE
 
 	if(is_safe())
-		return PROCESS_KILL
+		return FALSE
 
 	// If argument is set, we're only burning JUST that thing. Otherwise this burns all turf contents.
 	var/thing_to_check = src
@@ -98,9 +98,6 @@
 			. = TRUE
 			L.lava_act()
 			continue
-
-	if(!.) // Nothing to burn
-		return PROCESS_KILL
 
 // Lava that does nothing at all.
 /turf/simulated/floor/lava/harmless/burn_stuff(atom/movable/AM)

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -30,8 +30,9 @@
 	return ..()
 
 /turf/simulated/floor/lava/Destroy()
+	if(datum_flags & DF_ISPROCESSING)
+		STOP_PROCESSING(SSturfs, src)
 	. = ..()
-	STOP_PROCESSING(SSturfs, src)
 
 /turf/simulated/floor/lava/make_outdoors()
 	..()

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -99,17 +99,19 @@
 	return return_air() // Otherwise their head is above the water, so get the air from the atmosphere instead.
 
 /turf/simulated/floor/water/Entered(atom/movable/AM, atom/oldloc)
+	if(AM.throwing)
+		return ..()
 	if(isliving(AM))
 		var/mob/living/L = AM
 		if(L.hovering || L.flying || L.is_incorporeal())
-			return
+			return ..()
 		L.update_water()
 		if(L.check_submerged() <= 0)
-			return
+			return ..()
 		if(!istype(oldloc, /turf/simulated/floor/water))
 			to_chat(L, span_warning("You get drenched in water from entering \the [src]!"))
 	AM.water_act(5)
-	..()
+	. = ..()
 
 /turf/simulated/floor/water/Exited(atom/movable/AM, atom/newloc)
 	if(isliving(AM))

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -85,6 +85,10 @@ GLOBAL_LIST_EMPTY(fuel_injectors)
 	return ..()
 
 /obj/machinery/fusion_fuel_injector/attack_hand(mob/user)
+	if(..())
+		return TRUE
+	if(!Adjacent(user))
+		return TRUE
 
 	if(injecting)
 		to_chat(user, span_warning("Shut \the [src] off before playing with the fuel rod!"))


### PR DESCRIPTION
## About The Pull Request
Fixes some turfs and objects that do not properly call parent when called, so signals are never called. 

## Changelog
Water properly calls parent when Entered()
Lava calls parent when Entered()
Rust fuel injector respects signals for attack_hand()
Borgs can no longer remove RUST fuel from injectors from across the room
Entering water checks if you are being thrown, and if so doesn't get you wet.
Being thrown over landmines no longer triggers the mine if you don't land on it.

:cl: Will
fix: Fixed water and lava not respecting signal behaviors
fix: RUST injectors respect signal behaviors
fix: Borgs can no longer remove RUST fuel cells from injectors from afar
fix: Being thrown over water will no longer get you wet
add: Being thrown over landmines no longer triggers the mine if you don't land on it.
/:cl:
