### PR TITLE
Fix salt shakers made from condimaster3000 not having an icon

### DIFF
--- a/code/modules/food/food/condiment.dm
+++ b/code/modules/food/food/condiment.dm
@@ -101,7 +101,7 @@
 			if(REAGENT_ID_SODIUMCHLORIDE)
 				name = "Salt Shaker"
 				desc = "Salt. From space oceans, presumably."
-				icon_state = "saltshaker"
+				icon_state = "saltshakersmall"
 				center_of_mass_x = 17
 				center_of_mass_y = 11
 			if(REAGENT_ID_BLACKPEPPER)


### PR DESCRIPTION

## About The Pull Request
This PR fixes this one from Polaris : 
https://github.com/PolarisSS13/Polaris/issues/9198

I haven't been able to find what the 'big' salt shaker looks like, and I wager the sprite has been deleted at some point. Given there's no reference in the code for any other 'big' salt shaker that I could find, I'm comfortable just fixing the path that way.

## Changelog
:cl:
fix: fixed salt shakers from condimaster not having an icon
/:cl:
