### PR TITLE
Remove non-functional xenochimera version of hardfeet trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -482,15 +482,6 @@
 	category = 0
 	custom_only = FALSE
 
-/datum/trait/positive/hardfeet/xenochimera
-	sort = TRAIT_SORT_SPECIES
-	allowed_species = list(SPECIES_XENOCHIMERA)
-	name = "Xenochimera: Hard Feet"
-	desc = "Your body has adapted to make your feet immune to glass shards, whether by developing hooves, chitin, or just horrible callous."
-	cost = 0
-	category = 0
-	custom_only = FALSE
-
 /datum/trait/positive/melee_attack_fangs/xenochimera
 	sort = TRAIT_SORT_SPECIES
 	allowed_species = list(SPECIES_XENOCHIMERA)


### PR DESCRIPTION
## About The Pull Request
Removes non-functional xenochimera version of the hardfeet trait. Both traits cost 0 points, and you can already take normal hardfeet as xenochimera. This trait does not work, as hardfeet is a neutral subtype, and xenochi version assumes it will inherit, but is a positive subtype? Either way the trait is useless and costs nothing, and you can always get the normal trait. So i'm just removing it outright as code bloat.

## Changelog
Removes xenochimera version of hardfeet trait.

:cl: Will
del: Removes non-functional xenochimera version of hardfeet trait
/:cl:

