### PR TITLE
Borg Rolling Pins

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -649,6 +649,7 @@
 	L.lit = 1
 	src.modules += L
 
+	src.modules += new /obj/item/material/kitchen/rollingpin/cyborg(src)
 	src.modules += new /obj/item/tray/robotray(src)
 	src.modules += new /obj/item/reagent_containers/borghypo/service(src)
 	var/obj/item/reagent_containers/food/drinks/bottle/small/beer/PB = new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
@@ -697,6 +698,7 @@
 	L.lit = 1
 	src.modules += L
 
+	src.modules += new /obj/item/material/kitchen/rollingpin/cyborg(src)
 	src.modules += new /obj/item/tray/robotray(src)
 	src.modules += new /obj/item/reagent_containers/borghypo/service(src)
 

--- a/code/modules/mob/living/silicon/robot/subtypes/boozeborg.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/boozeborg.dm
@@ -42,7 +42,7 @@
 	//src.modules += new /obj/item/storage/bag/plants(src)
 	//src.modules += new /obj/item/robot_harvester(src)
 	src.modules += new /obj/item/material/knife(src)
-	src.modules += new /obj/item/material/kitchen/rollingpin(src)
+	src.modules += new /obj/item/material/kitchen/rollingpin/cyborg(src)
 	src.modules += new /obj/item/multitool/cyborg(src) //to freeze trays
 	src.modules += new /obj/item/dogborg/jaws/small(src)
 	src.modules += new /obj/item/dogborg/boop_module(src)


### PR DESCRIPTION
## About The Pull Request
Gives service and clown borgs rolling pins. Allowing for kitchen tasks.

## Changelog
Service and clown borgs get rolling pins.
Boozebot rolling pin uses the cyborg rolling pin

:cl: Will
add: Service and clown borgs get a rolling pin for kitchen tasks
fix: Boozeborgs get the correct type of rolling pin
/:cl:
