### PR TITLE
Fix the paper bin being IMPOSSIBLE to remove from a backpack

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -47,6 +47,10 @@
 		if(temp && !temp.is_usable())
 			to_chat(user, span_notice("You try to move your [temp.name], but cannot!"))
 			return
+		if(isstorage(src.loc))
+			user.put_in_hands(src)
+			to_chat(user, span_notice("You pick up the [src]."))
+			return
 	var/response = ""
 	if(!papers.len > 0)
 		response = tgui_alert(user, "Do you take regular paper, or Carbon copy paper?", "Paper type request", list("Regular", "Carbon-Copy", "Cancel"))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -48,6 +48,7 @@
 			to_chat(user, span_notice("You try to move your [temp.name], but cannot!"))
 			return
 		if(isstorage(src.loc))
+			remove_from_storage(B, H.loc)
 			user.put_in_hands(src)
 			to_chat(user, span_notice("You pick up the [src]."))
 			return

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -47,8 +47,9 @@
 		if(temp && !temp.is_usable())
 			to_chat(user, span_notice("You try to move your [temp.name], but cannot!"))
 			return
-		if(isstorage(src.loc))
-			remove_from_storage(B, H.loc)
+		if(istype(src.loc, /obj/item/storage))
+			var/obj/item/storage/S = src.loc
+			S.remove_from_storage(src)
 			user.put_in_hands(src)
 			to_chat(user, span_notice("You pick up the [src]."))
 			return


### PR DESCRIPTION

## About The Pull Request
Paper bins have long been impossible to remove from backpacks or satchels. This PR fixes that. 

Not quite a vorestation issue, but this fixes this : 
https://github.com/PolarisSS13/Polaris/issues/9228



## Changelog
:cl:
fix: fixed paper bins being impossible to remove from storage.
/:cl:
