### PR TITLE
Add more things to the antag description system

### DIFF
--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -5,7 +5,7 @@
 	pipe_state = "mtvalve"
 
 	name = "manual switching valve"
-	desc = "A pipe valve"
+	desc = "A pipe valve."
 
 	level = 1
 	dir = SOUTH

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -1,6 +1,7 @@
 /obj/machinery/camera
 	name = "security camera"
 	desc = "It's used to monitor rooms."
+	description_antag = "It looks pretty smashable. You could also just cut the wires."
 	icon = 'icons/obj/monitors_vr.dmi' //VOREStation Edit - New Icons
 	icon_state = "camera"
 	use_power = USE_POWER_ACTIVE

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -16,6 +16,7 @@
 /obj/machinery/door/blast
 	name = "Blast Door"
 	desc = "That looks like it doesn't open easily."
+	description_antag = "Dangerous if they close on you normally, but you could probably make it worse with an emag."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = null
 	min_force = 20 //minimum amount of force needed to damage the door with a melee weapon

--- a/code/game/machinery/suit_storage/suit_cycler.dm
+++ b/code/game/machinery/suit_storage/suit_cycler.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_EMPTY(suit_cycler_typecache)
 /obj/machinery/suit_cycler
 	name = "suit cycler"
 	desc = "An industrial machine for painting and refitting voidsuits."
+	description_antag = "Safeties can be overriden with the use of a cryptographic sequencer. Or emag, if you aren't a nerd."
 	anchored = TRUE
 	density = TRUE
 

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -4,6 +4,7 @@ GLOBAL_DATUM(sleevemate_mob, /mob/living/carbon/human/dummy/mannequin)
 /obj/item/sleevemate
 	name = "\improper SleeveMate 3700"
 	desc = "A hand-held sleeve management tool for performing one-time backups and managing mindstates."
+	description_antag = "Frying it with an emag transforms this into a BSD, a body snatcher device. Very illegal, if you care."
 	icon = 'icons/obj/device_alt.dmi'
 	icon_state = "sleevemate"
 	item_state = "healthanalyzer"

--- a/code/game/objects/items/pizza_voucher_vr.dm
+++ b/code/game/objects/items/pizza_voucher_vr.dm
@@ -1,6 +1,7 @@
 /obj/item/pizzavoucher
 	name = "free pizza voucher"
 	desc = "A pocket-sized plastic slip with a button in the middle. The writing on it seems to have faded."
+	description_antag = "Careful! Emagging this will mess with the delivery, crushing the recipient under it! Which, is probably fine and dandy for you! Just, don't forget about it."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "pizza_voucher"
 	var/spent = FALSE

--- a/code/game/objects/items/toys/toys_vr.dm
+++ b/code/game/objects/items/toys/toys_vr.dm
@@ -806,6 +806,7 @@
 	name = "bread tube"
 	desc = "Bread in a tube. Chewy...and surprisingly tasty."
 	description_fluff = "This is the product that brought Centauri Provisions into the limelight. A product of the earliest extrasolar colony of Heaven, the Bread Tube, while bland, contains all the nutrients a spacer needs to get through the day and is decidedly edible when compared to some of its competitors. Due to the high-fructose corn syrup content of NanoTrasen's own-brand bread tubes, many jurisdictions classify them as a confectionary."
+	description_antag = "Frying the safeties will replace the contents with a real, BIG snake!"
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "tastybread"
 	var/popped = 0

--- a/code/game/objects/items/weapons/id cards/cards.dm
+++ b/code/game/objects/items/weapons/id cards/cards.dm
@@ -95,8 +95,9 @@
 	item_state = "card-id"
 
 /obj/item/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry."
 	name = "cryptographic sequencer"
+	desc = "It's a card with a magnetic strip attached to some circuitry. The shoddy wiring is only good for a dozen uses or so."
+	description_antag = "A well known tool among certain circles. It allows bypass of security systems for a frightingly large amount of devices, robots or machinery. It does tend to leave visible traces."
 	icon_state = "emag"
 	item_state = "card-id"
 	var/uses = 10
@@ -137,6 +138,7 @@
 
 
 /obj/item/card/emag/borg
+	desc = "It's a card with a magnetic strip attached to some circuitry."
 	uses = 12
 	var/burnt_out = FALSE
 

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -1,6 +1,7 @@
 /obj/item/tape_roll
 	name = "tape roll"
 	desc = "A roll of sticky tape. Possibly for taping ducks... or was that ducts?"
+	description_antag = "You could use this to tape someone's mouth shut. Or eyes."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
 	w_class = ITEMSIZE_TINY

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -147,8 +147,9 @@
 	return TRUE
 
 /obj/structure/closet/crate/secure
-	desc = "A secure crate."
 	name = "Secure crate"
+	desc = "A secure crate."
+	description_antag = "You could fry the lock with an emag. Or just shoot the crate until it breaks."
 	closet_appearance = /datum/decl/closet_appearance/crate/secure
 	var/broken = 0
 	var/locked = 1

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -9,6 +9,7 @@
 /obj/machinery/vending
 	name = "Vendomat"
 	desc = "A generic vending machine."
+	description_antag = "An emag could give you full access."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "generic"
 	anchored = TRUE

--- a/code/modules/food/kitchen/gibber.dm
+++ b/code/modules/food/kitchen/gibber.dm
@@ -2,6 +2,7 @@
 /obj/machinery/gibber
 	name = "gibber"
 	desc = "The name isn't descriptive enough?"
+	description_antag = "An emag could disable the safety guard. You sicko."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "grinder"
 	density = TRUE

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -1,6 +1,7 @@
 /obj/machinery/computer/HolodeckControl
 	name = "holodeck control console"
 	desc = "A computer used to control a nearby holodeck."
+	description_antag = "You could override the safeties with an emag. Or, just enough access. Could get pretty bloody!"
 	icon_keyboard = "tech_key"
 	icon_screen = "holocontrol"
 
@@ -165,7 +166,7 @@
 		safety_disabled = 1
 		update_projections()
 		to_chat(user, span_notice("You vastly increase projector power and override the safety and security protocols."))
-		to_chat(user, "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call [using_map.company_name] maintenance and do not use the simulator.")
+		to_chat(user, span_warning("Warning. Automatic shutoff and derezing protocols have been corrupted. Please call [using_map.company_name] maintenance and do not use the simulator."))
 		log_game("[key_name(user)] emagged the Holodeck Control Computer")
 		return 1
 	return

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -10,6 +10,7 @@
 /mob/living/bot/mulebot
 	name = "Mulebot"
 	desc = "A Multiple Utility Load Effector bot."
+	description_antag = "You could use an emag on this to bypass the safeties. And run people over!"
 	icon_state = "mulebot0"
 	anchored = TRUE
 	density = TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 /obj/machinery/light_construct
 	name = "light fixture frame"
 	desc = "A light fixture under construction."
+	description_antag = "There's a flexible cover near the ballast. Someone figured you can inject phoron in there as a rigged explosive. Just, don't do it while it is on."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-stage1"
 	anchored = TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -985,6 +985,8 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 	var/init_nightshift_range = 8
 	var/init_nightshift_power = 0.45
 
+	description_antag = "There's a flexible cover near the ballast. Someone figured you can inject phoron in there as a rigged explosive. Just, don't do it while it is on."
+
 /obj/item/light/tube
 	name = "light tube"
 	desc = "A replacement light tube."
@@ -1198,6 +1200,15 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 		sharp = TRUE
 		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)
 		update_icon()
+	if(rigged)
+		var/atom/location = src.loc
+		var/datum/gas_mixture/air_contents
+		air_contents = new
+		//0.2L
+		air_contents.volume = 0.2
+		air_contents.temperature = T20C
+		air_contents.adjust_gas(GAS_PHORON, 1)
+		location.assume_air(air_contents)
 
 //Lamp Shade
 /obj/item/lampshade

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -985,8 +985,6 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 	var/init_nightshift_range = 8
 	var/init_nightshift_power = 0.45
 
-	description_antag = "There's a flexible cover near the ballast. Someone figured you can inject phoron in there as a rigged explosive. Just, don't do it while it is on."
-
 /obj/item/light/tube
 	name = "light tube"
 	desc = "A replacement light tube."
@@ -1200,15 +1198,6 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 		sharp = TRUE
 		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)
 		update_icon()
-	if(rigged)
-		var/atom/location = src.loc
-		var/datum/gas_mixture/air_contents
-		air_contents = new
-		//0.2L
-		air_contents.volume = 0.2
-		air_contents.temperature = T20C
-		air_contents.adjust_gas(GAS_PHORON, 1)
-		location.assume_air(air_contents)
 
 //Lamp Shade
 /obj/item/lampshade

--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -116,7 +116,8 @@
 //Fuel
 /obj/structure/reagent_dispensers/fueltank
 	name = "fuel tank"
-	desc = "A fuel tank."
+	desc = "A fuel tank. Filled with flammable fuel suitable for welding tools, or some small engines. Unless someone siphoned it again!"
+	description_antag = "Explosive if filled with fuel. Can be wrenched open to spill fuel over the floor."
 	icon_state = REAGENT_ID_FUEL
 	amount_per_transfer_from_this = 10
 	var/modded = 0


### PR DESCRIPTION

## About The Pull Request
If you've never been an antag, you might not know there's a special description for certain items that list interesting facts for antags. Such as, that can be blown up, or sabotaged in X or Y manner. This PR just adds more descriptions. 

Also, two small typo corrections.
## Changelog
:cl:
qol: Added more special descriptions for antags
/:cl:
