### PR TITLE
Add a slight phoron effect to breaking phoron filled lights

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -1198,6 +1198,15 @@ GLOBAL_LIST_EMPTY(light_type_cache)
 		sharp = TRUE
 		playsound(src, 'sound/effects/Glasshit.ogg', 75, 1)
 		update_icon()
+	if(rigged)
+		var/atom/location = src.loc
+		var/datum/gas_mixture/air_contents
+		air_contents = new
+		//0.2L
+		air_contents.volume = 0.2
+		air_contents.temperature = T20C
+		air_contents.adjust_gas(GAS_PHORON, 1)
+		location.assume_air(air_contents)
 
 //Lamp Shade
 /obj/item/lampshade


### PR DESCRIPTION

## About The Pull Request
You can fill lights with phoron to make them explode. This PR adds a slight gas effect when you break one of those by, say, throwing them against the wall like an idiot.
## Changelog
:cl:
add: Add a slight phoron effect to breaking phoron filled lights
/:cl:
