### PR TITLE
Make it so emagging a bot also unlocks it and remove access restrictions

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -197,6 +197,9 @@
 		..()
 
 /mob/living/bot/emag_act(remaining_charges, mob/user)
+	locked = 0
+	req_access = list()
+	req_one_access = list()
 	return 0
 
 /mob/living/bot/proc/handleAI()


### PR DESCRIPTION

## About The Pull Request
When you emag a robot, it doesn't actually give you any access, unlike with doors, closets, crates, guns, turret controls and the list goes on. This PR changes that. I think this is an oversight, but I'll file it as balance. 
## Changelog
:cl:
balance: Make it so emagging a bot also unlocks it and remove access restrictions
/:cl:
